### PR TITLE
Also migrate 'official' plugins that are from the old site but are using 'main'

### DIFF
--- a/.docker/app/startup.sh
+++ b/.docker/app/startup.sh
@@ -102,16 +102,26 @@ if [ -z "$TTRSS_NO_STARTUP_PLUGIN_UPDATES" ]; then
 				esac
 
 				if [ -n "$NEW_ORIGIN_URL" ]; then
-					if [ $(sudo -u app git branch --show-current) = "master" ]; then
-						echo "Migrating origin remote from ${ORIGIN_URL} to ${NEW_ORIGIN_URL}"
-						sudo -u app git remote set-url origin "$NEW_ORIGIN_URL"
-						sudo -u app git branch -m master main
-						sudo -u app git fetch origin
-						sudo -u app git branch --set-upstream-to origin/main main
-						sudo -u app git remote set-head origin --auto
-					else
-						echo "Skipping migration of origin remote from ${ORIGIN_URL} to ${NEW_ORIGIN_URL} (local branch is not 'master')"
-					fi
+					case $(sudo -u app git branch --show-current) in
+						master)
+							echo "Migrating origin remote from ${ORIGIN_URL} to ${NEW_ORIGIN_URL} (and switching the branch from 'master' to 'main')"
+							sudo -u app git remote set-url origin "$NEW_ORIGIN_URL"
+							sudo -u app git branch -m master main
+							sudo -u app git fetch origin
+							sudo -u app git branch --set-upstream-to origin/main main
+							sudo -u app git remote set-head origin --auto
+							;;
+						main)
+							echo "Migrating origin remote from ${ORIGIN_URL} to ${NEW_ORIGIN_URL}"
+							sudo -u app git remote set-url origin "$NEW_ORIGIN_URL"
+							sudo -u app git fetch origin
+							sudo -u app git branch --set-upstream-to origin/main main
+							sudo -u app git remote set-head origin --auto
+							;;
+						*)
+							echo "Skipping migration of origin remote from ${ORIGIN_URL} to ${NEW_ORIGIN_URL} (local branch is not 'master' or 'main')"
+							;;
+					esac
 				fi
 			fi
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Also migrate 'official' plugins that are from the old site but are using `main`.

These would be plugins cloned from `git.tt-rss.org` after the Cloudflare redirect to their corresponding GitHub repos was implemented.  Their remote should be updated to just use the GitHub URLs directly.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Additional fix for #12, and a follow-up to #13.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
Manually tweaked the git config of some installed plugins.

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
