### PR TITLE
Automatically close the "Opening debugger" message

### DIFF
--- a/js/CommonDialogs.js
+++ b/js/CommonDialogs.js
@@ -253,7 +253,7 @@ const	CommonDialogs = {
 						const sel_rows = this.getSelectedFeeds();
 
 						if (sel_rows.length > 0) {
-							if (sel_rows.length == 1 || confirm(__("Debug selected feeds?"))) {
+							if (sel_rows.length === 1 || confirm(__("Debug selected feeds?"))) {
 								Notify.progress("Opening debugger for selected feeds...", false);
 
 								for (let i = 0; i < sel_rows.length; i++) {


### PR DESCRIPTION
## Description
In the _Preferences_ page, in the _Feeds_ tab, in _Feeds with errors_ page, one can select a feed, and click on the button _Debug selected feeds_.

This opens a new _web browser tab_, and also adds a yellow message _Opening debugger for selected feeds..._. However, when we come back to the _Preferences_ page, we have to manually close this yellow message, which becomes useless.

This patch automatically closes the message after 5 seconds, by setting the second parameter of `Notify.progress()` to `false`.

This patch also opens the `confirm()` only when there are several selected feeds. There is not need for a confirmation for one feed only.

## Motivation and Context
Automatically close useless message.

## How Has This Been Tested?
Inside Docker.

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
