### PR TITLE
Only skip hotkey handling for text input types

### DIFF
--- a/js/App.js
+++ b/js/App.js
@@ -912,24 +912,35 @@ const App = {
 
       document.title = tmp;
    },
-   hotkeyHandler: function(event) {
-      if (event.target.nodeName === "INPUT" || event.target.nodeName === "TEXTAREA") return;
+	hotkeyHandler: function(event) {
+		if (event.target.nodeName === 'TEXTAREA')
+			return;
 
-      // Arrow buttons and escape are not reported via keypress, handle them via keydown.
-      // escape = 27, left = 37, up = 38, right = 39, down = 40, pgup = 33, pgdn = 34, insert = 45, delete = 46
-      if (event.type === "keydown" && event.which !== 27 && (event.which < 33 || event.which > 46)) return;
-      const action_name = this.keyeventToAction(event);
+		if (event.target.nodeName === 'INPUT') {
+			const type = (event.target.type || 'text').toLowerCase();
+			const text_input_types = ['text', 'password', 'email', 'search', 'tel', 'url', 'number', 'date', 'datetime-local', 'month', 'time', 'week'];
 
-      if (action_name) {
-         const action_func = this.hotkey_actions[action_name];
+			if (text_input_types.includes(type))
+				return;
+		}
 
-         if (typeof action_func === 'function') {
-            action_func(event);
-            event.stopPropagation();
-            return false;
-         }
-      }
-   },
+		// Arrow buttons and escape are not reported via keypress, handle them via keydown.
+		if (event.type === 'keydown'
+			&& !['Escape', 'ArrowLeft', 'ArrowUp', 'ArrowRight', 'ArrowDown', 'PageUp', 'PageDown', 'Insert', 'Delete'].includes(event.key))
+			return;
+
+		const action_name = this.keyeventToAction(event);
+
+		if (action_name) {
+			const action_func = this.hotkey_actions[action_name];
+
+			if (typeof action_func === 'function') {
+				action_func(event);
+				event.stopPropagation();
+				return false;
+			}
+		}
+	},
 	isWideScreenMode: function() {
 		return !!this._widescreen_mode;
 	},


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
* Only skip hotkey handling for text input types.
* Started replacing use of the deprecated `event.which`.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #133.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
Hotkeys with various page elements focused.

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
