### PR TITLE
Replace e-mail and mail by email

### DIFF
--- a/classes/Mailer.php
+++ b/classes/Mailer.php
@@ -21,7 +21,7 @@ class Mailer {
 		$to_combined = $to_name ? "$to_name <$to_address>" : $to_address;
 
 		if (Config::get(Config::LOG_SENT_MAIL))
-			Logger::log(E_USER_NOTICE, "Sending mail from $from_combined to $to_combined [$subject]: $message");
+			Logger::log(E_USER_NOTICE, "Sending email from $from_combined to $to_combined [$subject]: $message");
 
 		// HOOK_SEND_MAIL plugin instructions:
 		// 1. return 1 or true if mail is handled
@@ -50,7 +50,7 @@ class Mailer {
 		]));
 
 		if (!$rc) {
-			$this->set_error(error_get_last()['message'] ?? T_sprintf("Unknown error while sending mail. Hooks tried: %d.", $hooks_tried));
+			$this->set_error(error_get_last()['message'] ?? T_sprintf("Unknown error while sending email. Hooks tried: %d.", $hooks_tried));
 		}
 
 		return $rc;
@@ -58,7 +58,7 @@ class Mailer {
 
 	function set_error(string $message): void {
 		$this->last_error = $message;
-		user_error("Error sending mail: $message", E_USER_WARNING);
+		user_error("Error sending email: $message", E_USER_WARNING);
 	}
 
 	function error(): string {

--- a/classes/Pref_Feeds.php
+++ b/classes/Pref_Feeds.php
@@ -618,7 +618,7 @@ class Pref_Feeds extends Handler_Protected {
 			$local_purge_intervals[0] .= " " . sprintf("(%s)", __("Disabled"));
 
 		$options = [
-			"include_in_digest" => __('Include in e-mail digest'),
+			"include_in_digest" => __('Include in email digest'),
 			"always_display_enclosures" => __('Always display image attachments'),
 			"hide_images" => __('Do not embed media'),
 			"cache_images" => __('Cache media'),

--- a/classes/Pref_Prefs.php
+++ b/classes/Pref_Prefs.php
@@ -103,7 +103,7 @@ class Pref_Prefs extends Handler_Protected {
 			Prefs::CONFIRM_FEED_CATCHUP => [__("Confirm marking feeds as read")],
 			Prefs::DEFAULT_UPDATE_INTERVAL => [__("Default update interval")],
 			Prefs::DIGEST_CATCHUP => [__("Mark sent articles as read")],
-			Prefs::DIGEST_ENABLE => [__("Enable digest"), __("Send daily digest of new (and unread) headlines to your e-mail address")],
+			Prefs::DIGEST_ENABLE => [__("Enable digest"), __("Send daily digest of new (and unread) headlines to your email address")],
 			Prefs::DIGEST_PREFERRED_TIME => [__("Try to send around this time"), __("Time in UTC")],
 			Prefs::ENABLE_API_ACCESS => [__("Enable API"), __("Allows accessing this account through the API")],
 			Prefs::ENABLE_FEED_CATS => [__("Enable categories")],
@@ -303,7 +303,7 @@ class Pref_Prefs extends Handler_Protected {
 			</fieldset>
 
 			<fieldset>
-				<label><?= __('E-mail:') ?></label>
+				<label><?= __('Email:') ?></label>
 				<input dojoType='dijit.form.ValidationTextBox' name='email' required='1' value="<?= htmlspecialchars($user->email) ?>">
 			</fieldset>
 

--- a/classes/Pref_System.php
+++ b/classes/Pref_System.php
@@ -20,7 +20,7 @@ class Pref_System extends Handler_Administrative {
 		$rc = $mailer->mail(["to_name" => "",
 			"to_address" => $mail_address,
 			"subject" => __("Test message from tt-rss"),
-			"message" => ("This message confirms that tt-rss can send outgoing mail.")
+			"message" => ("This message confirms that tt-rss can send outgoing email.")
 			]);
 
 		print json_encode(['rc' => $rc, 'error' => $mailer->error()]);
@@ -199,7 +199,7 @@ class Pref_System extends Handler_Administrative {
 					?>
 				</div>
 			<?php } ?>
-			<div dojoType='dijit.layout.AccordionPane' style='padding : 0' title='<i class="material-icons">mail</i> <?= __('Mail configuration') ?>'>
+			<div dojoType='dijit.layout.AccordionPane' style='padding : 0' title='<i class="material-icons">mail</i> <?= __('Email configuration') ?>'>
 				<div dojoType="dijit.layout.ContentPane">
 
 					<form dojoType="dijit.form.Form">

--- a/js/CommonDialogs.js
+++ b/js/CommonDialogs.js
@@ -497,7 +497,7 @@ const	CommonDialogs = {
 
 					// options tab
 					const options = {
-						include_in_digest: [ feed.include_in_digest, __('Include in e-mail digest') ],
+						include_in_digest: [ feed.include_in_digest, __('Include in email digest') ],
 						always_display_enclosures: [ feed.always_display_enclosures, __('Always display image attachments') ],
 						hide_images: [ feed.hide_images, __('Do not embed media') ],
 						cache_images: [ feed.cache_images, __('Cache media') ],

--- a/js/PrefUsers.js
+++ b/js/PrefUsers.js
@@ -95,7 +95,7 @@ const	Users = {
 									<hr/>
 
 									<fieldset>
-										<label>${__("E-mail:")}</label>
+										<label>${__("Email:")}</label>
 										<input dojoType='dijit.form.TextBox' size='30' name='email'
 											value="${App.escapeHtml(user.email)}">
 									</fieldset>

--- a/plugins/auth_remote/init.php
+++ b/plugins/auth_remote/init.php
@@ -69,7 +69,7 @@ class Auth_Remote extends Auth_Base {
 						$sth = $this->pdo->prepare("UPDATE ttrss_users SET full_name = ? WHERE id = ?");
 						$sth->execute([$fullname, $user_id]);
 					}
-					// update user mail
+					// update user email
 					$email = $_SERVER['HTTP_USER_MAIL'] ?? $_SERVER['AUTHENTICATE_MAIL'] ?? '';
 					if ($email){
 						$sth = $this->pdo->prepare("UPDATE ttrss_users SET email = ? WHERE id = ?");

--- a/templates/mail_change_template.txt
+++ b/templates/mail_change_template.txt
@@ -1,7 +1,7 @@
 <!-- $BeginBlock message -->
 Hello, ${LOGIN}.
 
-Your mail address for this Tiny Tiny RSS instance has been changed to ${NEWMAIL}.
+Your email address for this Tiny Tiny RSS instance has been changed to ${NEWMAIL}.
 
 If you haven't requested this change, consider contacting your instance owner or resetting your password.
 


### PR DESCRIPTION
## Description
The words `e-mail`, `mail` and `email` are used in several places of tt-rss.
This PR replaces `e-mail` and `mail` by `email`.

## How Has This Been Tested?
No test has been done. It was edited online.

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
