### PR TITLE
fix: Backup script now works with non-default DB listening ports

### DIFF
--- a/.docker/app/backup.sh
+++ b/.docker/app/backup.sh
@@ -11,7 +11,7 @@ if pg_isready -h $TTRSS_DB_HOST -U $TTRSS_DB_USER -p $TTRSS_DB_PORT; then
 
 	export PGPASSWORD=$TTRSS_DB_PASS
 
-	pg_dump --clean -h $TTRSS_DB_HOST -U $TTRSS_DB_USER $TTRSS_DB_NAME | gzip > $DST_DIR/$DST_FILE
+	pg_dump --clean -h $TTRSS_DB_HOST -U $TTRSS_DB_USER -p $TTRSS_DB_PORT $TTRSS_DB_NAME | gzip > $DST_DIR/$DST_FILE
 
 	DST_FILE=ttrss-backup-$(date +%Y%m%d).tar.gz
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Added -p $TTRSS_DB_PORT flag to call to pg_dump, to support installations where the DB being connected to is not listening at the default port of 5432.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
https://github.com/tt-rss/tt-rss/issues/232

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
`backup.sh` script failed in my setup.
After this modification it completes successfully.

## Screenshots (if appropriate)
<!-- If screenshots will help in understanding the change, include them here. -->

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
