### PR TITLE
sanitize content preview in headlines

### DIFF
--- a/classes/API.php
+++ b/classes/API.php
@@ -724,7 +724,13 @@ class API extends Handler {
 
 			if (!is_numeric($result)) {
 				while ($line = $result->fetch()) {
-					$line["content_preview"] = truncate_string(strip_tags($line["content"]), $excerpt_length);
+					$content = Sanitizer::sanitize(
+								$line['content'], self::_param_to_bool($line['hide_images']),
+								site_url: $line['site_url'], article_id: $line['id']);
+					if(! $content) $content = '';
+
+					$line["content_preview"] = truncate_string(strip_tags($content), $excerpt_length);
+					unset($content);
 
 					PluginHost::getInstance()->chain_hooks_callback(PluginHost::HOOK_QUERY_HEADLINES,
 						function ($result) use (&$line) {

--- a/classes/Feeds.php
+++ b/classes/Feeds.php
@@ -208,7 +208,10 @@ class Feeds extends Handler_Protected {
 				if (!Prefs::get(Prefs::SHOW_CONTENT_PREVIEW, $_SESSION['uid'], $profile)) {
 					$line["content_preview"] = "";
 				} else {
-					$line["content_preview"] =  "&mdash; " . truncate_string(strip_tags($line["content"]), 250);
+					$content = Sanitizer::sanitize($line['content'], $line['hide_images'],
+						site_url: $line['site_url'], article_id: $line['id']);
+					if(! $content) $content = '';
+					$line["content_preview"] =  "&mdash; " . truncate_string(strip_tags($content), 250);
 
 					$max_excerpt_length = 250;
 


### PR DESCRIPTION
## Description
Calls Sanitizer::sanitize on content in headline mode before tag stripping and truncating.

## Motivation and Context
Recently, a feed whose content I'm scraping introduced `script` tags at the beginning, which made the headline preview useless and broke the layout.

## How Has This Been Tested?
Wrote, commited and run this on my instance.

## Screenshots (if appropriate)


## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.