### PR TITLE
Fix stdout logger to actually write to stdout

### DIFF
--- a/classes/Logger_Stdout.php
+++ b/classes/Logger_Stdout.php
@@ -11,7 +11,7 @@ class Logger_Stdout implements Logger_Adapter {
 
 		$errname = Logger::ERROR_NAMES[$errno] . " ($errno)";
 
-		print "[EEE] $priority $errname ($file:$line) $errstr\n";
+		file_put_contents("php://stdout", "[EEE] $priority $errname ($file:$line) $errstr\n");
 
 		return true;
 	}


### PR DESCRIPTION
## Description

Fix stdout logger to actually write to stdout.

print writes into the HTTP response which is not where logs should end up.

## Motivation and Context

Logs not showing up and instead corrupt the response.

## How Has This Been Tested?

Checked by emitting a log line in a request handler.
Previously: log can been seen in HTTP response body
Now: log is printed on stdout

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
