### PR TITLE
Support simple logical operators in search queries

### DIFF
--- a/classes/Feeds.php
+++ b/classes/Feeds.php
@@ -2373,12 +2373,16 @@ class Feeds extends Handler_Protected {
 
 		if (count($search_query_leftover) > 0) {
 
-			// if there's no joiners consider this a "simple" search and
-			// concatenate everything with &, otherwise don't try to mess with tsquery syntax
-			if (preg_match('/[&|]/', implode(' ', $search_query_leftover))) {
-				// Known issue: other operators such as ! and parenthesis are not detected.
-				// Allowing them may have side effects, so change nothing for now.
-				$tsquery = $pdo->quote(implode(' ', $search_query_leftover));
+			/**
+			 * If there is no logical operator, consider this a "simple" search and
+			 * concatenate everything with &, otherwise don't try to mess with tsquery
+			 * syntax.
+			 * Known issue : Once the user is using at least one logical operator, he
+			 * has to ensure his query is well formatted. No warning will be displayed.
+			 */
+			$concatenated_leftovers = implode(' ', $search_query_leftover);
+			if (preg_match('/[&|!()]/', $concatenated_leftovers)) {
+				$tsquery = $pdo->quote($concatenated_leftovers);
 			} else {
 				$tsquery = $pdo->quote(implode(' & ', $search_query_leftover));
 			}


### PR DESCRIPTION
## Description
tt-rss is currently supporting complex text search queries like `( one | two )`.

However, simple queries containing only _!_, _(_ or _)_ were not supported.

This is because the regexp only matched _&_ and _|_.

Please, DO NOT UPDATE the documentation yet ([Search Syntax](https://github.com/tt-rss/tt-rss/wiki/Search-Syntax)).
Indeed, I am writing a new help page for search queries: [draft](https://github.com/LaurentGH/tt-rss/wiki/Search-syntax)
I have other PRs to submit in the next days, in order to improve the search.
Then, I'll give you the source code of this Wiki page. Then, you can adapt it if needed.

## Motivation and Context
A very simple query such as _! word_ was not supported.

## How Has This Been Tested?
Inside Docker.

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
