### PR TITLE
Cache PHPStan results, drop 'parallel.maximumNumberOfProcesses' param.

### DIFF
--- a/.github/workflows/php-code-quality.yml
+++ b/.github/workflows/php-code-quality.yml
@@ -37,8 +37,26 @@ jobs:
         # PHPUnit is installed to support PHPStan checking tests/
         tools: phpstan/phpstan:2.1.31, phpunit/phpunit:9.6.29
 
+    # https://phpstan.org/user-guide/result-cache
+    - name: Restore result cache
+      uses: actions/cache/restore@v4
+      with:
+        path: .phpstan-tmp
+        key: phpstan-result-cache-${{ github.run_id }}
+        restore-keys: |
+          phpstan-result-cache-
+
     - name: Run PHPStan
       run: phpstan analyze --no-progress
+
+    # https://phpstan.org/user-guide/result-cache
+    - name: Save result cache
+      uses: actions/cache/save@v4
+      if: ${{ !cancelled() }}
+      with:
+        # same as in phpstan.neon
+        path: .phpstan-tmp
+        key: phpstan-result-cache-${{ github.run_id }}
 
   phpunit:
     name: PHPUnit

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,8 +1,6 @@
 parameters:
    level: 6
    tmpDir: .phpstan-tmp
-   parallel:
-      maximumNumberOfProcesses: 4
    reportUnmatchedIgnoredErrors: false
    ignoreErrors:
       # set_include_path detection issue


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
* Follows https://phpstan.org/user-guide/result-cache#setup-in-github-actions guidance to cache PHPStan results.
* Removes the PHPStan [`parallel.maximumNumberOfProcesses` param](https://phpstan.org/config-reference#parallel-processing) to let PHPStan detect what to use.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Gotta go fast.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
It's about to be.

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
