### PR TITLE
Local templates should be ignored, just as local plugins and themes are ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ Thumbs.db
 /locale/**/*.po~
 /plugins.local/*
 /themes.local/*
+/templates.local/*
 /config.php
 /feed-icons/*
 /cache/*/*


### PR DESCRIPTION
## Description
Adding `/templates.local` to `.gitignore`.

## Motivation and Context
tt-rss supports the override of standard templates (e.g. for mail body) in `/templates.local`. Those are currently not ignored while `/plugins.local` and `/themes.local` are ignored. IMO, they should be treated the same.

## How Has This Been Tested?
n/a

## Screenshots (if appropriate)
n/a

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
