### PR TITLE
Remove the old .app_is_ready file earlier

### DIFF
--- a/.docker/app/startup.sh
+++ b/.docker/app/startup.sh
@@ -3,6 +3,11 @@
 # this script initializes the working copy on a persistent volume and starts PHP FPM
 #
 
+DST_DIR=$APP_INSTALL_BASE_DIR/tt-rss
+
+# Remove the previous file indicating the app is ready.
+[ -e $DST_DIR ] && rm -f $DST_DIR/.app_is_ready
+
 # helper to run git commands as the 'app' user while preserving proxy environment variables
 git_as_app() {
     sudo -u app \
@@ -53,10 +58,6 @@ if ! id app >/dev/null 2>&1; then
 fi
 
 update-ca-certificates || true
-
-DST_DIR=$APP_INSTALL_BASE_DIR/tt-rss
-
-[ -e $DST_DIR ] && rm -f $DST_DIR/.app_is_ready
 
 export PGPASSWORD=$TTRSS_DB_PASS
 


### PR DESCRIPTION
## Description
The `$DST_DIR/.app_is_ready` file indicates the app is ready. The previous file should be removed sooner, instead of being removed in the middle of `startup.sh`.

It is used by `updater.sh`, which waits sufficiently long to start (30 seconds), and then waits again watching the above file and config.

## Motivation and Context
If the user creates `docker-compose.override.yml` to set a `post_start` command, he/she can also wait for this file. Removing it sooner allows for a shorter waiting time.

## How Has This Been Tested?
Not tested. Only online editing.

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
