### PR TITLE
When adding tags to an article process linefeeds like commas

### DIFF
--- a/classes/Article.php
+++ b/classes/Article.php
@@ -192,7 +192,7 @@ class Article extends Handler_Protected {
 		$id = clean($_REQUEST["id"]);
 
 		// When user enters linefeeds, also process them as a separator.
-		$tags = FeedItem_Common::normalize_categories(preg_split("/[,\n]/", clean($_REQUEST["tags_str"] ?? "")));
+		$tags = FeedItem_Common::normalize_categories(preg_split('/[,\r\n]+/', clean($_REQUEST['tags_str'] ?? ''), -1, PREG_SPLIT_NO_EMPTY));
 
 		$this->pdo->beginTransaction();
 


### PR DESCRIPTION
## Description
When a user adds tags to an article, a `textarea` is used to retrieve the values. The form indicates that tags have to be separated by _commas_.

However, it is also convenient to separate them by linefeeds. A user can also enter a linefeed thinking it is a separator.

## Motivation and Context
Keeping tags with new lines in the middle is not useful. So, split the string on commas and linefeeds.

## How Has This Been Tested?
Inside Docker.

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
