### PR TITLE
When a filter rule is not inverted display it in green

### DIFF
--- a/classes/Pref_Filters.php
+++ b/classes/Pref_Filters.php
@@ -404,13 +404,16 @@ class Pref_Filters extends Handler_Protected {
 						$rrow["feed_id"] = ["" . $feed_id]; // set item type to string for in_array()
 					}
 
+                    // The function _get_rule_name() expects $rrow['inverse'] to be unset
+                    // to mean "false", in order to have a behavior similar to the HTML
+                    // checkbox which is unset when not checked on the web page.
+					if (!$rrow['inverse'])
+						unset($rrow['inverse']);
+
 					// NOTE: '_get_rule_name()' depends upon the 'match_on'/'feed_id' massaging that happens above.
 					$rrow['name'] = $this->_get_rule_name($rrow);
 
 					unset($rrow['cat_filter'], $rrow['cat_id'], $rrow['filter_id'], $rrow['id'], $rrow['match_on']);
-
-					if (!$rrow['inverse'])
-						unset($rrow['inverse']);
 
 					$rv['rules'][] = $rrow;
 				}


### PR DESCRIPTION
## Description
When a filter is edited, the _Match_ tab contains one line per rule.

Rules which are not inverted should appear in green color. However, every rule line appears in red.

This is due to `$rrow['inverse']` not being unset before calling `_get_rule_name()`.

Indeed, the function `_get_rule_name()` expects `$rrow['inverse']` to be unset to mean `false`, in order to have a behavior similar to the HTML checkbox which is unset when not checked on the web page.

## Motivation and Context
To have the good color for non inverted filter rules.

## How Has This Been Tested?
Inside a Docker image.

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
