### PR TITLE
Consider a feed without articles to be "successfully updated"

### DIFF
--- a/classes/RSSUtils.php
+++ b/classes/RSSUtils.php
@@ -512,10 +512,12 @@ class RSSUtils {
 				Debug::log("source claims data not modified (304), nothing to do.", Debug::LOG_VERBOSE);
 				$error_message = "";
 
+				$now = Db::NOW();
+
 				$feed_obj->set([
 					'last_error' => '',
-					'last_successful_update' => Db::NOW(),
-					'last_updated' => Db::NOW(),
+					'last_successful_update' => $now,
+					'last_updated' => $now,
 				]);
 
 				$feed_obj->save();
@@ -679,9 +681,12 @@ class RSSUtils {
 			if (count($items) === 0) {
 				Debug::log("no articles found.", Debug::LOG_VERBOSE);
 
+				$now = Db::NOW();
+
 				$feed_obj->set([
-					'last_updated' => Db::NOW(),
-					'last_unconditional' => Db::NOW(),
+					'last_updated' => $now,
+					'last_unconditional' => $now,
+					'last_successful_update' => $now,
 					'last_error' => '',
 				]);
 
@@ -1275,10 +1280,12 @@ class RSSUtils {
 
 			Feeds::_purge($feed, 0);
 
+			$now = Db::NOW();
+
 			$feed_obj->set([
-				'last_updated' => Db::NOW(),
-				'last_unconditional' => Db::NOW(),
-				'last_successful_update' => Db::NOW(),
+				'last_updated' => $now,
+				'last_unconditional' => $now,
+				'last_successful_update' => $now,
 				'last_error' => '',
 			]);
 
@@ -1296,9 +1303,11 @@ class RSSUtils {
 				}
 			}
 
+			$now = Db::NOW();
+
 			$feed_obj->set([
-				'last_updated' => Db::NOW(),
-				'last_unconditional' => Db::NOW(),
+				'last_updated' => $now,
+				'last_unconditional' => $now,
 				'last_error' => $error_msg,
 			]);
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Consider a feed without articles to be "successfully updated".

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
* Prior to this `DAEMON_UNSUCCESSFUL_DAYS_LIMIT` would disable empty (but otherwise valid) feeds due to `last_successful_update` not getting set/updated.
* Since there might be valid reasons for a feed to be empty, and tt-rss doesn't currently treat such a feed as invalid or surface info that it will be disabled, we'll just treat that situation as a successful update.
* Closes #230.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
Feed updates in a local instance.

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
