### PR TITLE
Add selectionDisplayArticleUrl() to have a main menu consistent with the right-click menu

### DIFF
--- a/js/Article.js
+++ b/js/Article.js
@@ -131,6 +131,27 @@ const Article = {
             alert(__("No articles selected."));
         }
     },
+    selectionDisplayArticleUrl: function () {
+        const ids = Headlines.getSelected();
+
+        if (ids.length > 0) {
+            let content = "<ul>\n";
+            ids.forEach((id) => {
+                const hl = Headlines.objectById(id);
+                if (hl?.link) {
+                    content += '<li><a href="' + encodeURI(hl.link) + '" target="_blank">' + encodeURI(hl.link) + "</li>\n";
+                }
+            });
+            content += "</ul>\n";
+            const dialog = new fox.SingleUseDialog({
+                title: __("URL of selected articles"),
+                content: content,
+            });
+            dialog.show();
+        } else {
+            alert(__("No articles selected."));
+        }
+	},
 	renderNote: function (id, note) {
 		return `<div class="article-note" data-note-for="${id}" style="display : ${note ? "" : "none"}">
 				${App.FormFields.icon('note')} <div onclick class='body'>${note ? App.escapeHtml(note) : ""}</div>

--- a/js/Headlines.js
+++ b/js/Headlines.js
@@ -660,6 +660,7 @@ const Headlines = {
 						<option value='headlines_select_none'>${__('None')}</option>
 						<option></option>
 						<option value='article_selectionOpenInNewWindow'>${__('Open original article')}</option>
+						<option value='article_selectionDisplayArticleUrl'>${__('Display article URL')}</option>
 						<option></option>
 						<option value='headlines_selectionToggleUnread'>${__('Toggle unread')}</option>
 						<option value='headlines_selectionToggleMarked'>${__('Toggle starred')}</option>
@@ -722,6 +723,9 @@ const Headlines = {
 						break;
 					case 'article_selectionOpenInNewWindow':
 						Article.selectionOpenInNewWindow();
+						break;
+					case 'article_selectionDisplayArticleUrl':
+						Article.selectionDisplayArticleUrl();
 						break;
 					case 'headlines_deleteSelection':
 						Headlines.deleteSelection();


### PR DESCRIPTION
## Description
The main `Select` menu contains:
- Open original article
- Toggle unread
- etc.

However, the right-click menu contains:
- Open original article
- Display article URL
- Toggle unread
- etc.

## Motivation and Context
Adding a _Display article URL_ in the main menu is more consistent. This new function also works on several articles, whereas the right-click menu only works on one article.

I reused the same _Display article URL_ sentence, so no translation is needed for its line.

The _Display article URL_ right-click menu opens a popup to show the url. As this is not sufficient for multiple url, the new function creates a `fox.SingleUseDialog()` which is nicer.

This new window title is _URL of selected articles_. I searched on Weblate to see if an existing sentence was matching this new need, but I found none, so I added it. This means the script `utils/rebase-translations.sh` will have to be run again.

## How Has This Been Tested?
Inside a Docker image. I then used https://github.dev/ to paste in the two files.

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
