### PR TITLE
Separate tt-rss and plugin update icons, link to useful targets

### DIFF
--- a/classes/RPC.php
+++ b/classes/RPC.php
@@ -331,10 +331,11 @@ class RPC extends Handler_Protected {
 				$content = json_decode($content, true);
 
 				if ($content && isset($content["changeset"])) {
-					if ($git_timestamp < (int)$content["changeset"]["timestamp"] &&
-						$git_commit != $content["changeset"]["id"]) {
-
-						$rv["changeset"] = $content["changeset"];
+					if ($git_timestamp < (int)$content['changeset']['timestamp'] && $git_commit != $content['changeset']['id']) {
+						$rv['changeset'] = [
+							...$content['changeset'],
+							'compare_url' => "https://github.com/tt-rss/tt-rss/compare/{$git_commit}...{$content['changeset']['id']}",
+						];
 					}
 				}
 			}

--- a/index.php
+++ b/index.php
@@ -159,14 +159,19 @@
 
 				<!-- order 5: alert icons -->
 
-            <i class="material-icons net-alert" style="display : none; order : 5"
-                title="<?= __("Communication problem with server.") ?>">error_outline</i>
+						<i class="material-icons net-alert" style="display : none; order : 5"
+							title="<?= __("Communication problem with server.") ?>">error_outline</i>
 
-            <i class="material-icons log-alert" style="display : none; order : 5" onclick="App.openPreferences('system')"
-                 title="<?= __("Recent entries found in event log.") ?>">warning</i>
+						<i class="material-icons log-alert" style="display : none; order : 5" onclick="App.openPreferences('system')"
+							title="<?= __("Recent entries found in event log.") ?>">warning</i>
 
-            <i id="updates-available" class="material-icons icon-new-version" style="display : none; order: 5"
-               title="<?= __('Updates are available from Git.') ?>">new_releases</i>
+						<a id="updates-available" target="_blank" rel="noopener noreferrer" href="" style="display: none; order: 5">
+							<i class="material-icons icon-new-version" title="<?= __('Updates for Tiny Tiny RSS are available.') ?>">new_releases</i>
+						</a>
+
+						<a id="plugin-updates-available" href="prefs.php?tab=prefs" style="display: none; order: 5">
+							<i class="material-icons icon-new-version" title="<?= __('Updates for some local plugins are available.') ?>">new_releases</i>
+						</a>
 
 				<!-- order 10: headlines toolbar -->
 

--- a/js/App.js
+++ b/js/App.js
@@ -881,30 +881,25 @@ const App = {
       console.log("second stage ok");
 
    },
-   checkForUpdates: function() {
-      xhr.json("backend.php", {op: 'RPC', method: 'checkforupdates'})
-         .then((reply) => {
+	checkForUpdates: function() {
+		xhr.json("backend.php", {op: 'RPC', method: 'checkforupdates'})
+			.then((reply) => {
+				const ttrss_icon_a = document.getElementById('updates-available');
+				const plugin_icon_a = document.getElementById('plugin-updates-available');
 
-            const icon = document.getElementById("updates-available");
+				if (reply.changeset.id) {
+					ttrss_icon_a.href = reply.changeset.compare_url;
+					ttrss_icon_a.show();
+				} else {
+					ttrss_icon_a.hide();
+				}
 
-            if (reply.changeset.id || reply.plugins.length > 0) {
-               icon.show();
-
-               const tips = [];
-
-               if (reply.changeset.id)
-                  tips.push(__("Updates for Tiny Tiny RSS are available."));
-
-               if (reply.plugins.length > 0)
-                  tips.push(__("Updates for some local plugins are available."));
-
-               icon.setAttribute("title", tips.join("\n"));
-
-            } else {
-               icon.hide();
-            }
-         });
-   },
+				if (reply.plugins.length)
+					plugin_icon_a.show()
+				else
+					plugin_icon_a.hide();
+			});
+	},
    updateTitle: function() {
       let tmp = "Tiny Tiny RSS";
 

--- a/prefs.php
+++ b/prefs.php
@@ -121,11 +121,16 @@
 </div>
 
 <div id="header">
-	<i class="material-icons net-alert" style="display : none"
-   	title="<?= __("Communication problem with server.") ?>">error_outline</i>
-	<i class="material-icons log-alert" style="display : none" onclick="App.openPreferences('system')"
-		title="<?= __("Recent entries found in event log.") ?>">warning</i>
-	<i id="updates-available" class="material-icons icon-new-version" style="display : none">new_releases</i>
+	<i class="material-icons net-alert" style="display: none"
+		title="<?= __("Communication problem with server.") ?>">error_outline</i>
+	<i class="material-icons log-alert" style="display: none"
+		 title="<?= __("Recent entries found in event log.") ?>" onclick="App.openPreferences('system')">warning</i>
+	<a id="updates-available" target="_blank" rel="noopener noreferrer" href="" style="display: none">
+		<i class="material-icons icon-new-version" title="<?= __('Updates for Tiny Tiny RSS are available.') ?>">new_releases</i>
+	</a>
+	<a id="plugin-updates-available" href="prefs.php" onclick="dijit.byId('pref-tabs').selectChild(dijit.byId('prefsTab')); return false" style="display: none">
+		<i class="material-icons icon-new-version" title="<?= __('Updates for some local plugins are available.') ?>">new_releases</i>
+	</a>
 	<a href="#" onclick="document.location.href = 'index.php'"><?= __('Exit preferences') ?></a>
 </div>
 

--- a/themes/compact.css
+++ b/themes/compact.css
@@ -820,6 +820,12 @@ body.ttrss_main #toolbar-frame #toolbar #toolbar-headlines .right {
 body.ttrss_main #toolbar-frame #toolbar #updates-available {
   color: #69C671;
   padding-right: 4px;
+  text-decoration: none;
+}
+body.ttrss_main #toolbar-frame #toolbar #plugin-updates-available {
+  color: #b3e2b7;
+  padding-right: 4px;
+  text-decoration: none;
 }
 body.ttrss_main #toolbar-frame #toolbar #selected_prompt {
   font-style: italic;
@@ -860,6 +866,12 @@ body.ttrss_main #header i.log-alert {
 body.ttrss_main #header #updates-available {
   color: #69C671;
   padding-right: 4px;
+  text-decoration: none;
+}
+body.ttrss_main #header #plugin-updates-available {
+  color: #8ed494;
+  padding-right: 4px;
+  text-decoration: none;
 }
 body.ttrss_main #header i {
   margin: 0 4px;

--- a/themes/compact_night.css
+++ b/themes/compact_night.css
@@ -820,6 +820,12 @@ body.ttrss_main #toolbar-frame #toolbar #toolbar-headlines .right {
 body.ttrss_main #toolbar-frame #toolbar #updates-available {
   color: #69C671;
   padding-right: 4px;
+  text-decoration: none;
+}
+body.ttrss_main #toolbar-frame #toolbar #plugin-updates-available {
+  color: #b3e2b7;
+  padding-right: 4px;
+  text-decoration: none;
 }
 body.ttrss_main #toolbar-frame #toolbar #selected_prompt {
   font-style: italic;
@@ -860,6 +866,12 @@ body.ttrss_main #header i.log-alert {
 body.ttrss_main #header #updates-available {
   color: #69C671;
   padding-right: 4px;
+  text-decoration: none;
+}
+body.ttrss_main #header #plugin-updates-available {
+  color: #8ed494;
+  padding-right: 4px;
+  text-decoration: none;
 }
 body.ttrss_main #header i {
   margin: 0 4px;

--- a/themes/light-high-contrast.css
+++ b/themes/light-high-contrast.css
@@ -820,6 +820,12 @@ body.ttrss_main #toolbar-frame #toolbar #toolbar-headlines .right {
 body.ttrss_main #toolbar-frame #toolbar #updates-available {
   color: #69C671;
   padding-right: 4px;
+  text-decoration: none;
+}
+body.ttrss_main #toolbar-frame #toolbar #plugin-updates-available {
+  color: #b3e2b7;
+  padding-right: 4px;
+  text-decoration: none;
 }
 body.ttrss_main #toolbar-frame #toolbar #selected_prompt {
   font-style: italic;
@@ -860,6 +866,12 @@ body.ttrss_main #header i.log-alert {
 body.ttrss_main #header #updates-available {
   color: #69C671;
   padding-right: 4px;
+  text-decoration: none;
+}
+body.ttrss_main #header #plugin-updates-available {
+  color: #8ed494;
+  padding-right: 4px;
+  text-decoration: none;
 }
 body.ttrss_main #header i {
   margin: 0 4px;

--- a/themes/light.css
+++ b/themes/light.css
@@ -820,6 +820,12 @@ body.ttrss_main #toolbar-frame #toolbar #toolbar-headlines .right {
 body.ttrss_main #toolbar-frame #toolbar #updates-available {
   color: #69C671;
   padding-right: 4px;
+  text-decoration: none;
+}
+body.ttrss_main #toolbar-frame #toolbar #plugin-updates-available {
+  color: #b3e2b7;
+  padding-right: 4px;
+  text-decoration: none;
 }
 body.ttrss_main #toolbar-frame #toolbar #selected_prompt {
   font-style: italic;
@@ -860,6 +866,12 @@ body.ttrss_main #header i.log-alert {
 body.ttrss_main #header #updates-available {
   color: #69C671;
   padding-right: 4px;
+  text-decoration: none;
+}
+body.ttrss_main #header #plugin-updates-available {
+  color: #8ed494;
+  padding-right: 4px;
+  text-decoration: none;
 }
 body.ttrss_main #header i {
   margin: 0 4px;

--- a/themes/light/tt-rss.less
+++ b/themes/light/tt-rss.less
@@ -970,6 +970,13 @@ body.ttrss_main {
 			#updates-available {
 				color : @color-checked;
 				padding-right : 4px;
+				text-decoration: none;
+			}
+
+			#plugin-updates-available {
+				color : lighten(@color-checked, 20%);
+				padding-right : 4px;
+				text-decoration: none;
 			}
 
 			#selected_prompt {
@@ -1018,6 +1025,13 @@ body.ttrss_main {
 		#updates-available {
 			color : @color-checked;
 			padding-right : 4px;
+			text-decoration: none;
+		}
+
+		#plugin-updates-available {
+			color : lighten(@color-checked, 10%);
+			padding-right : 4px;
+			text-decoration: none;
 		}
 
 		i {

--- a/themes/night.css
+++ b/themes/night.css
@@ -821,6 +821,12 @@ body.ttrss_main #toolbar-frame #toolbar #toolbar-headlines .right {
 body.ttrss_main #toolbar-frame #toolbar #updates-available {
   color: #69C671;
   padding-right: 4px;
+  text-decoration: none;
+}
+body.ttrss_main #toolbar-frame #toolbar #plugin-updates-available {
+  color: #b3e2b7;
+  padding-right: 4px;
+  text-decoration: none;
 }
 body.ttrss_main #toolbar-frame #toolbar #selected_prompt {
   font-style: italic;
@@ -861,6 +867,12 @@ body.ttrss_main #header i.log-alert {
 body.ttrss_main #header #updates-available {
   color: #69C671;
   padding-right: 4px;
+  text-decoration: none;
+}
+body.ttrss_main #header #plugin-updates-available {
+  color: #8ed494;
+  padding-right: 4px;
+  text-decoration: none;
 }
 body.ttrss_main #header i {
   margin: 0 4px;

--- a/themes/night_blue.css
+++ b/themes/night_blue.css
@@ -821,6 +821,12 @@ body.ttrss_main #toolbar-frame #toolbar #toolbar-headlines .right {
 body.ttrss_main #toolbar-frame #toolbar #updates-available {
   color: #69C671;
   padding-right: 4px;
+  text-decoration: none;
+}
+body.ttrss_main #toolbar-frame #toolbar #plugin-updates-available {
+  color: #b3e2b7;
+  padding-right: 4px;
+  text-decoration: none;
 }
 body.ttrss_main #toolbar-frame #toolbar #selected_prompt {
   font-style: italic;
@@ -861,6 +867,12 @@ body.ttrss_main #header i.log-alert {
 body.ttrss_main #header #updates-available {
   color: #69C671;
   padding-right: 4px;
+  text-decoration: none;
+}
+body.ttrss_main #header #plugin-updates-available {
+  color: #8ed494;
+  padding-right: 4px;
+  text-decoration: none;
 }
 body.ttrss_main #header i {
   margin: 0 4px;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
* Introduces separate "update available" icons for tt-rss and plugins.
* The tt-rss update icon links to a commit comparison (what the user's instance is on vs last published).
* The plugin update icon just links to Preferences.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
* Easier to differentiate between tt-rss and plugin update availability.
* Help users understand "what's new" between their current version and the latest release.  Closes #92.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
Locally.

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.