### PR TITLE
Properly sync 'nginx_xaccel' from source to destination

### DIFF
--- a/.docker/app/startup.sh
+++ b/.docker/app/startup.sh
@@ -84,7 +84,7 @@ if [ -z $SKIP_RSYNC_ON_STARTUP ]; then
 			$SRC_DIR/ $DST_DIR/
 
 		sudo -u app rsync -a --no-owner --delete \
-			$SRC_DIR/plugins.local/nginx_xaccel \
+			$SRC_DIR/plugins.local/nginx_xaccel/ \
 			$DST_DIR/plugins.local/nginx_xaccel
 	fi
 else

--- a/.docker/app/update.sh
+++ b/.docker/app/update.sh
@@ -62,7 +62,7 @@ if [ -z $SKIP_RSYNC_ON_STARTUP ]; then
 			$SRC_DIR/ $DST_DIR/
 
 		sudo -u app rsync -a --no-owner --delete \
-			$SRC_DIR/plugins.local/nginx_xaccel \
+			$SRC_DIR/plugins.local/nginx_xaccel/ \
 			$DST_DIR/plugins.local/nginx_xaccel
 	fi
 else


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Properly sync 'nginx_xaccel' from source to destination.

Before this we ended up with 'plugins.local/nginx_xaccel/nginx_xaccel'.

Thanks to @jdeluyck for pointing out this issue in tt-rss/tt-rss#145.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
* Ensures `nginx_xaccel` gets updated properly.
* Closes #145.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
Local instance.

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
