### PR TITLE
Enable graceful shutdown of updater service docker container.

### DIFF
--- a/.docker/app/updater.sh
+++ b/.docker/app/updater.sh
@@ -66,4 +66,4 @@ done
 # - fatal error: could not open certificate file "/root/.postgresql/postgresql.crt": Permission denied
 chown -R app:app /root # /.postgresql
 
-sudo -E -u app "${TTRSS_PHP_EXECUTABLE}" $APP_INSTALL_BASE_DIR/tt-rss/update_daemon2.php "$@"
+exec sudo -E -u app "${TTRSS_PHP_EXECUTABLE}" $APP_INSTALL_BASE_DIR/tt-rss/update_daemon2.php "$@"


### PR DESCRIPTION
## Description
When `/bin/sh` receives a term signal from docker to gracefully shutdown (e.g. `docker compose stop`), `sh` doesn't propagate the signal to the child process, the php executable. Docker ends up waiting for it to timeout and then kills the process forcefully. This fix just calls `exec` instead to remove `/bin/sh` from the process tree entirely. The container now shuts down almost instantaneously.

## Motivation and Context
Speed up shutdown sequence.

## How Has This Been Tested?
Manually

## Types of Changes
- [ x] Bug fix (non-breaking change which fixes an issue)