### PR TITLE
Fix headline text overflow

### DIFF
--- a/themes/compact.css
+++ b/themes/compact.css
@@ -57,6 +57,7 @@ body.ttrss_main .post .header .row {
 }
 body.ttrss_main .post .header .comments {
   flex-grow: 2;
+  min-width: 0;
 }
 body.ttrss_main .post .header .date {
   white-space: nowrap;
@@ -70,11 +71,19 @@ body.ttrss_main .post .header i.material-icons {
 }
 body.ttrss_main .post .header .title {
   flex-grow: 2;
+  min-width: 0;
   font-size: 15px;
   font-weight: 600;
   text-rendering: optimizelegibility;
   font-family: system-ui, "Helvetica Neue", Helvetica, Arial, sans-serif;
   word-break: break-all;
+  overflow-wrap: anywhere;
+}
+body.ttrss_main .post .header .author {
+  flex: 1 1 auto;
+  min-width: 0;
+  white-space: normal;
+  overflow-wrap: anywhere;
 }
 body.ttrss_main .post .header .tags {
   max-width: 25%;
@@ -265,11 +274,18 @@ body.ttrss_main .hl .right i.material-icons {
 body.ttrss_main .hl .title {
   cursor: pointer;
   flex-grow: 2;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: normal;
+  overflow-wrap: anywhere;
 }
 body.ttrss_main .hl .author {
-  white-space: nowrap;
+  display: block;
+  min-width: 0;
+  max-width: 100%;
+  white-space: normal;
+  overflow-wrap: anywhere;
   color: #555;
   font-size: 11px;
   font-weight: normal;
@@ -1301,7 +1317,9 @@ body.ttrss_utility hr {
 }
 .cdm .header .titleWrap {
   flex-grow: 2;
+  min-width: 0;
   width: 0;
+  overflow-wrap: anywhere;
 }
 .cdm .header .updated {
   color: #555;
@@ -1323,7 +1341,11 @@ body.ttrss_utility hr {
   color: #555;
 }
 .cdm .header .author {
-  white-space: nowrap;
+  display: block;
+  min-width: 0;
+  max-width: 100%;
+  white-space: normal;
+  overflow-wrap: anywhere;
   color: #555;
   font-size: 11px;
   font-weight: normal;
@@ -1455,9 +1477,8 @@ body.ttrss_utility hr {
   display: none;
 }
 .cdm.expandable div.header span.titleWrap {
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  overflow: hidden;
+  white-space: normal;
+  overflow-wrap: anywhere;
 }
 .cdm.expandable .excerpt {
   white-space: nowrap;

--- a/themes/compact_night.css
+++ b/themes/compact_night.css
@@ -57,6 +57,7 @@ body.ttrss_main .post .header .row {
 }
 body.ttrss_main .post .header .comments {
   flex-grow: 2;
+  min-width: 0;
 }
 body.ttrss_main .post .header .date {
   white-space: nowrap;
@@ -70,11 +71,19 @@ body.ttrss_main .post .header i.material-icons {
 }
 body.ttrss_main .post .header .title {
   flex-grow: 2;
+  min-width: 0;
   font-size: 15px;
   font-weight: 600;
   text-rendering: optimizelegibility;
   font-family: system-ui, "Helvetica Neue", Helvetica, Arial, sans-serif;
   word-break: break-all;
+  overflow-wrap: anywhere;
+}
+body.ttrss_main .post .header .author {
+  flex: 1 1 auto;
+  min-width: 0;
+  white-space: normal;
+  overflow-wrap: anywhere;
 }
 body.ttrss_main .post .header .tags {
   max-width: 25%;
@@ -265,11 +274,18 @@ body.ttrss_main .hl .right i.material-icons {
 body.ttrss_main .hl .title {
   cursor: pointer;
   flex-grow: 2;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: normal;
+  overflow-wrap: anywhere;
 }
 body.ttrss_main .hl .author {
-  white-space: nowrap;
+  display: block;
+  min-width: 0;
+  max-width: 100%;
+  white-space: normal;
+  overflow-wrap: anywhere;
   color: #ccc;
   font-size: 11px;
   font-weight: normal;
@@ -1301,7 +1317,9 @@ body.ttrss_utility hr {
 }
 .cdm .header .titleWrap {
   flex-grow: 2;
+  min-width: 0;
   width: 0;
+  overflow-wrap: anywhere;
 }
 .cdm .header .updated {
   color: #ccc;
@@ -1323,7 +1341,11 @@ body.ttrss_utility hr {
   color: #ccc;
 }
 .cdm .header .author {
-  white-space: nowrap;
+  display: block;
+  min-width: 0;
+  max-width: 100%;
+  white-space: normal;
+  overflow-wrap: anywhere;
   color: #ccc;
   font-size: 11px;
   font-weight: normal;
@@ -1455,9 +1477,8 @@ body.ttrss_utility hr {
   display: none;
 }
 .cdm.expandable div.header span.titleWrap {
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  overflow: hidden;
+  white-space: normal;
+  overflow-wrap: anywhere;
 }
 .cdm.expandable .excerpt {
   white-space: nowrap;

--- a/themes/light-high-contrast.css
+++ b/themes/light-high-contrast.css
@@ -57,6 +57,7 @@ body.ttrss_main .post .header .row {
 }
 body.ttrss_main .post .header .comments {
   flex-grow: 2;
+  min-width: 0;
 }
 body.ttrss_main .post .header .date {
   white-space: nowrap;
@@ -70,11 +71,19 @@ body.ttrss_main .post .header i.material-icons {
 }
 body.ttrss_main .post .header .title {
   flex-grow: 2;
+  min-width: 0;
   font-size: 15px;
   font-weight: 600;
   text-rendering: optimizelegibility;
   font-family: system-ui, "Helvetica Neue", Helvetica, Arial, sans-serif;
   word-break: break-all;
+  overflow-wrap: anywhere;
+}
+body.ttrss_main .post .header .author {
+  flex: 1 1 auto;
+  min-width: 0;
+  white-space: normal;
+  overflow-wrap: anywhere;
 }
 body.ttrss_main .post .header .tags {
   max-width: 25%;
@@ -265,11 +274,18 @@ body.ttrss_main .hl .right i.material-icons {
 body.ttrss_main .hl .title {
   cursor: pointer;
   flex-grow: 2;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: normal;
+  overflow-wrap: anywhere;
 }
 body.ttrss_main .hl .author {
-  white-space: nowrap;
+  display: block;
+  min-width: 0;
+  max-width: 100%;
+  white-space: normal;
+  overflow-wrap: anywhere;
   color: black;
   font-size: 11px;
   font-weight: normal;
@@ -1301,7 +1317,9 @@ body.ttrss_utility hr {
 }
 .cdm .header .titleWrap {
   flex-grow: 2;
+  min-width: 0;
   width: 0;
+  overflow-wrap: anywhere;
 }
 .cdm .header .updated {
   color: black;
@@ -1323,7 +1341,11 @@ body.ttrss_utility hr {
   color: black;
 }
 .cdm .header .author {
-  white-space: nowrap;
+  display: block;
+  min-width: 0;
+  max-width: 100%;
+  white-space: normal;
+  overflow-wrap: anywhere;
   color: black;
   font-size: 11px;
   font-weight: normal;
@@ -1455,9 +1477,8 @@ body.ttrss_utility hr {
   display: none;
 }
 .cdm.expandable div.header span.titleWrap {
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  overflow: hidden;
+  white-space: normal;
+  overflow-wrap: anywhere;
 }
 .cdm.expandable .excerpt {
   white-space: nowrap;

--- a/themes/light.css
+++ b/themes/light.css
@@ -57,6 +57,7 @@ body.ttrss_main .post .header .row {
 }
 body.ttrss_main .post .header .comments {
   flex-grow: 2;
+  min-width: 0;
 }
 body.ttrss_main .post .header .date {
   white-space: nowrap;
@@ -70,11 +71,19 @@ body.ttrss_main .post .header i.material-icons {
 }
 body.ttrss_main .post .header .title {
   flex-grow: 2;
+  min-width: 0;
   font-size: 15px;
   font-weight: 600;
   text-rendering: optimizelegibility;
   font-family: system-ui, "Helvetica Neue", Helvetica, Arial, sans-serif;
   word-break: break-all;
+  overflow-wrap: anywhere;
+}
+body.ttrss_main .post .header .author {
+  flex: 1 1 auto;
+  min-width: 0;
+  white-space: normal;
+  overflow-wrap: anywhere;
 }
 body.ttrss_main .post .header .tags {
   max-width: 25%;
@@ -265,11 +274,18 @@ body.ttrss_main .hl .right i.material-icons {
 body.ttrss_main .hl .title {
   cursor: pointer;
   flex-grow: 2;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: normal;
+  overflow-wrap: anywhere;
 }
 body.ttrss_main .hl .author {
-  white-space: nowrap;
+  display: block;
+  min-width: 0;
+  max-width: 100%;
+  white-space: normal;
+  overflow-wrap: anywhere;
   color: #555;
   font-size: 11px;
   font-weight: normal;
@@ -1301,7 +1317,9 @@ body.ttrss_utility hr {
 }
 .cdm .header .titleWrap {
   flex-grow: 2;
+  min-width: 0;
   width: 0;
+  overflow-wrap: anywhere;
 }
 .cdm .header .updated {
   color: #555;
@@ -1323,7 +1341,11 @@ body.ttrss_utility hr {
   color: #555;
 }
 .cdm .header .author {
-  white-space: nowrap;
+  display: block;
+  min-width: 0;
+  max-width: 100%;
+  white-space: normal;
+  overflow-wrap: anywhere;
   color: #555;
   font-size: 11px;
   font-weight: normal;
@@ -1455,9 +1477,8 @@ body.ttrss_utility hr {
   display: none;
 }
 .cdm.expandable div.header span.titleWrap {
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  overflow: hidden;
+  white-space: normal;
+  overflow-wrap: anywhere;
 }
 .cdm.expandable .excerpt {
   white-space: nowrap;

--- a/themes/light/cdm.less
+++ b/themes/light/cdm.less
@@ -45,7 +45,9 @@
 
 		.titleWrap {
 			flex-grow : 2;
+			min-width : 0;
 			width : 0;
+			overflow-wrap : anywhere;
 		}
 
 		.updated {
@@ -70,7 +72,11 @@
 		}
 
 		.author {
-			white-space : nowrap;
+			display : block;
+			min-width : 0;
+			max-width : 100%;
+			white-space : normal;
+			overflow-wrap : anywhere;
 			color : @default-text;
 			font-size : @font-size-small;
 			font-weight : normal;
@@ -244,9 +250,8 @@
 		}
 
 		div.header span.titleWrap {
-			white-space : nowrap;
-			text-overflow : ellipsis;
-			overflow : hidden;
+			white-space : normal;
+			overflow-wrap : anywhere;
 		}
 
 		.excerpt {

--- a/themes/light/tt-rss.less
+++ b/themes/light/tt-rss.less
@@ -39,6 +39,7 @@ body.ttrss_main {
 
 			.comments {
 				flex-grow : 2;
+				min-width : 0;
 			}
 
 			.date {
@@ -54,11 +55,20 @@ body.ttrss_main {
 
 			.title {
 				flex-grow : 2;
+				min-width : 0;
 				font-size : 15px;
 				font-weight : 600;
 				text-rendering: optimizelegibility;
 				font-family : @fonts-ui;
 				word-break : break-all;
+				overflow-wrap : anywhere;
+			}
+
+			.author {
+				flex : 1 1 auto;
+				min-width : 0;
+				white-space : normal;
+				overflow-wrap : anywhere;
 			}
 
 			.tags {
@@ -292,12 +302,19 @@ body.ttrss_main {
 		.title {
 			cursor : pointer;
 			flex-grow : 2;
+			min-width : 0;
 			overflow : hidden;
 			text-overflow : ellipsis;
+			white-space : normal;
+			overflow-wrap : anywhere;
 		}
 
 		.author {
-			white-space : nowrap;
+			display : block;
+			min-width : 0;
+			max-width : 100%;
+			white-space : normal;
+			overflow-wrap : anywhere;
 			color : @default-text;
 			font-size : @font-size-small;
 			font-weight : normal;
@@ -1487,4 +1504,3 @@ body.ttrss_main, body.ttrss_utility {
 /* video::-webkit-media-controls-overlay-play-button {
 	display: none;
 } */
-

--- a/themes/night.css
+++ b/themes/night.css
@@ -58,6 +58,7 @@ body.ttrss_main .post .header .row {
 }
 body.ttrss_main .post .header .comments {
   flex-grow: 2;
+  min-width: 0;
 }
 body.ttrss_main .post .header .date {
   white-space: nowrap;
@@ -71,11 +72,19 @@ body.ttrss_main .post .header i.material-icons {
 }
 body.ttrss_main .post .header .title {
   flex-grow: 2;
+  min-width: 0;
   font-size: 15px;
   font-weight: 600;
   text-rendering: optimizelegibility;
   font-family: system-ui, "Helvetica Neue", Helvetica, Arial, sans-serif;
   word-break: break-all;
+  overflow-wrap: anywhere;
+}
+body.ttrss_main .post .header .author {
+  flex: 1 1 auto;
+  min-width: 0;
+  white-space: normal;
+  overflow-wrap: anywhere;
 }
 body.ttrss_main .post .header .tags {
   max-width: 25%;
@@ -266,11 +275,18 @@ body.ttrss_main .hl .right i.material-icons {
 body.ttrss_main .hl .title {
   cursor: pointer;
   flex-grow: 2;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: normal;
+  overflow-wrap: anywhere;
 }
 body.ttrss_main .hl .author {
-  white-space: nowrap;
+  display: block;
+  min-width: 0;
+  max-width: 100%;
+  white-space: normal;
+  overflow-wrap: anywhere;
   color: #ccc;
   font-size: 11px;
   font-weight: normal;
@@ -1302,7 +1318,9 @@ body.ttrss_utility hr {
 }
 .cdm .header .titleWrap {
   flex-grow: 2;
+  min-width: 0;
   width: 0;
+  overflow-wrap: anywhere;
 }
 .cdm .header .updated {
   color: #ccc;
@@ -1324,7 +1342,11 @@ body.ttrss_utility hr {
   color: #ccc;
 }
 .cdm .header .author {
-  white-space: nowrap;
+  display: block;
+  min-width: 0;
+  max-width: 100%;
+  white-space: normal;
+  overflow-wrap: anywhere;
   color: #ccc;
   font-size: 11px;
   font-weight: normal;
@@ -1456,9 +1478,8 @@ body.ttrss_utility hr {
   display: none;
 }
 .cdm.expandable div.header span.titleWrap {
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  overflow: hidden;
+  white-space: normal;
+  overflow-wrap: anywhere;
 }
 .cdm.expandable .excerpt {
   white-space: nowrap;

--- a/themes/night_blue.css
+++ b/themes/night_blue.css
@@ -58,6 +58,7 @@ body.ttrss_main .post .header .row {
 }
 body.ttrss_main .post .header .comments {
   flex-grow: 2;
+  min-width: 0;
 }
 body.ttrss_main .post .header .date {
   white-space: nowrap;
@@ -71,11 +72,19 @@ body.ttrss_main .post .header i.material-icons {
 }
 body.ttrss_main .post .header .title {
   flex-grow: 2;
+  min-width: 0;
   font-size: 15px;
   font-weight: 600;
   text-rendering: optimizelegibility;
   font-family: system-ui, "Helvetica Neue", Helvetica, Arial, sans-serif;
   word-break: break-all;
+  overflow-wrap: anywhere;
+}
+body.ttrss_main .post .header .author {
+  flex: 1 1 auto;
+  min-width: 0;
+  white-space: normal;
+  overflow-wrap: anywhere;
 }
 body.ttrss_main .post .header .tags {
   max-width: 25%;
@@ -266,11 +275,18 @@ body.ttrss_main .hl .right i.material-icons {
 body.ttrss_main .hl .title {
   cursor: pointer;
   flex-grow: 2;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: normal;
+  overflow-wrap: anywhere;
 }
 body.ttrss_main .hl .author {
-  white-space: nowrap;
+  display: block;
+  min-width: 0;
+  max-width: 100%;
+  white-space: normal;
+  overflow-wrap: anywhere;
   color: #ccc;
   font-size: 11px;
   font-weight: normal;
@@ -1302,7 +1318,9 @@ body.ttrss_utility hr {
 }
 .cdm .header .titleWrap {
   flex-grow: 2;
+  min-width: 0;
   width: 0;
+  overflow-wrap: anywhere;
 }
 .cdm .header .updated {
   color: #ccc;
@@ -1324,7 +1342,11 @@ body.ttrss_utility hr {
   color: #ccc;
 }
 .cdm .header .author {
-  white-space: nowrap;
+  display: block;
+  min-width: 0;
+  max-width: 100%;
+  white-space: normal;
+  overflow-wrap: anywhere;
   color: #ccc;
   font-size: 11px;
   font-weight: normal;
@@ -1456,9 +1478,8 @@ body.ttrss_utility hr {
   display: none;
 }
 .cdm.expandable div.header span.titleWrap {
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  overflow: hidden;
+  white-space: normal;
+  overflow-wrap: anywhere;
 }
 .cdm.expandable .excerpt {
   white-space: nowrap;


### PR DESCRIPTION
Fixes headline/article layout overflow caused by long unbroken text.

The change lets article titles wrap inside long tokens, such as SHA256 hashes, instead of forcing the main view wider. Author lists now render as their own wrapping metadata line within the title area, so long author strings no longer create horizontal scrolling or overlap awkwardly with the title.

The LESS source was updated and the compiled theme CSS files were regenerated for all bundled themes.

Before (title overflowing):
<img width="770" height="154" alt="image" src="https://github.com/user-attachments/assets/8143f202-e062-4901-98a6-0f619d973bc2" />

Before (authors overflowing):
<img width="764" height="175" alt="image" src="https://github.com/user-attachments/assets/fef29c8c-b8ea-49fe-83cb-861535086c7b" />


After (title overflowing):
<img width="770" height="154" alt="image" src="https://github.com/user-attachments/assets/d425dac9-5c22-43a6-a291-acf8c72de100" />

After (authors overflowing):
<img width="828" height="221" alt="image" src="https://github.com/user-attachments/assets/a58cf61d-cf07-4e59-9f18-04e554f05908" />
