### PR TITLE
Display FeedParser error instead of the raw feed contents

### DIFF
--- a/classes/Feeds.php
+++ b/classes/Feeds.php
@@ -1032,7 +1032,9 @@ class Feeds extends Handler_Protected {
 
 		// Don't allow subscribing if the content is invalid
 		$fp = new FeedParser($contents);
-		if ($fp->error() || $fp->get_type() === FeedParser::FEED_UNKNOWN)
+		if ($fp->error())
+			return ['code' => 6, 'message' => truncate_string(clean($fp->error()), 250, '…')];
+		if ($fp->get_type() === FeedParser::FEED_UNKNOWN)
 			return ['code' => 6, 'message' => truncate_string(clean($contents), 250, '…')];
 
 		$feed = ORM::for_table('ttrss_feeds')


### PR DESCRIPTION
## Description
When subscribing to a feed, if there is a `FeedParser` error, display the error message instead of the raw feed contents.

## Motivation and Context
The raw feed contents does not help to understand why there is an error during the call to `FeedParser` class.

## How Has This Been Tested?
Inside Docker.

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
