### PR TITLE
Old table ttrss_user_prefs still used in Pref_Prefs.php

### DIFF
--- a/classes/Pref_Prefs.php
+++ b/classes/Pref_Prefs.php
@@ -1413,14 +1413,14 @@ class Pref_Prefs extends Handler_Protected {
 			$new_profile->owner_uid = $_SESSION['uid'];
 
 			if ($new_profile->save()) {
-				$sth = $this->pdo->prepare("INSERT INTO ttrss_user_prefs
+				$sth = $this->pdo->prepare("INSERT INTO ttrss_user_prefs2
 					(owner_uid, pref_name, profile, value)
 						SELECT
 							:uid,
 							pref_name,
 							:new_profile,
 							value
-						FROM ttrss_user_prefs
+						FROM ttrss_user_prefs2
 						WHERE owner_uid = :uid AND profile = :old_profile");
 
 				$sth->execute([
@@ -1496,7 +1496,7 @@ class Pref_Prefs extends Handler_Protected {
 		foreach ($profiles as $profile) {
 			$profile['active'] = ($_SESSION["profile"] ?? 0) == $profile->id;
 
-			$num_settings = ORM::for_table('ttrss_user_prefs')
+			$num_settings = ORM::for_table('ttrss_user_prefs2')
 				->where('profile', $profile->id)
 				->count();
 


### PR DESCRIPTION
## Description
The table `ttrss_user_prefs` was replaced by `ttrss_user_prefs2` in database version 141.

However, the profile cloning feature still uses twice the old table name, so nothing is really cloned.

The `getProfiles()` function also uses this old table, so the attribute `initialized` is always false, so there is always `(empty)` at the end of cloned profile names.

## Motivation and Context
Support profile cloning.

## How Has This Been Tested?
Inside a Docker image.

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
