### PR TITLE
Error message when cancelling a label creation

### DIFF
--- a/js/CommonDialogs.js
+++ b/js/CommonDialogs.js
@@ -325,7 +325,7 @@ const	CommonDialogs = {
 		addLabel: function() {
 			const caption = prompt(__("Please enter label caption:"), "");
 
-			if (caption !== undefined && caption.trim().length > 0) {
+			if (caption && caption.trim().length > 0) {
 
 				const query = {op: "Pref_Labels", method: "add", caption: caption.trim()};
 


### PR DESCRIPTION
## Description
When "Create label" menu is clicked, a popup asks for the label caption. If the Cancel button is immediately pressed, an error message is displayed: `TypeError: can't access property "trim", caption is null.`

Indeed, the JavaScript `prompt()` message returns `null` when Cancel is pressed. The test `caption !== undefined` is thus true, and the `trim()` is tried on `null`, which fails.

The fix is to only check for `caption` as a boolean or `caption != null`.

While on this bug, I searched for other erroneous usages of the `prompt()` return, and I found no other ones.

## Motivation and Context
Suppress the warning.

## How Has This Been Tested?
By editing a running Docker container. With the fix, the error disappears.

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
