### PR TITLE
Fix a known search issue related to negative note keyword

### DIFF
--- a/classes/Feeds.php
+++ b/classes/Feeds.php
@@ -2223,6 +2223,11 @@ class Feeds extends Handler_Protected {
 
 				switch ($keyword_name) {
 					case 'title':
+						/**
+						 * Known issue: a Search Query containing spaces like _title:" be "_
+						 * matches "cyBErspace", and not only " be ", because the spaces
+						 * are trimmed by the two trim() above.
+						 */
 						$query_keywords[] = "($not (LOWER(ttrss_entries.title) LIKE " .
 							$pdo->quote("%{$keyword_value}%") . '))';
 						$valid_keyword_processed = true;
@@ -2237,12 +2242,7 @@ class Feeds extends Handler_Protected {
 						else if ($keyword_value == 'false')
 							$query_keywords[] = "($not (note IS NULL OR note = ''))";
 						else
-							/**
-							 * Known issue: when this Keyword is negated like _-note:store_ it only
-							 * selects articles with a note different of "store", but article with no
-							 * notes are not selected (whereas it should also select them).
-							 */
-							$query_keywords[] = "($not (LOWER(note) LIKE " . $pdo->quote("%{$keyword_value}%") . '))';
+							$query_keywords[] = "($not (LOWER(COALESCE(note, '')) LIKE " . $pdo->quote("%{$keyword_value}%") . '))';
 						$valid_keyword_processed = true;
 						break;
 					case 'star':


### PR DESCRIPTION
## Description
When a user searches _-note:store_ the results now contains:
- articles with a note different of "store"
- articles with no notes

Indeed, the NULL case was not handled, so articles without a note were not displayed.

## Motivation and Context
Improve the search support.

## How Has This Been Tested?
Inside Docker.

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
