### PR TITLE
Add a viewport meta tag to the login page

### DIFF
--- a/include/login_form.php
+++ b/include/login_form.php
@@ -5,6 +5,7 @@
 	<title>Tiny Tiny RSS : Login</title>
 	<link rel="shortcut icon" type="image/png" href="images/favicon.png">
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+	<meta name="viewport" content="initial-scale=1,width=device-width" />
 	<?php
 	foreach (["lib/dojo/dojo.js",
 				"lib/dojo/tt-rss-layer.js",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The login form is a self-contained HTML document (include/login_form.php) and never got the viewport meta tag that index.php and prefs.php carry, so on a phone it rendered at the default ~980px width -- zoomed out and tiny. Declare width=device-width so the login screen lays out at device width like the rest of the app.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This makes the UI more usable on phones. References https://github.com/tt-rss/tt-rss/issues/157.

## How Has This Been Tested?
Tested on Firefox for Android

## Screenshots (if appropriate)
<!-- If screenshots will help in understanding the change, include them here. -->

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
