### PR TITLE
Make article rows two-line with a feed-icon avatar on narrow screens

### DIFF
--- a/themes/compact.css
+++ b/themes/compact.css
@@ -684,6 +684,49 @@ body.ttrss_main #feeds-holder-backdrop {
     visibility: visible;
   }
 }
+@media (max-width: 768px) {
+  body.ttrss_main .hl,
+  body.ttrss_main .cdm .header {
+    flex-wrap: wrap;
+  }
+  body.ttrss_main .hl > .title,
+  body.ttrss_main .cdm .header > .titleWrap {
+    flex-basis: 100%;
+    order: -1;
+  }
+  body.ttrss_main .hl > .right,
+  body.ttrss_main .cdm .header > .right {
+    margin-left: auto;
+  }
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .hl,
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .cdm {
+    position: relative;
+  }
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .hl,
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .cdm .header {
+    padding-right: 48px;
+  }
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .hl .icon-feed,
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .cdm .header .icon-feed {
+    position: absolute;
+    right: 8px;
+    top: 50%;
+    transform: translateY(-50%);
+    margin: 0;
+    padding: 0;
+  }
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .hl .icon-feed img.icon,
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .cdm .header .icon-feed img.icon {
+    width: 32px;
+    height: 32px;
+    border-radius: 4px;
+  }
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .hl .icon-feed i.icon-no-feed,
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .cdm .header .icon-feed i.icon-no-feed {
+    font-size: 32px;
+    opacity: 0.4;
+  }
+}
 body.ttrss_main #headlines-frame:not([data-headlines-count="0"])[data-is-cdm="true"][data-is-cdm-expanded="true"][data-enable-grid="true"] {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(600px, 1fr));

--- a/themes/compact_night.css
+++ b/themes/compact_night.css
@@ -684,6 +684,49 @@ body.ttrss_main #feeds-holder-backdrop {
     visibility: visible;
   }
 }
+@media (max-width: 768px) {
+  body.ttrss_main .hl,
+  body.ttrss_main .cdm .header {
+    flex-wrap: wrap;
+  }
+  body.ttrss_main .hl > .title,
+  body.ttrss_main .cdm .header > .titleWrap {
+    flex-basis: 100%;
+    order: -1;
+  }
+  body.ttrss_main .hl > .right,
+  body.ttrss_main .cdm .header > .right {
+    margin-left: auto;
+  }
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .hl,
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .cdm {
+    position: relative;
+  }
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .hl,
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .cdm .header {
+    padding-right: 48px;
+  }
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .hl .icon-feed,
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .cdm .header .icon-feed {
+    position: absolute;
+    right: 8px;
+    top: 50%;
+    transform: translateY(-50%);
+    margin: 0;
+    padding: 0;
+  }
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .hl .icon-feed img.icon,
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .cdm .header .icon-feed img.icon {
+    width: 32px;
+    height: 32px;
+    border-radius: 4px;
+  }
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .hl .icon-feed i.icon-no-feed,
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .cdm .header .icon-feed i.icon-no-feed {
+    font-size: 32px;
+    opacity: 0.4;
+  }
+}
 body.ttrss_main #headlines-frame:not([data-headlines-count="0"])[data-is-cdm="true"][data-is-cdm-expanded="true"][data-enable-grid="true"] {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(600px, 1fr));

--- a/themes/light-high-contrast.css
+++ b/themes/light-high-contrast.css
@@ -684,6 +684,49 @@ body.ttrss_main #feeds-holder-backdrop {
     visibility: visible;
   }
 }
+@media (max-width: 768px) {
+  body.ttrss_main .hl,
+  body.ttrss_main .cdm .header {
+    flex-wrap: wrap;
+  }
+  body.ttrss_main .hl > .title,
+  body.ttrss_main .cdm .header > .titleWrap {
+    flex-basis: 100%;
+    order: -1;
+  }
+  body.ttrss_main .hl > .right,
+  body.ttrss_main .cdm .header > .right {
+    margin-left: auto;
+  }
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .hl,
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .cdm {
+    position: relative;
+  }
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .hl,
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .cdm .header {
+    padding-right: 48px;
+  }
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .hl .icon-feed,
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .cdm .header .icon-feed {
+    position: absolute;
+    right: 8px;
+    top: 50%;
+    transform: translateY(-50%);
+    margin: 0;
+    padding: 0;
+  }
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .hl .icon-feed img.icon,
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .cdm .header .icon-feed img.icon {
+    width: 32px;
+    height: 32px;
+    border-radius: 4px;
+  }
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .hl .icon-feed i.icon-no-feed,
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .cdm .header .icon-feed i.icon-no-feed {
+    font-size: 32px;
+    opacity: 0.4;
+  }
+}
 body.ttrss_main #headlines-frame:not([data-headlines-count="0"])[data-is-cdm="true"][data-is-cdm-expanded="true"][data-enable-grid="true"] {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(600px, 1fr));

--- a/themes/light.css
+++ b/themes/light.css
@@ -684,6 +684,49 @@ body.ttrss_main #feeds-holder-backdrop {
     visibility: visible;
   }
 }
+@media (max-width: 768px) {
+  body.ttrss_main .hl,
+  body.ttrss_main .cdm .header {
+    flex-wrap: wrap;
+  }
+  body.ttrss_main .hl > .title,
+  body.ttrss_main .cdm .header > .titleWrap {
+    flex-basis: 100%;
+    order: -1;
+  }
+  body.ttrss_main .hl > .right,
+  body.ttrss_main .cdm .header > .right {
+    margin-left: auto;
+  }
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .hl,
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .cdm {
+    position: relative;
+  }
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .hl,
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .cdm .header {
+    padding-right: 48px;
+  }
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .hl .icon-feed,
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .cdm .header .icon-feed {
+    position: absolute;
+    right: 8px;
+    top: 50%;
+    transform: translateY(-50%);
+    margin: 0;
+    padding: 0;
+  }
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .hl .icon-feed img.icon,
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .cdm .header .icon-feed img.icon {
+    width: 32px;
+    height: 32px;
+    border-radius: 4px;
+  }
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .hl .icon-feed i.icon-no-feed,
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .cdm .header .icon-feed i.icon-no-feed {
+    font-size: 32px;
+    opacity: 0.4;
+  }
+}
 body.ttrss_main #headlines-frame:not([data-headlines-count="0"])[data-is-cdm="true"][data-is-cdm-expanded="true"][data-enable-grid="true"] {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(600px, 1fr));

--- a/themes/light/tt-rss.less
+++ b/themes/light/tt-rss.less
@@ -811,6 +811,75 @@ body.ttrss_main {
 		}
 	}
 
+	// Narrow / phone layout: wrap each article row onto two lines — the title
+	// claims the whole first line, and the feed name, date and icons wrap onto
+	// a second line below it. Applies to both list (.hl) and combined (.cdm)
+	// rows, which share the same left | title | feed | date | right flex layout.
+	@media (max-width: @breakpoint-md) {
+		.hl,
+		.cdm .header {
+			flex-wrap : wrap;
+		}
+
+		.hl > .title,
+		.cdm .header > .titleWrap {
+			flex-basis : 100%;
+			order : -1;
+		}
+
+		// keep the trailing icons flush with the right edge of the second line
+		.hl > .right,
+		.cdm .header > .right {
+			margin-left : auto;
+		}
+
+		// In aggregate/virtual feeds, promote the per-row feed icon to a larger,
+		// right-aligned avatar spanning both lines so rows from different feeds
+		// are easy to tell apart (matching its normal right-side position).
+		// Single-feed views already hide
+		// .feed / .icon-feed, so the avatar and its gutter only appear where they
+		// add value.
+		#headlines-frame[data-is-vfeed="true"] {
+			// Give each row its own positioning context for the absolute feed
+			// icon. In collapsed CDM the .header is position:static (it's only
+			// the sticky containing block when expanded), so without a relative
+			// row the icons would resolve against #headlines-frame and stack on
+			// top of one another.
+			.hl,
+			.cdm {
+				position : relative;
+			}
+
+			.hl,
+			.cdm .header {
+				padding-right : 48px;
+			}
+
+			.hl .icon-feed,
+			.cdm .header .icon-feed {
+				position : absolute;
+				right : 8px;
+				top : 50%;
+				transform : translateY(-50%);
+				margin : 0;
+				padding : 0;
+			}
+
+			.hl .icon-feed img.icon,
+			.cdm .header .icon-feed img.icon {
+				width : 32px;
+				height : 32px;
+				border-radius : 4px;
+			}
+
+			.hl .icon-feed i.icon-no-feed,
+			.cdm .header .icon-feed i.icon-no-feed {
+				font-size : 32px;
+				opacity : 0.4;
+			}
+		}
+	}
+
 	#headlines-frame:not([data-headlines-count="0"])[data-is-cdm="true"][data-is-cdm-expanded="true"][data-enable-grid="true"] {
 		display : grid;
 		grid-template-columns: repeat(auto-fit, minmax(@cdm-grid-col-width, 1fr));

--- a/themes/night.css
+++ b/themes/night.css
@@ -685,6 +685,49 @@ body.ttrss_main #feeds-holder-backdrop {
     visibility: visible;
   }
 }
+@media (max-width: 768px) {
+  body.ttrss_main .hl,
+  body.ttrss_main .cdm .header {
+    flex-wrap: wrap;
+  }
+  body.ttrss_main .hl > .title,
+  body.ttrss_main .cdm .header > .titleWrap {
+    flex-basis: 100%;
+    order: -1;
+  }
+  body.ttrss_main .hl > .right,
+  body.ttrss_main .cdm .header > .right {
+    margin-left: auto;
+  }
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .hl,
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .cdm {
+    position: relative;
+  }
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .hl,
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .cdm .header {
+    padding-right: 48px;
+  }
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .hl .icon-feed,
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .cdm .header .icon-feed {
+    position: absolute;
+    right: 8px;
+    top: 50%;
+    transform: translateY(-50%);
+    margin: 0;
+    padding: 0;
+  }
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .hl .icon-feed img.icon,
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .cdm .header .icon-feed img.icon {
+    width: 32px;
+    height: 32px;
+    border-radius: 4px;
+  }
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .hl .icon-feed i.icon-no-feed,
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .cdm .header .icon-feed i.icon-no-feed {
+    font-size: 32px;
+    opacity: 0.4;
+  }
+}
 body.ttrss_main #headlines-frame:not([data-headlines-count="0"])[data-is-cdm="true"][data-is-cdm-expanded="true"][data-enable-grid="true"] {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(600px, 1fr));

--- a/themes/night_blue.css
+++ b/themes/night_blue.css
@@ -685,6 +685,49 @@ body.ttrss_main #feeds-holder-backdrop {
     visibility: visible;
   }
 }
+@media (max-width: 768px) {
+  body.ttrss_main .hl,
+  body.ttrss_main .cdm .header {
+    flex-wrap: wrap;
+  }
+  body.ttrss_main .hl > .title,
+  body.ttrss_main .cdm .header > .titleWrap {
+    flex-basis: 100%;
+    order: -1;
+  }
+  body.ttrss_main .hl > .right,
+  body.ttrss_main .cdm .header > .right {
+    margin-left: auto;
+  }
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .hl,
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .cdm {
+    position: relative;
+  }
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .hl,
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .cdm .header {
+    padding-right: 48px;
+  }
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .hl .icon-feed,
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .cdm .header .icon-feed {
+    position: absolute;
+    right: 8px;
+    top: 50%;
+    transform: translateY(-50%);
+    margin: 0;
+    padding: 0;
+  }
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .hl .icon-feed img.icon,
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .cdm .header .icon-feed img.icon {
+    width: 32px;
+    height: 32px;
+    border-radius: 4px;
+  }
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .hl .icon-feed i.icon-no-feed,
+  body.ttrss_main #headlines-frame[data-is-vfeed="true"] .cdm .header .icon-feed i.icon-no-feed {
+    font-size: 32px;
+    opacity: 0.4;
+  }
+}
 body.ttrss_main #headlines-frame:not([data-headlines-count="0"])[data-is-cdm="true"][data-is-cdm-expanded="true"][data-enable-grid="true"] {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(600px, 1fr));


### PR DESCRIPTION
## Description
On viewports <= 768px (@breakpoint-md) each article row wraps onto two lines: the title claims the whole first line, and the feed name, date and icons wrap onto a second line below it. Applies to both list (.hl) and combined (.cdm) rows. Wider screens keep the single-line layout.

In aggregate/virtual feeds (data-is-vfeed="true"), the per-row feed icon is promoted to a larger right-aligned avatar spanning both lines so rows from different feeds are easy to tell apart; single-feed views already hide the per-row icon, so no empty gutter appears there.

Each row is given position:relative so the absolutely-positioned avatar anchors to its own row -- in collapsed combined mode the .cdm .header is position:static (only the sticky containing block when expanded), which otherwise made every icon resolve against #headlines-frame and stack onto a single spot.

Themes recompiled via gulp less.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This makes the UI more usable on narrow screens, e.g., phones. References https://github.com/tt-rss/tt-rss/issues/157.

## How Has This Been Tested?
Tested in desktop Firefox by expanding and shrinking the browser window.

## Screenshots (if appropriate)
before:
<img width="726" height="801" alt="image" src="https://github.com/user-attachments/assets/98ef5959-8a29-4be2-9eb5-71e7b0c3248f" />

after:
<img width="726" height="2070" alt="image" src="https://github.com/user-attachments/assets/587aed8b-7eec-4173-a009-9f3c951a11d6" />

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.