### PR TITLE
Use the tt-rss logo for the feed-drawer toggle on narrow screens

### DIFF
--- a/index.php
+++ b/index.php
@@ -153,11 +153,11 @@
         <div id="toolbar-frame" dojoType="dijit.layout.ContentPane" region="top">
             <div id="toolbar" dojoType="fox.Toolbar">
 
-					<!-- order -1: feed drawer toggle, shown only in narrow/phone layout -->
-					<i class="material-icons sidebar-toggle" role="button" tabindex="0"
+					<!-- order -1: feed drawer toggle (the app logo), shown only in narrow/phone layout -->
+					<img class="sidebar-toggle" src="images/favicon-72px.png" alt="" draggable="false" role="button" tabindex="0"
 						aria-expanded="false" title="<?= __('Toggle feed list') ?>"
 						onclick="App.toggleSidebar()"
-						onkeydown="if (event.key === 'Enter' || event.key === ' ') { App.toggleSidebar(); event.preventDefault(); }">menu</i>
+						onkeydown="if (event.key === 'Enter' || event.key === ' ') { App.toggleSidebar(); event.preventDefault(); }">
 
 			 	<!-- order 0, default -->
 

--- a/themes/compact.css
+++ b/themes/compact.css
@@ -637,7 +637,12 @@ body.ttrss_main #feeds-holder-backdrop {
 @media (max-width: 768px) {
   body.ttrss_main .sidebar-toggle {
     display: inline-block;
-    font-size: 24px;
+    width: 28px;
+    height: 28px;
+    margin: 0 4px;
+    vertical-align: middle;
+    user-select: none;
+    -webkit-touch-callout: none;
   }
   body.ttrss_main #content-wrap,
   body.ttrss_main #toolbar-frame,

--- a/themes/compact_night.css
+++ b/themes/compact_night.css
@@ -637,7 +637,12 @@ body.ttrss_main #feeds-holder-backdrop {
 @media (max-width: 768px) {
   body.ttrss_main .sidebar-toggle {
     display: inline-block;
-    font-size: 24px;
+    width: 28px;
+    height: 28px;
+    margin: 0 4px;
+    vertical-align: middle;
+    user-select: none;
+    -webkit-touch-callout: none;
   }
   body.ttrss_main #content-wrap,
   body.ttrss_main #toolbar-frame,

--- a/themes/light-high-contrast.css
+++ b/themes/light-high-contrast.css
@@ -637,7 +637,12 @@ body.ttrss_main #feeds-holder-backdrop {
 @media (max-width: 768px) {
   body.ttrss_main .sidebar-toggle {
     display: inline-block;
-    font-size: 24px;
+    width: 28px;
+    height: 28px;
+    margin: 0 4px;
+    vertical-align: middle;
+    user-select: none;
+    -webkit-touch-callout: none;
   }
   body.ttrss_main #content-wrap,
   body.ttrss_main #toolbar-frame,

--- a/themes/light.css
+++ b/themes/light.css
@@ -637,7 +637,12 @@ body.ttrss_main #feeds-holder-backdrop {
 @media (max-width: 768px) {
   body.ttrss_main .sidebar-toggle {
     display: inline-block;
-    font-size: 24px;
+    width: 28px;
+    height: 28px;
+    margin: 0 4px;
+    vertical-align: middle;
+    user-select: none;
+    -webkit-touch-callout: none;
   }
   body.ttrss_main #content-wrap,
   body.ttrss_main #toolbar-frame,

--- a/themes/light/tt-rss.less
+++ b/themes/light/tt-rss.less
@@ -735,7 +735,7 @@ body.ttrss_main {
 	}
 
 	// Narrow / phone layout: collapse the feed sidebar into a slide-in drawer
-	// that overlays the article view, toggled by the .sidebar-toggle hamburger
+	// that overlays the article view, toggled by the .sidebar-toggle app-logo button
 	// in the toolbar. Wider screens keep the docked, resizable sidebar above.
 	.sidebar-toggle {
 		display : none;
@@ -750,7 +750,12 @@ body.ttrss_main {
 	@media (max-width: @breakpoint-md) {
 		.sidebar-toggle {
 			display : inline-block;
-			font-size : 24px;
+			width : 28px;
+			height : 28px;
+			margin : 0 4px;
+			vertical-align : middle;
+			user-select : none;
+			-webkit-touch-callout : none;
 		}
 
 		// The drawer is a fixed overlay, but BorderContainer still reserves its

--- a/themes/night.css
+++ b/themes/night.css
@@ -638,7 +638,12 @@ body.ttrss_main #feeds-holder-backdrop {
 @media (max-width: 768px) {
   body.ttrss_main .sidebar-toggle {
     display: inline-block;
-    font-size: 24px;
+    width: 28px;
+    height: 28px;
+    margin: 0 4px;
+    vertical-align: middle;
+    user-select: none;
+    -webkit-touch-callout: none;
   }
   body.ttrss_main #content-wrap,
   body.ttrss_main #toolbar-frame,

--- a/themes/night_blue.css
+++ b/themes/night_blue.css
@@ -638,7 +638,12 @@ body.ttrss_main #feeds-holder-backdrop {
 @media (max-width: 768px) {
   body.ttrss_main .sidebar-toggle {
     display: inline-block;
-    font-size: 24px;
+    width: 28px;
+    height: 28px;
+    margin: 0 4px;
+    vertical-align: middle;
+    user-select: none;
+    -webkit-touch-callout: none;
   }
   body.ttrss_main #content-wrap,
   body.ttrss_main #toolbar-frame,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The narrow/phone layout's feed-drawer toggle used a hamburger (menu) glyph -- the same icon as the existing top-right "Actions..." dropdown -- so the toolbar showed two identical hamburgers. Replace the toggle with the tt-rss logo (favicon-72px.png): it disambiguates the two controls and doubles as app branding in the top-left corner, while still opening the feed drawer.

The toggle keeps its button semantics (role, tabindex, aria-expanded, title, click + Enter/Space handlers); its narrow-layout style swaps the glyph font-size for a 28px image box and adds user-select:none / -webkit-touch-callout:none so long-pressing the logo button on a phone doesn't pop the image context menu.

Themes recompiled via gulp less.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This makes the UI more usable on phones. References https://github.com/tt-rss/tt-rss/issues/157.

## How Has This Been Tested?
Tested on Firefox for Android

## Screenshots (if appropriate)
<!-- If screenshots will help in understanding the change, include them here. -->

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
