### PR TITLE
Exclude labels from article hash calculation, improve tag+enclosure change detection

### DIFF
--- a/classes/FeedEnclosure.php
+++ b/classes/FeedEnclosure.php
@@ -1,5 +1,5 @@
 <?php
-class FeedEnclosure {
+class FeedEnclosure implements \Stringable {
 	public string $link = '';
 	public string $type = '';
 	public string $length = '';

--- a/classes/FeedEnclosure.php
+++ b/classes/FeedEnclosure.php
@@ -6,4 +6,16 @@ class FeedEnclosure {
 	public string $title = '';
 	public string $height = '';
 	public string $width = '';
+
+	public function __toString(): string {
+		return sprintf(
+			'FeedEnclosure(link=%s, type=%s, length=%s, title=%s, height=%s, width=%s)',
+			$this->link,
+			$this->type,
+			$this->length,
+			$this->title,
+			$this->height,
+			$this->width,
+		);
+	}
 }

--- a/classes/RSSUtils.php
+++ b/classes/RSSUtils.php
@@ -18,23 +18,44 @@ class RSSUtils {
 	 * @param array<string, mixed> $article
 	 */
 	static function calculate_article_hash(array $article, PluginHost $pluginhost): string {
-		$tmp = "";
+		$ignored_fields = [
+			// Details about the parent feed aren't relevant.
+			'feed',
+			'owner_uid',
 
-		$ignored_fields = [ "feed", "guid", "guid_hashed", "owner_uid", "force_catchup" ];
+			// GUIDs uniquely identify articles, so no point in including them when detecting changes.
+			'guid',
+			'guid_hashed',
+
+			// Labels are a tt-rss concept, and not directly sourced from article data.
+			//
+			// This exclusion is primarily to prevent filters from re-executing and potentially reapplying
+			// labels a user intentionally removed.
+			//
+			// In theory plugins might rely upon label-related article hash changes, but no instances of that
+			// have been found.
+			'labels',
+
+			// Only present in $article to allow plugins to indicate it should be marked as read.
+			'force_catchup',
+		];
+
+		$tmp = '';
 
 		foreach ($article as $k => $v) {
-			if (in_array($k, $ignored_fields))
+			if (!isset($v) || in_array($k, $ignored_fields))
 				continue;
 
-			if ($k != "feed" && isset($v)) {
-				$x = strip_tags(
-					is_array($v) ? implode(",", array_keys($v)) : $v);
+			$x = match ($k) {
+				'content' => strip_tags((string) $v),
+				'tags', 'enclosures' => implode(',', $v),
+				default => (string) $v,
+			};
 
-				$tmp .= sha1("$k:" . sha1($x));
-			}
+			$tmp .= sha1("$k:" . sha1($x));
 		}
 
-		return sha1(implode(",", $pluginhost->get_plugin_names()) . $tmp);
+		return sha1(implode(',', $pluginhost->get_plugin_names()) . $tmp);
 	}
 
 	static function cleanup_feed_icons(): void {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
* Exclude labels from article hash calculation.
* Properly detect tag+enclosure changes (for the most part-- still not perfect).
* Document why certain fields are excluded when calculating the article hash.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
* Making article hash calculation a bit more correct.
* Closes #306.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
Local instance.

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
