### PR TITLE
Make filter types and action names translatable

### DIFF
--- a/messages.pot
+++ b/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-11-04 17:27+0000\n"
+"POT-Creation-Date: 2025-11-05 19:10+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -178,12 +178,13 @@ msgstr ""
 msgid "Oldest first"
 msgstr ""
 
-#: index.php:199 js/CommonFilters.js:418
+#: index.php:199 classes/Pref_Filters.php:38 js/CommonFilters.js:418
 msgid "Title"
 msgstr ""
 
-#: index.php:212 index.php:269 classes/RPC.php:537 js/Headlines.js:1542
-#: js/FeedTree.js:94 js/FeedTree.js:133 js/Headlines.js:666
+#: index.php:212 index.php:269 classes/RPC.php:537 classes/Pref_Filters.php:25
+#: js/Headlines.js:1542 js/FeedTree.js:94 js/FeedTree.js:133
+#: js/Headlines.js:666
 msgid "Mark as read"
 msgstr ""
 
@@ -306,7 +307,7 @@ msgstr ""
 msgid "Feeds"
 msgstr ""
 
-#: prefs.php:148 classes/Pref_Filters.php:288
+#: prefs.php:148 classes/Pref_Filters.php:300
 msgid "Filters"
 msgstr ""
 
@@ -555,7 +556,7 @@ msgstr ""
 msgid "Create label"
 msgstr ""
 
-#: classes/RPC.php:556 classes/Pref_Filters.php:745
+#: classes/RPC.php:556 classes/Pref_Filters.php:736
 msgid "Create filter"
 msgstr ""
 
@@ -961,21 +962,21 @@ msgid "Reset to defaults"
 msgstr ""
 
 #: classes/Pref_Prefs.php:840 classes/Pref_Feeds.php:928
-#: classes/Pref_Filters.php:730 classes/Pref_Users.php:199 js/Feeds.js:662
+#: classes/Pref_Filters.php:721 classes/Pref_Users.php:199 js/Feeds.js:662
 #: js/Feeds.js:657 js/Feeds.js:712
 msgid "Search"
 msgstr ""
 
 #: classes/Pref_Prefs.php:845 classes/Pref_Prefs.php:1523
 #: classes/Pref_Labels.php:175 classes/Pref_Feeds.php:933
-#: classes/Pref_Filters.php:735 classes/Pref_Users.php:205
+#: classes/Pref_Filters.php:726 classes/Pref_Users.php:205
 #: js/CommonFilters.js:426 js/CommonFilters.js:459 js/PrefFeedTree.js:516
 #: js/PrefHelpers.js:183 js/CommonDialogs.js:276
 msgid "Select"
 msgstr ""
 
 #: classes/Pref_Prefs.php:848 classes/Pref_Prefs.php:1526
-#: classes/Pref_Feeds.php:936 classes/Pref_Filters.php:738
+#: classes/Pref_Feeds.php:936 classes/Pref_Filters.php:729
 #: classes/Pref_Users.php:208 js/CommonFilters.js:430 js/CommonFilters.js:462
 #: js/PrefFeedTree.js:519 js/Headlines.js:657 js/PrefHelpers.js:186
 #: js/CommonDialogs.js:279
@@ -983,7 +984,7 @@ msgid "All"
 msgstr ""
 
 #: classes/Pref_Prefs.php:850 classes/Pref_Prefs.php:1528
-#: classes/Pref_Feeds.php:938 classes/Pref_Filters.php:740
+#: classes/Pref_Feeds.php:938 classes/Pref_Filters.php:731
 #: classes/Pref_Users.php:210 js/CommonFilters.js:432 js/CommonFilters.js:464
 #: js/PrefFeedTree.js:521 js/Headlines.js:660 js/PrefHelpers.js:188
 #: js/CommonDialogs.js:281
@@ -1143,7 +1144,7 @@ msgid "Fresh articles"
 msgstr ""
 
 #: classes/Feeds.php:1345 classes/OPML.php:532 classes/Digest.php:107
-#: classes/Pref_Feeds.php:247 classes/Pref_Filters.php:1018
+#: classes/Pref_Feeds.php:247 classes/Pref_Filters.php:1009
 #: include/controls.php:215
 msgid "Uncategorized"
 msgstr ""
@@ -1419,7 +1420,7 @@ msgid "Edit selected feeds"
 msgstr ""
 
 #: classes/Pref_Feeds.php:950 classes/Pref_Feeds.php:965
-#: classes/Pref_Filters.php:753
+#: classes/Pref_Filters.php:744
 msgid "Reset sort order"
 msgstr ""
 
@@ -1471,69 +1472,125 @@ msgstr ""
 msgid "Sharing"
 msgstr ""
 
-#: classes/Pref_Filters.php:260 classes/Pref_Filters.php:270
-#: classes/Pref_Filters.php:452 classes/Pref_Filters.php:965
+#: classes/Pref_Filters.php:24
+msgid "Delete article"
+msgstr ""
+
+#: classes/Pref_Filters.php:26
+msgid "Set starred"
+msgstr ""
+
+#: classes/Pref_Filters.php:27
+msgid "Assign tags"
+msgstr ""
+
+#: classes/Pref_Filters.php:28
+msgid "Publish article"
+msgstr ""
+
+#: classes/Pref_Filters.php:29
+msgid "Modify score"
+msgstr ""
+
+#: classes/Pref_Filters.php:30 js/Headlines.js:1500
+msgid "Assign label"
+msgstr ""
+
+#: classes/Pref_Filters.php:31
+msgid "Stop / Do nothing"
+msgstr ""
+
+#: classes/Pref_Filters.php:32
+msgid "Invoke plugin"
+msgstr ""
+
+#: classes/Pref_Filters.php:33
+msgid "Ignore tags"
+msgstr ""
+
+#: classes/Pref_Filters.php:39
+msgid "Content"
+msgstr ""
+
+#: classes/Pref_Filters.php:40
+msgid "Title or Content"
+msgstr ""
+
+#: classes/Pref_Filters.php:41
+msgid "Link"
+msgstr ""
+
+#: classes/Pref_Filters.php:44
+msgid "Author"
+msgstr ""
+
+#: classes/Pref_Filters.php:45
+msgid "Article Tags"
+msgstr ""
+
+#: classes/Pref_Filters.php:272 classes/Pref_Filters.php:282
+#: classes/Pref_Filters.php:454 classes/Pref_Filters.php:956
 msgid "All feeds"
 msgstr ""
 
-#: classes/Pref_Filters.php:279 classes/Pref_Filters.php:473
-#: classes/Pref_Filters.php:476
+#: classes/Pref_Filters.php:291 classes/Pref_Filters.php:465
+#: classes/Pref_Filters.php:468
 msgid "(inverse)"
 msgstr ""
 
-#: classes/Pref_Filters.php:275 classes/Pref_Filters.php:472
-#: classes/Pref_Filters.php:475
+#: classes/Pref_Filters.php:287 classes/Pref_Filters.php:464
+#: classes/Pref_Filters.php:467
 #, php-format
 msgid "%s on %s in %s %s"
 msgstr ""
 
-#: classes/Pref_Filters.php:492
+#: classes/Pref_Filters.php:483
 #, php-format
 msgid "Unknown action: %d"
 msgstr ""
 
-#: classes/Pref_Filters.php:704 js/PrefFilterTree.js:178
+#: classes/Pref_Filters.php:695 js/PrefFilterTree.js:178
 #, java-printf-format, javascript-format, php-format
 msgid "Clone of %s"
 msgstr ""
 
-#: classes/Pref_Filters.php:747 js/PrefHelpers.js:228
+#: classes/Pref_Filters.php:738 js/PrefHelpers.js:228
 msgid "Clone"
 msgstr ""
 
-#: classes/Pref_Filters.php:749
+#: classes/Pref_Filters.php:740
 msgid "Combine"
 msgstr ""
 
-#: classes/Pref_Filters.php:751 classes/Pref_Users.php:219
+#: classes/Pref_Filters.php:742 classes/Pref_Users.php:219
 #: js/CommonFilters.js:504 js/CommonDialogs.js:620
 msgid "Remove"
 msgstr ""
 
-#: classes/Pref_Filters.php:755
+#: classes/Pref_Filters.php:746
 msgid "Toggle rule display"
 msgstr ""
 
-#: classes/Pref_Filters.php:802
+#: classes/Pref_Filters.php:793
 msgid "[No caption]"
 msgstr ""
 
-#: classes/Pref_Filters.php:806
+#: classes/Pref_Filters.php:797
 #, php-format
 msgid "%s (%d rule)"
 msgid_plural "%s (%d rules)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: classes/Pref_Filters.php:811
+#: classes/Pref_Filters.php:802
 msgid "matches any rule"
 msgstr ""
 
-#: classes/Pref_Filters.php:814
+#: classes/Pref_Filters.php:805
 msgid "inverse"
 msgstr ""
 
-#: classes/Pref_Filters.php:846
+#: classes/Pref_Filters.php:837
 #, php-format
 msgid "(+%d action)"
 msgid_plural "(+%d actions)"
@@ -2338,10 +2395,6 @@ msgstr ""
 
 #: js/Headlines.js:1396
 msgid "Display article URL"
-msgstr ""
-
-#: js/Headlines.js:1500
-msgid "Assign label"
 msgstr ""
 
 #: js/Headlines.js:1505


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
* Make filter types and action names translatable.
* Also fix rule name display when editing a filter.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
* Support non-English languages in more parts of tt-rss.
* Closes #111.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
Local instance, PHPStan.

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
