### PR TITLE
Add environment overrides for local folders

### DIFF
--- a/classes/Config.php
+++ b/classes/Config.php
@@ -79,6 +79,15 @@ class Config {
 	/** base directory for local cache (must be writable) */
 	const CACHE_DIR = "CACHE_DIR";
 
+	/** base directory for local plugins (must be writable) */
+	const LOCAL_PLUGINS_DIR = "LOCAL_PLUGINS_DIR";
+
+	/** base directory for local templates (must be writable) */
+	const LOCAL_TEMPLATES_DIR = "LOCAL_TEMPLATES_DIR";
+
+	/** base directory for local themes (must be writable) */
+	const LOCAL_THEMES_DIR = "LOCAL_THEMES_DIR";
+
 	/** auto create users authenticated via external modules */
 	const AUTH_AUTO_CREATE = "AUTH_AUTO_CREATE";
 
@@ -249,6 +258,9 @@ class Config {
 		Config::PHP_EXECUTABLE => [ "/usr/bin/php",					Config::T_STRING ],
 		Config::LOCK_DIRECTORY => [ "lock",								Config::T_STRING ],
 		Config::CACHE_DIR => [ "cache",									Config::T_STRING ],
+		Config::LOCAL_PLUGINS_DIR => [ "plugins.local", Config::T_STRING ],
+		Config::LOCAL_TEMPLATES_DIR => [ "templates.local", Config::T_STRING ],
+		Config::LOCAL_THEMES_DIR => [ "themes.local", Config::T_STRING ],
 		Config::AUTH_AUTO_CREATE => [ "true",							Config::T_BOOL ],
 		Config::AUTH_AUTO_LOGIN => [ "true",							Config::T_BOOL ],
 		Config::FORCE_ARTICLE_PURGE => [ 0,								Config::T_INT ],
@@ -594,6 +606,15 @@ class Config {
 
 		if (!is_writable(self::get(Config::CACHE_DIR) . '/export'))
 			$errors[] = 'Data export cache is not writable (chmod -R 777 ' . self::get(Config::CACHE_DIR) . '/export)';
+
+		if (!is_writable(self::get(Config::LOCAL_PLUGINS_DIR)))
+			$errors[] = 'Local plugin directory is not writable (chmod -R 777 ' . self::get(Config::LOCAL_PLUGINS_DIR) . ')';
+
+		if (!is_writable(self::get(Config::LOCAL_TEMPLATES_DIR)))
+			$errors[] = 'Local template directory is not writable (chmod -R 777 ' . self::get(Config::LOCAL_TEMPLATES_DIR) . ')';
+
+		if (!is_writable(self::get(Config::LOCAL_THEMES_DIR)))
+			$errors[] = 'Local theme directory is not writable (chmod -R 777 ' . self::get(Config::LOCAL_THEMES_DIR) . ')';
 
 		if (!is_writable(self::get(Config::LOCK_DIRECTORY)))
 			$errors[] = 'LOCK_DIRECTORY is not writable (chmod -R 777 ' . self::get(Config::LOCK_DIRECTORY) . ').';

--- a/classes/PluginHost.php
+++ b/classes/PluginHost.php
@@ -422,7 +422,8 @@ class PluginHost {
 	 * @param PluginHost::KIND_* $kind
 	 */
 	function load_all(int $kind, ?int $owner_uid = null, bool $skip_init = false): void {
-		$plugins = [...(glob("plugins/*") ?: []), ...(glob("plugins.local/*") ?: [])];
+		$plugin_root_dir = Config::get(Config::LOCAL_PLUGINS_DIR);
+		$plugins = [...(glob("plugins/*") ?: []), ...(glob("$plugin_root_dir/*") ?: [])];
 		$plugins = array_filter($plugins, is_dir(...));
 		$plugins = array_map(basename(...), $plugins);
 
@@ -451,7 +452,8 @@ class PluginHost {
 			$file = Config::get_self_dir() . "/plugins/$class_file/init.php";
 
 			if (!file_exists($file)) {
-				$file = Config::get_self_dir() . "/plugins.local/$class_file/init.php";
+				$plugin_root_dir = Config::get(Config::LOCAL_PLUGINS_DIR);
+				$file = "$plugin_root_dir/$class_file/init.php";
 
 				if (!file_exists($file)) {
 					continue;
@@ -906,10 +908,10 @@ class PluginHost {
 		return dirname($ref->getFileName());
 	}
 
-	// TODO: use get_plugin_dir()
 	function is_local(Plugin $plugin): bool {
-		$ref = new ReflectionClass($plugin::class);
-		return basename(dirname($ref->getFileName(), 2)) == "plugins.local";
+		$plugin_root_dir = Config::get(Config::LOCAL_PLUGINS_DIR);
+		$plugin_dir = $this->get_plugin_dir($plugin);
+		return realpath($plugin_root_dir) == realpath(dirname($plugin_dir));
 	}
 
 	/**

--- a/classes/Pref_Prefs.php
+++ b/classes/Pref_Prefs.php
@@ -625,7 +625,7 @@ class Pref_Prefs extends Handler_Protected {
 						$theme_files = array_map(basename(...), [
 							...glob('themes/*.php') ?: [],
 							...glob('themes/*.css') ?: [],
-							...glob('themes.local/*.css') ?: [],
+							...glob(Config::get(Config::LOCAL_THEMES_DIR) . '/*.css') ?: [],
 						]);
 
 						asort($theme_files);
@@ -1052,7 +1052,8 @@ class Pref_Prefs extends Handler_Protected {
 	 */
 	static function _get_updated_plugins(): array {
 		$root_dir = Config::get_self_dir();
-		$plugin_dirs = array_filter(glob("$root_dir/plugins.local/*"), is_dir(...));
+		$plugin_root_dir = Config::get(Config::LOCAL_PLUGINS_DIR);
+		$plugin_dirs = array_filter(glob("$plugin_root_dir/*"), is_dir(...));
 		$rv = [];
 
 		foreach ($plugin_dirs as $dir) {
@@ -1112,7 +1113,7 @@ class Pref_Prefs extends Handler_Protected {
 	 * @return array{'stdout': false|string, 'stderr': false|string, 'git_status': int, 'need_update': bool}|null
 	 */
 	private static function _plugin_needs_update(string $root_dir, string $plugin_name): ?array {
-		$plugin_dir = "$root_dir/plugins.local/" . basename($plugin_name);
+		$plugin_dir = Config::get(Config::LOCAL_PLUGINS_DIR) . "/" . basename($plugin_name);
 		$rv = null;
 
 		if (is_dir($plugin_dir) && is_dir("$plugin_dir/.git")) {
@@ -1143,7 +1144,7 @@ class Pref_Prefs extends Handler_Protected {
 	 * @return array{}|array{stdout: false|string, stderr: false|string, git_status: int}
 	 */
 	private function _update_plugin(string $root_dir, string $plugin_name): array {
-		$plugin_dir = "$root_dir/plugins.local/" . basename($plugin_name);
+		$plugin_dir = Config::get(Config::LOCAL_PLUGINS_DIR) . "/" . basename($plugin_name);
 
 		if (is_dir($plugin_dir) && is_dir("$plugin_dir/.git")) {
 			$current_branch = self::_git_current_branch($plugin_dir);
@@ -1213,7 +1214,7 @@ class Pref_Prefs extends Handler_Protected {
 			$plugin_name = basename(clean($_REQUEST['plugin']));
 			$status = 0;
 
-			$plugin_dir = Config::get_self_dir() . "/plugins.local/$plugin_name";
+			$plugin_dir = Config::get(Config::LOCAL_PLUGINS_DIR) . "/" . $plugin_name;
 
 			if (is_dir($plugin_dir)) {
 				$status = $this->_recursive_rmdir($plugin_dir);
@@ -1227,7 +1228,7 @@ class Pref_Prefs extends Handler_Protected {
 		if ($_SESSION["access_level"] >= UserHelper::ACCESS_LEVEL_ADMIN && Config::get(Config::ENABLE_PLUGIN_INSTALLER)) {
 			$plugin_name = basename(clean($_REQUEST['plugin']));
 			$all_plugins = $this->_get_available_plugins();
-			$plugin_dir = Config::get_self_dir() . "/plugins.local";
+			$plugin_dir = Config::get(Config::LOCAL_PLUGINS_DIR);
 
 			$work_dir = "$plugin_dir/plugin-installer";
 
@@ -1353,7 +1354,8 @@ class Pref_Prefs extends Handler_Protected {
 					$rv[] = ['plugin' => $plugin_name, 'rv' => $this->_update_plugin($root_dir, $plugin_name)];
 				}
 			} else {
-				$plugin_dirs = array_filter(glob("$root_dir/plugins.local/*"), is_dir(...));
+				$plugin_root_dir = Config::get(Config::LOCAL_PLUGINS_DIR);
+				$plugin_dirs = array_filter(glob("$plugin_root_dir/*"), is_dir(...));
 
 				foreach ($plugin_dirs as $dir) {
 					if (is_dir("$dir/.git")) {

--- a/classes/Pref_Prefs.php
+++ b/classes/Pref_Prefs.php
@@ -1062,7 +1062,7 @@ class Pref_Prefs extends Handler_Protected {
 
 				$rv[] = [
 					'plugin' => $plugin_name,
-					'rv' => self::_plugin_needs_update($root_dir, $plugin_name),
+					'rv' => self::_plugin_needs_update($plugin_name),
 				];
 			}
 		}
@@ -1112,7 +1112,7 @@ class Pref_Prefs extends Handler_Protected {
 	/**
 	 * @return array{'stdout': false|string, 'stderr': false|string, 'git_status': int, 'need_update': bool}|null
 	 */
-	private static function _plugin_needs_update(string $root_dir, string $plugin_name): ?array {
+	private static function _plugin_needs_update(string $plugin_name): ?array {
 		$plugin_dir = Config::get(Config::LOCAL_PLUGINS_DIR) . "/" . basename($plugin_name);
 		$rv = null;
 
@@ -1143,7 +1143,7 @@ class Pref_Prefs extends Handler_Protected {
 	/**
 	 * @return array{}|array{stdout: false|string, stderr: false|string, git_status: int}
 	 */
-	private function _update_plugin(string $root_dir, string $plugin_name): array {
+	private function _update_plugin(string $plugin_name): array {
 		$plugin_dir = Config::get(Config::LOCAL_PLUGINS_DIR) . "/" . basename($plugin_name);
 
 		if (is_dir($plugin_dir) && is_dir("$plugin_dir/.git")) {
@@ -1336,7 +1336,7 @@ class Pref_Prefs extends Handler_Protected {
 			$root_dir = Config::get_self_dir();
 
 			$rv = empty($plugin_name) ? self::_get_updated_plugins() : [
-				["plugin" => $plugin_name, "rv" => self::_plugin_needs_update($root_dir, $plugin_name)],
+				["plugin" => $plugin_name, "rv" => self::_plugin_needs_update($plugin_name)],
 			];
 
 			print json_encode($rv);
@@ -1351,7 +1351,7 @@ class Pref_Prefs extends Handler_Protected {
 
 			if ($plugins) {
 				foreach ($plugins as $plugin_name) {
-					$rv[] = ['plugin' => $plugin_name, 'rv' => $this->_update_plugin($root_dir, $plugin_name)];
+					$rv[] = ['plugin' => $plugin_name, 'rv' => $this->_update_plugin($plugin_name)];
 				}
 			} else {
 				$plugin_root_dir = Config::get(Config::LOCAL_PLUGINS_DIR);
@@ -1361,10 +1361,10 @@ class Pref_Prefs extends Handler_Protected {
 					if (is_dir("$dir/.git")) {
 						$plugin_name = basename($dir);
 
-						$test = self::_plugin_needs_update($root_dir, $plugin_name);
+						$test = self::_plugin_needs_update($plugin_name);
 
 						if (!empty($test["stdout"]))
-							$rv[] = ['plugin' => $plugin_name, 'rv' => $this->_update_plugin($root_dir, $plugin_name)];
+							$rv[] = ['plugin' => $plugin_name, 'rv' => $this->_update_plugin($plugin_name)];
 					}
 				}
 			}

--- a/classes/Templator.php
+++ b/classes/Templator.php
@@ -7,10 +7,11 @@ class Templator extends MiniTemplator {
 	function readTemplateFromFile ($fileName) {
 		if (!str_contains($fileName, "/")) {
 
+			$templateRootDir = Config::get(Config::LOCAL_TEMPLATES_DIR);
 			$fileName = basename($fileName);
 
-			if (file_exists("templates.local/$fileName"))
-				return parent::readTemplateFromFile("templates.local/$fileName");
+			if (file_exists("$templateRootDir/$fileName"))
+				return parent::readTemplateFromFile("$templateRootDir/$fileName");
 			else
 				return parent::readTemplateFromFile("templates/$fileName");
 

--- a/include/functions.php
+++ b/include/functions.php
@@ -476,14 +476,14 @@
 		$check = "themes/$theme";
 		if (file_exists($check)) return $check;
 
-		$check = "themes.local/$theme";
+		$check = Config::get(Config::LOCAL_THEMES_DIR) . "/$theme";
 		if (file_exists($check)) return $check;
 
 		return $default;
 	}
 
 	function theme_exists(string $theme): bool {
-		return file_exists("themes/$theme") || file_exists("themes.local/$theme");
+		return file_exists("themes/$theme") || file_exists(Config::get(Config::LOCAL_THEMES_DIR) . "/$theme");
 	}
 
 	/**


### PR DESCRIPTION
## Description

This adds new environment variables to customise the locations of the various `*.local` directories:
- `TTRSS_LOCAL_PLUGINS_DIR`
- `TTRSS_LOCAL_TEMPLATES_DIR`
- `TTRSS_LOCAL_THEMES_DIR`

## Motivation and Context

Fixes #263.

## How Has This Been Tested?

Deployed as my local installation (Arch Linux `tt-rss-git` package), I've tried switching between the default theme and custom themes in the local directory, switching custom plugins on and off, and using the plugin management admin pages to add and remove plugins.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
