### PR TITLE
When using the CLI, only set a user password if it's changed.

### DIFF
--- a/classes/Article.php
+++ b/classes/Article.php
@@ -58,6 +58,9 @@ class Article extends Handler_Protected {
 		$rc = false;
 
 		if (!$title) $title = $url;
+
+		// TODO: look into this
+		// @phpstan-ignore booleanNot.alwaysTrue
 		if (!$title && !$url) return false;
 
 		if (filter_var($url, FILTER_VALIDATE_URL) === false) return false;

--- a/update.php
+++ b/update.php
@@ -459,7 +459,7 @@
 
 		Debug::log("Changing password of user $login...");
 
-		if (UserHelper::user_modify($uid, $password)) {
+		if (UserHelper::user_has_password($uid, $password) || UserHelper::user_modify($uid, $password)) {
 			Debug::log("Success.");
 		} else {
 			Debug::log("Operation failed, check the logs for more information.");


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This is mainly to prevent session invalidation for the `admin` user when `ADMIN_USER_PASS` is defined and the container starts up.  Even if `ADMIN_USER_PASS` hadn't changed, `UserHelper::user_modify()` would get invoked and change `pwd_hash`, which would result in `Sessions::validate_session()` invalidating the session.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #286.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
Local instance with the config mentioned above.

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
