### PR TITLE
Seven sentences were missing the gettext call to be translated

### DIFF
--- a/classes/Pref_Labels.php
+++ b/classes/Pref_Labels.php
@@ -175,20 +175,20 @@ class Pref_Labels extends Handler_Protected {
 						<span><?= __('Select') ?></span>
 						<div dojoType='dijit.Menu' style='display: none'>
 						<div onclick="dijit.byId('labelTree').model.setAllChecked(true)"
-							dojoType='dijit.MenuItem'><?=('All') ?></div>
+							dojoType='dijit.MenuItem'><?= __('All') ?></div>
 						<div onclick="dijit.byId('labelTree').model.setAllChecked(false)"
-							dojoType='dijit.MenuItem'><?=('None') ?></div>
+							dojoType='dijit.MenuItem'><?= __('None') ?></div>
 					</div>
 				</div>
 
 				<button dojoType='dijit.form.Button' onclick='CommonDialogs.addLabel()'>
-					<?=('Create label') ?></button dojoType='dijit.form.Button'>
+					<?= __('Create label') ?></button dojoType='dijit.form.Button'>
 
 				<button dojoType='dijit.form.Button' onclick="dijit.byId('labelTree').removeSelected()">
-					<?=('Remove') ?></button dojoType='dijit.form.Button'>
+					<?= __('Remove') ?></button dojoType='dijit.form.Button'>
 
 				<button dojoType='dijit.form.Button' onclick="dijit.byId('labelTree').resetColors()">
-					<?=('Clear colors') ?></button dojoType='dijit.form.Button'>
+					<?= __('Clear colors') ?></button dojoType='dijit.form.Button'>
 
 				</div>
 			</div>

--- a/index.php
+++ b/index.php
@@ -117,7 +117,7 @@
 
 <body class="flat ttrss_main ttrss_index css_loading">
 
-<noscript class="alert alert-error"><?= ('Javascript is disabled. Please enable it.') ?></noscript>
+<noscript class="alert alert-error"><?= __('Javascript is disabled. Please enable it.') ?></noscript>
 
 <div id="overlay">
 	<div id="overlay_inner">

--- a/prefs.php
+++ b/prefs.php
@@ -106,7 +106,7 @@
 
 <body class="flat ttrss_main ttrss_prefs css_loading">
 
-<noscript class="alert alert-error"><?= ('Javascript is disabled. Please enable it.') ?></noscript>
+<noscript class="alert alert-error"><?= __('Javascript is disabled. Please enable it.') ?></noscript>
 
 <div id="notify" class="notify"></div>
 <div id="cmdline" style="display : none"></div>


### PR DESCRIPTION
## Description
Seven sentences used for example `<?=('...') ?>` instead of `<?= __('...') ?>`.

## How Has This Been Tested?
No test. Only online editing.

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
