### PR TITLE
Update PHP website url in the help message for date format

### DIFF
--- a/classes/Pref_Prefs.php
+++ b/classes/Pref_Prefs.php
@@ -110,7 +110,7 @@ class Pref_Prefs extends Handler_Protected {
 			Prefs::FRESH_ARTICLE_MAX_AGE => [__("Maximum age of fresh articles"), "<strong>" . __("hours") . "</strong>"],
 			Prefs::HIDE_READ_FEEDS => [__("Hide read feeds")],
 			Prefs::HIDE_READ_SHOWS_SPECIAL => [__("Always show special feeds"), __("While hiding read feeds")],
-			Prefs::LONG_DATE_FORMAT => [__("Long date format"), __("Syntax is identical to PHP <a href='http://php.net/manual/function.date.php'>date()</a> function.")],
+			Prefs::LONG_DATE_FORMAT => [__("Long date format"), __("Syntax is identical to PHP <a href='https://www.php.net/manual/function.date.php'>date()</a> function.")],
 			Prefs::ON_CATCHUP_SHOW_NEXT_FEED => [__("Automatically show next feed"), __("After marking one as read")],
 			Prefs::PURGE_OLD_DAYS => [__("Purge articles older than"), __("<strong>days</strong> (0 disables)")],
 			Prefs::PURGE_UNREAD_ARTICLES => [__("Purge unread articles")],


### PR DESCRIPTION
## Description
The preference named Prefs::LONG_DATE_FORMAT contains an help message pointing to the PHP date() function webpage, to explain the supported format.

## Motivation and Context
The url was in http instead of https.
You are free to reject this PR, if you prefer keeping the old http url.

## How Has This Been Tested?
No test. Only online editing.

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
