### PR TITLE
Notify.progress() and Notify.error() parameter was useless

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -399,16 +399,13 @@ const Notify = {
 			}, this.default_timeout);
 
 	},
-	info: function(msg, keep) {
-		keep = keep || false;
+	info: function(msg, keep = false) {
 		this.msg(msg, keep, this.KIND_INFO);
 	},
-	progress: function(msg, keep) {
-		keep = (keep === undefined) || keep; // Means true by default.
+	progress: function(msg, keep = true) {
 		this.msg(msg, keep, this.KIND_PROGRESS);
 	},
-	error: function(msg, keep) {
-		keep = (keep === undefined) || keep; // Means true by default.
+	error: function(msg, keep = true) {
 		this.msg(msg, keep, this.KIND_ERROR);
 	}
 };


### PR DESCRIPTION
## Description
The second parameter `keep` of `Notify.progress()` and `Notify.error()` indicates if the windows is kept open or automatically closed.

The developer intent was to have `keep = true` when unset.

However, the code contained:
```
keep = keep || true;
```
If `keep` was unset the result was `true`, but if `keep` was `false` the result was also `true`.

If all cases (`undef`, `false`, `true`), this parameter was thus `true`, and it was impossible to automatically close this window.

It can be noted that a `grep -rs 'Notify.progress.*true'` finds 27 places where the second parameter `true` could be removed because this is the default value.

## Motivation and Context
Be able to automatically close a `Notify.progress()`.

## How Has This Been Tested?
Inside Docker.

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
