### PR TITLE
Allow nginx to gzip responses

### DIFF
--- a/.docker/web-nginx/nginx.conf
+++ b/.docker/web-nginx/nginx.conf
@@ -14,6 +14,12 @@ http {
 
 	sendfile on;
 
+	gzip on;
+	gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+	gzip_min_length 1024;
+	gzip_proxied any;
+	gzip_vary on;
+
 	index index.php;
 
 	resolver ${RESOLVER} valid=5s;


### PR DESCRIPTION
## Description

Allow nginx to gzip responses

## Motivation and Context

This can yield 4x compression for large JSON responses, particularly useful for slower cellular connections.

## How Has This Been Tested?
Tested locally, observed the following in the response:
```
Content-Encoding: gzip
```

## Screenshots (if appropriate)
<!-- If screenshots will help in understanding the change, include them here. -->

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.