### PR TITLE
Add Docker build caching to the Publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -104,6 +104,12 @@ jobs:
         context: .
         file: ${{ matrix.image.dockerfile }}
         platforms: linux/arm64,linux/amd64
+        cache-from: |
+          type=gha,scope=${{ matrix.image.name }}
+          type=registry,ref=${{ matrix.image.repository_ghcr }}:cache
+        cache-to: |
+          type=gha,scope=${{ matrix.image.name }},mode=max
+          type=registry,ref=${{ matrix.image.repository_ghcr }}:cache,mode=max
         # TODO: clean up build arg and environment variable naming.
         build-args: |
           CI_COMMIT_BRANCH=${{ github.ref_name }}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This adds Docker build caching to the Publish workflow.

The GitHub Actions cache is checked first, with fallback to GitHub Container Registry if needed.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Reduce build times.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
It will be in the next couple `Publish` workflow runs.

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
