### PR TITLE
Rename Show help dialog to Keyboard shortcuts help

### DIFF
--- a/classes/RPC.php
+++ b/classes/RPC.php
@@ -555,7 +555,7 @@ class RPC extends Handler_Protected {
 				"create_label" => __("Create label"),
 				"create_filter" => __("Create filter"),
 				"collapse_sidebar" => __("Un/collapse sidebar"),
-				"help_dialog" => __("Show help dialog")]
+				"help_dialog" => __("Keyboard shortcuts help")]
 		];
 
 		PluginHost::getInstance()->chain_hooks_callback(PluginHost::HOOK_HOTKEY_INFO,


### PR DESCRIPTION
## Description
In the dialog showing hotkeys, the `?` key explanation was _Show help dialog_. However, it does not open an help page, but the list of keyboard shortcuts. This sentence is more clear.

## Motivation and Context
To have a clear explanation of what the `?` key is doing. We also reuse the sentence _Keyboard shortcuts help_ which is already in the main menu, so previously translated.

## How Has This Been Tested?
No test. Only online editing.

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
