### PR TITLE
Fix Content-Length for disallowed mime types in cached file response

### DIFF
--- a/classes/DiskCache.php
+++ b/classes/DiskCache.php
@@ -356,6 +356,10 @@ class DiskCache implements Cache_Adapter {
 		header("Content-Disposition: inline; filename=\"{$filename}{$fake_extension}\"");
 		header("Content-type: $mimetype");
 
+		$size = $this->get_size($filename);
+		if ($size && $size > 0)
+			header("Content-Length: $size");
+
 		$stamp_expires = gmdate("D, d M Y H:i:s",
 			(int)$this->get_mtime($filename) + 86400 * Config::get(Config::CACHE_MAX_DAYS)) . " GMT";
 

--- a/classes/Handler_Public.php
+++ b/classes/Handler_Public.php
@@ -775,11 +775,6 @@ class Handler_Public extends Handler {
 		$cache = DiskCache::instance($cache_dir);
 
 		if ($cache->exists($filename)) {
-			$size = $cache->get_size($filename);
-
-			if ($size && $size > 0)
-				header("Content-Length: $size");
-
 			$cache->send($filename);
 		} else {
 			header($_SERVER["SERVER_PROTOCOL"]." 404 Not Found");


### PR DESCRIPTION
## Description

Fixes an invalid Content-Length when accessing `/public.php?op=cached&file=images/[...]` and the file has a disallowed mime type.

## Motivation and Context

`Handler_Public::cached()` sets a Content-Length header before calling `$cache->send()`.
If the mime type of the cached file is invalid `DiskCache::send()` will return an error message instead, thus changing the size of the response.

Fix this by removing the Content-Length header in the error case.


## How Has This Been Tested?

Checked the accessing the same cached URL before and after.

Before nginx logs `[error] 7#7: *6867 upstream prematurely closed FastCGI request while reading upstream`.
After there is no error in the log anymore.

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
