### PR TITLE
Get tests back to green + misc. tweaks

### DIFF
--- a/classes/Config.php
+++ b/classes/Config.php
@@ -327,6 +327,10 @@ class Config {
 
 	private Db_Migrations $migrations;
 
+	function __construct() {
+		$this->reload();
+	}
+
 	public static function get_instance() : Config {
 		if (self::$instance == null)
 			self::$instance = new self();
@@ -338,8 +342,8 @@ class Config {
 		//
 	}
 
-    /** load data from environment variables */
-    function reload(): void {
+	/** load data from environment variables */
+	function reload(): void {
 		$ref = new ReflectionClass(static::class);
 
 		foreach ($ref->getConstants() as $const => $cvalue) {
@@ -351,31 +355,24 @@ class Config {
 				$this->params[$cvalue] = [ self::cast_to($override !== false ? $override : $defval, $deftype), $deftype ];
 			}
 		}
-    }
+	}
 
-    /** this is primarily needed for tests, normally global config is not changed at runtime */
-    static function set(string $key, mixed $value): bool {
-        if (!getenv('IS_INTEGRATION_TESTING') && !getenv('IS_TESTING')) {
-            user_error("This method is only available for tests.", E_USER_WARNING);
+	/** this is primarily needed for tests, normally global config is not changed at runtime */
+	static function set(string $key, mixed $value): bool {
+			if (!getenv('IS_INTEGRATION_TESTING') && !getenv('IS_TESTING')) {
+				user_error("This method is only available for tests.", E_USER_WARNING);
+				return false;
+			}
 
-            return false;
-        } if (array_key_exists($key, self::_DEFAULTS)) {
-            list ($defval, $deftype) = self::_DEFAULTS[$key];
-
-            self::get_instance()->params[$key] = [self::cast_to($value, $deftype), $deftype];
-
-            return true;
-        } else {
-            user_error("Requested to set unknown global config variable: {$key}", E_USER_WARNING);
-
-            return false;
-        }
-    }
-
-    function __construct() {
-        $this->reload();
-    }
-
+			if (array_key_exists($key, self::_DEFAULTS)) {
+				[$defval, $deftype] = self::_DEFAULTS[$key];
+				self::get_instance()->params[$key] = [self::cast_to($value, $deftype), $deftype];
+				return true;
+			} else {
+				user_error("Requested to set unknown global config variable: {$key}", E_USER_WARNING);
+				return false;
+			}
+	}
 
 	/** determine tt-rss version (using git)
 	 *

--- a/classes/RSSUtils.php
+++ b/classes/RSSUtils.php
@@ -1585,7 +1585,7 @@ class RSSUtils {
 	 * @return array<int, array{'type': string, 'param': string}> An array of filter actions of type $filter_action_type
 	 */
 	static function find_article_filter_actions(array $filter_actions, string $filter_action_type): array {
-		return array_filter($filter_actions, fn(array $fa) => $fa['type'] === $filter_action_type);
+		return array_values(array_filter($filter_actions, fn(array $fa) => $fa['type'] === $filter_action_type));
 	}
 
 	/**

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -12,5 +12,7 @@ parameters:
         - node_modules (?)
         - plugins.local
         - tests
+        - tests_functional
+        - tests_integration
         - vendor
         - rector.php

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,22 +3,25 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/latest/phpunit.xsd"
     bootstrap="tests_functional/bootstrap.php"
-    verbose="true">
+    cacheDirectory=".phpunit.cache"
+    displayDetailsOnPhpunitDeprecations="true"
+    failOnPhpunitDeprecation="true"
+    failOnRisky="true"
+    failOnWarning="true">
     <testsuites>
         <testsuite name="tests">
             <directory>tests_functional</directory>
         </testsuite>
     </testsuites>
-    <coverage>
+    <source ignoreIndirectDeprecations="true" restrictNotices="true" restrictWarnings="true">
         <include>
             <directory suffix=".php">classes</directory>
             <directory suffix=".php">lib</directory>
         </include>
         <exclude>
-            <directory suffix=".php">classes/Plugin_*</directory>
             <directory suffix=".php">lib/gettext</directory>
         </exclude>
-    </coverage>
+    </source>
     <php>
         <const name="IS_TESTING" value="true"/>
     </php>

--- a/tests_functional/FeedItemAtomTest.php
+++ b/tests_functional/FeedItemAtomTest.php
@@ -645,7 +645,7 @@ final class FeedItemAtomTest extends TestCase {
         $items = $parser->get_items();
         /** @var \FeedItem_Atom $item */
         $item = $items[0];
-        $this->assertEquals("https://example.com/relative/path", $item->get_link());
+        $this->assertEquals("https://example.com/base/relative/path", $item->get_link());
     }
 
     public function test_get_link_trims_whitespace(): void {

--- a/tests_functional/FeedItemCommonTest.php
+++ b/tests_functional/FeedItemCommonTest.php
@@ -687,7 +687,6 @@ final class FeedItemCommonTest extends TestCase {
         $common = $items[0];
         // Use reflection to access protected count_children
         $ref = new ReflectionMethod($common, "count_children");
-        $ref->setAccessible(true);
         $this->assertEquals(0, $ref->invoke($common, $root));
     }
 
@@ -704,7 +703,6 @@ final class FeedItemCommonTest extends TestCase {
         $items = $parser->get_items();
         $common = $items[0];
         $ref = new ReflectionMethod($common, "count_children");
-        $ref->setAccessible(true);
         $this->assertEquals(3, $ref->invoke($common, $parent));
     }
 
@@ -722,7 +720,6 @@ final class FeedItemCommonTest extends TestCase {
         $items = $parser->get_items();
         $common = $items[0];
         $ref = new ReflectionMethod($common, "subtree_or_text");
-        $ref->setAccessible(true);
         $result = $ref->invoke($common, $node);
         $this->assertEquals("Simple Title", $result);
     }
@@ -742,7 +739,6 @@ final class FeedItemCommonTest extends TestCase {
         $items = $parser->get_items();
         $common = $items[0];
         $ref = new ReflectionMethod($common, "subtree_or_text");
-        $ref->setAccessible(true);
         $result = $ref->invoke($common, $node);
         $this->assertNotEquals("Hello world", $result);
         // Should return c14n serialized XML, not plain text

--- a/tests_functional/FunctionsTest.php
+++ b/tests_functional/FunctionsTest.php
@@ -339,7 +339,7 @@ final class FunctionsTest extends TestCase {
     }
 
     public function test_implements_interface_instance(): void {
-        $test = new self();
+        $test = new self("foo");
         // PHPUnit\Framework\TestCase implements Test, Reorderable, SelfDescribing
         $this->assertTrue(implements_interface($test, "PHPUnit\Framework\Test"));
         $this->assertFalse(implements_interface($test, "NonExistentInterface"));

--- a/tests_functional/UrlHelperTest.php
+++ b/tests_functional/UrlHelperTest.php
@@ -337,9 +337,8 @@ final class UrlHelperTest extends TestCase {
     }
 
     public function test_rewrite_relative_dotslash_with_base_dirname(): void {
-        // dirname("foo/bar/baz/") = "foo/bar", then append "test.html"
         $this->assertEquals(
-            'https://example.com/foo/bar/test.html',
+            'https://example.com/foo/bar/baz/test.html',
             UrlHelper::rewrite_relative('https://example.com/foo/bar/baz/', './test.html')
         );
     }

--- a/tests_functional/bootstrap.php
+++ b/tests_functional/bootstrap.php
@@ -1,8 +1,5 @@
 <?php
-    set_include_path(dirname(__DIR__) ."/include" . PATH_SEPARATOR .
-    get_include_path());
-
-    putenv("IS_TESTING=true");
+	putenv("IS_TESTING=true");
 	putenv("TTRSS_LOG_DESTINATION=stdout");
 
-    require_once "autoload.php";
+	require_once __DIR__ . '/../include/autoload.php';

--- a/tests_integration/DbTestCase.php
+++ b/tests_integration/DbTestCase.php
@@ -34,7 +34,7 @@ abstract class DbTestCase extends TestCase {
 
 		try {
 			$pdo->rollBack();
-		} catch (\Throwable $e) {
+		} catch (\Throwable) {
 			//
 		}
     }

--- a/tests_integration/FeedsIntegrationTest.php
+++ b/tests_integration/FeedsIntegrationTest.php
@@ -101,13 +101,13 @@ final class FeedsIntegrationTest extends DbTestCase {
 
     public function test_get_title_category_existing(): void {
         // seed.sql inserts categories with ids 1 and 2
-        $this->assertEquals("Technology", Feeds::_get_title(1, $_SESSION['uid'], 1, true));
-        $this->assertEquals("Science & Nature", Feeds::_get_title(2, $_SESSION['uid'], 1, true));
+        $this->assertEquals("Technology", Feeds::_get_title(1, $_SESSION['uid'], 1));
+        $this->assertEquals("Science & Nature", Feeds::_get_title(2, $_SESSION['uid'], 1));
     }
 
     public function test_get_title_category_missing(): void {
         // Category id 999 does not exist in seed.sql
-        $this->assertEquals("UNKNOWN", Feeds::_get_title(999, $_SESSION['uid'], 1, true));
+        $this->assertEquals("UNKNOWN", Feeds::_get_title(999, $_SESSION['uid'], 1));
     }
 
     // ── Owner UID parameter ──

--- a/tests_integration/IntegrationTestCase.php
+++ b/tests_integration/IntegrationTestCase.php
@@ -19,8 +19,6 @@ abstract class IntegrationTestCase extends TestCase {
 
         $this->setUp();
         $this->login();
-
-        parent::__construct($name);
     }
 
     /**

--- a/tests_integration/LoggerSqlTest.php
+++ b/tests_integration/LoggerSqlTest.php
@@ -18,7 +18,6 @@ final class LoggerSqlTest extends DbTestCase {
     private function resetLoggerSingleton(): void {
         $ref = new ReflectionClass(Logger::class);
         $prop = $ref->getProperty('instance');
-        $prop->setAccessible(true);
         $prop->setValue(null, null);
     }
 

--- a/tests_integration/PluginHostTest.php
+++ b/tests_integration/PluginHostTest.php
@@ -11,7 +11,6 @@ final class PluginHostTest extends DbTestCase {
 
         $ref = new ReflectionClass($host);
         $uidProp = $ref->getProperty('owner_uid');
-        $uidProp->setAccessible(true);
         $uidProp->setValue($host, 1);
 
         return $host;
@@ -105,9 +104,7 @@ final class PluginHostTest extends DbTestCase {
         $host->add_hook(PluginHost::HOOK_ARTICLE_FILTER, $plugin1, 50);
         $host->add_hook(PluginHost::HOOK_ARTICLE_FILTER, $plugin2, 60);
 
-        $host->run_hooks_callback(PluginHost::HOOK_ARTICLE_FILTER, function($result) {
-            return $result === 'stop';
-        });
+        $host->run_hooks_callback(PluginHost::HOOK_ARTICLE_FILTER, fn($result) => $result === 'stop');
 
         $this->assertTrue($plugin1->hookCalled);
         $this->assertFalse($plugin2->hookCalled);
@@ -190,7 +187,7 @@ final class PluginHostTest extends DbTestCase {
         // Verify it's gone from DB
         $pdo = Db::pdo();
         $row = $pdo->prepare("SELECT count(*) FROM ttrss_plugin_storage WHERE name = ? AND owner_uid = ?");
-        $row->execute([get_class($plugin), 1]);
+        $row->execute([$plugin::class, 1]);
         $this->assertEquals(0, (int) $row->fetchColumn());
     }
 
@@ -323,7 +320,7 @@ final class PluginHostTest extends DbTestCase {
         $host->add_filter_action($plugin, 'custom_action', 'Custom action description');
 
         $actions = $host->get_filter_actions();
-        $pluginClass = get_class($plugin);
+        $pluginClass = $plugin::class;
 
         $this->assertArrayHasKey($pluginClass, $actions);
         $this->assertCount(1, $actions[$pluginClass]);

--- a/tests_integration/PrefsTest.php
+++ b/tests_integration/PrefsTest.php
@@ -404,7 +404,7 @@ final class PrefsTest extends DbTestCase {
         $uid = $this->createTestUser('test_invalid');
 
         // set() triggers user_error() for invalid pref names; suppress it
-        set_error_handler(function(): bool { return true; }, E_USER_WARNING);
+        set_error_handler(fn(): bool => true, E_USER_WARNING);
         $result = Prefs::set('INVALID_PREF_NAME', 'value', $uid, null);
         restore_error_handler();
 

--- a/tests_integration/SchedulerIntegrationTest.php
+++ b/tests_integration/SchedulerIntegrationTest.php
@@ -10,7 +10,7 @@ final class SchedulerIntegrationTest extends DbTestCase {
         $result = $scheduler->add_scheduled_task(
             'test_task',
             '@daily',
-            function() { return 0; }
+            fn() => 0
         );
 
         $this->assertTrue($result);
@@ -22,13 +22,12 @@ final class SchedulerIntegrationTest extends DbTestCase {
         $scheduler->add_scheduled_task(
             'hourly_task',
             '0 * * * *',
-            function() { return 0; }
+            fn() => 0
         );
 
         // Reflect to inspect private property
         $ref = new ReflectionClass($scheduler);
         $prop = $ref->getProperty('scheduled_tasks');
-        $prop->setAccessible(true);
         $tasks = $prop->getValue($scheduler);
 
         $this->assertArrayHasKey('hourly_task', $tasks);
@@ -42,12 +41,11 @@ final class SchedulerIntegrationTest extends DbTestCase {
         $scheduler->add_scheduled_task(
             'UPPERCASE_TASK',
             '@daily',
-            function() { return 0; }
+            fn() => 0
         );
 
         $ref = new ReflectionClass($scheduler);
         $prop = $ref->getProperty('scheduled_tasks');
-        $prop->setAccessible(true);
         $tasks = $prop->getValue($scheduler);
 
         $this->assertArrayHasKey('uppercase_task', $tasks);
@@ -62,16 +60,16 @@ final class SchedulerIntegrationTest extends DbTestCase {
         $scheduler->add_scheduled_task(
             'dup_task',
             '@daily',
-            function() { return 0; }
+            fn() => 0
         );
 
         // Suppress the user_error warning
-        set_error_handler(function() { return true; });
+        set_error_handler(fn() => true);
 
         $result = $scheduler->add_scheduled_task(
             'dup_task',
             '@hourly',
-            function() { return 0; }
+            fn() => 0
         );
 
         restore_error_handler();
@@ -82,12 +80,12 @@ final class SchedulerIntegrationTest extends DbTestCase {
     public function test_add_scheduled_task_invalid_cron_returns_false(): void {
         $scheduler = new Scheduler('test-scheduler');
 
-        set_error_handler(function() { return true; });
+        set_error_handler(fn() => true);
 
         $result = $scheduler->add_scheduled_task(
             'bad_cron_task',
             'not-a-cron-expression',
-            function() { return 0; }
+            fn() => 0
         );
 
         restore_error_handler();
@@ -102,7 +100,6 @@ final class SchedulerIntegrationTest extends DbTestCase {
 
         $ref = new ReflectionClass($scheduler);
         $prop = $ref->getProperty('name');
-        $prop->setAccessible(true);
 
         $this->assertEquals('original-name', $prop->getValue($scheduler));
 
@@ -143,7 +140,7 @@ final class SchedulerIntegrationTest extends DbTestCase {
         $scheduler->add_scheduled_task(
             'record_task',
             '@daily',
-            function() { return 42; }
+            fn() => 42
         );
 
         $pdo = Db::pdo();
@@ -172,7 +169,7 @@ final class SchedulerIntegrationTest extends DbTestCase {
         $scheduler->add_scheduled_task(
             'new_task',
             '@weekly',
-            function() { return 0; }
+            fn() => 0
         );
 
         // No existing DB record — task should be created
@@ -231,7 +228,7 @@ final class SchedulerIntegrationTest extends DbTestCase {
         ");
 
         // Suppress warnings from user_error
-        set_error_handler(function() { return true; });
+        set_error_handler(fn() => true);
 
         $scheduler->run_due_tasks();
 
@@ -250,7 +247,7 @@ final class SchedulerIntegrationTest extends DbTestCase {
         $scheduler->add_scheduled_task(
             'keep_me',
             '@daily',
-            function() { return 0; }
+            fn() => 0
         );
 
         $pdo = Db::pdo();
@@ -272,14 +269,11 @@ final class SchedulerIntegrationTest extends DbTestCase {
         // Use reflection to invoke the private purge_orphaned_tasks method
         $ref = new ReflectionClass($scheduler);
         $purgeMethod = $ref->getMethod('purge_orphaned_tasks');
-        $purgeMethod->setAccessible(true);
 
         $purgeResult = $scheduler->add_scheduled_task(
             'purge_trigger',
             '@daily',
-            function() use ($purgeMethod, $scheduler) {
-                return $purgeMethod->invoke($scheduler);
-            }
+            fn() => $purgeMethod->invoke($scheduler)
         );
         $this->assertTrue($purgeResult);
 
@@ -302,20 +296,17 @@ final class SchedulerIntegrationTest extends DbTestCase {
         $scheduler->add_scheduled_task(
             'keep_me',
             '@daily',
-            function() { return 0; }
+            fn() => 0
         );
 
         // Use reflection to invoke the private purge_orphaned_tasks method
         $ref = new ReflectionClass($scheduler);
         $purgeMethod = $ref->getMethod('purge_orphaned_tasks');
-        $purgeMethod->setAccessible(true);
 
         $purgeResult = $scheduler->add_scheduled_task(
             'purge_trigger',
             '@daily',
-            function() use ($purgeMethod, $scheduler) {
-                return $purgeMethod->invoke($scheduler);
-            }
+            fn() => $purgeMethod->invoke($scheduler)
         );
         $this->assertTrue($purgeResult);
 
@@ -332,7 +323,6 @@ final class SchedulerIntegrationTest extends DbTestCase {
 
         $ref = new ReflectionClass($scheduler);
         $prop = $ref->getProperty('scheduled_tasks');
-        $prop->setAccessible(true);
         $tasks = $prop->getValue($scheduler);
 
         $this->assertArrayHasKey('purge_orphaned_scheduled_tasks', $tasks);
@@ -343,7 +333,6 @@ final class SchedulerIntegrationTest extends DbTestCase {
 
         $ref = new ReflectionClass($scheduler);
         $prop = $ref->getProperty('name');
-        $prop->setAccessible(true);
 
         $this->assertEquals(Scheduler::DEFAULT_NAME, $prop->getValue($scheduler));
     }


### PR DESCRIPTION
Following #315:
* Formatting and PHP preference (i.e. Rector-driven) tweaks
* Ignoring `tests_functional` and `tests_integration` with PHPStan (consistent with `tests`)
* Adding back some PHPUnit config relevant to this project's CI/CD and version
* Fix some tests that weren't current with this project (e.g. a041e2a39010f56d5a66054e8e31e6b64ee8f69e)
* Fixing a minor issue where `RSSUtils::find_article_filter_actions()` preserved the original int array keys (e.g. 0,2 vs 0,1)