### PR TITLE
Use the default 16px text size for the article list on narrow screens

### DIFF
--- a/themes/compact.css
+++ b/themes/compact.css
@@ -655,6 +655,21 @@ body.ttrss_main #feeds-holder-backdrop {
   body.ttrss_main #headlines-frame {
     overscroll-behavior-y: contain;
   }
+  body.ttrss_main .hl,
+  body.ttrss_main .cdm {
+    font-size: 16px;
+  }
+  body.ttrss_main .hl div.title a,
+  body.ttrss_main .hl .feed a,
+  body.ttrss_main .hl .author,
+  body.ttrss_main .hl .updated,
+  body.ttrss_main .cdm .header a.title,
+  body.ttrss_main .cdm .header .feed,
+  body.ttrss_main .cdm .header .author,
+  body.ttrss_main .cdm .header .updated,
+  body.ttrss_main .cdm .excerpt {
+    font-size: 16px;
+  }
   body.ttrss_main #feeds-holder_splitter {
     display: none ! important;
   }

--- a/themes/compact_night.css
+++ b/themes/compact_night.css
@@ -655,6 +655,21 @@ body.ttrss_main #feeds-holder-backdrop {
   body.ttrss_main #headlines-frame {
     overscroll-behavior-y: contain;
   }
+  body.ttrss_main .hl,
+  body.ttrss_main .cdm {
+    font-size: 16px;
+  }
+  body.ttrss_main .hl div.title a,
+  body.ttrss_main .hl .feed a,
+  body.ttrss_main .hl .author,
+  body.ttrss_main .hl .updated,
+  body.ttrss_main .cdm .header a.title,
+  body.ttrss_main .cdm .header .feed,
+  body.ttrss_main .cdm .header .author,
+  body.ttrss_main .cdm .header .updated,
+  body.ttrss_main .cdm .excerpt {
+    font-size: 16px;
+  }
   body.ttrss_main #feeds-holder_splitter {
     display: none ! important;
   }

--- a/themes/light-high-contrast.css
+++ b/themes/light-high-contrast.css
@@ -655,6 +655,21 @@ body.ttrss_main #feeds-holder-backdrop {
   body.ttrss_main #headlines-frame {
     overscroll-behavior-y: contain;
   }
+  body.ttrss_main .hl,
+  body.ttrss_main .cdm {
+    font-size: 16px;
+  }
+  body.ttrss_main .hl div.title a,
+  body.ttrss_main .hl .feed a,
+  body.ttrss_main .hl .author,
+  body.ttrss_main .hl .updated,
+  body.ttrss_main .cdm .header a.title,
+  body.ttrss_main .cdm .header .feed,
+  body.ttrss_main .cdm .header .author,
+  body.ttrss_main .cdm .header .updated,
+  body.ttrss_main .cdm .excerpt {
+    font-size: 16px;
+  }
   body.ttrss_main #feeds-holder_splitter {
     display: none ! important;
   }

--- a/themes/light.css
+++ b/themes/light.css
@@ -655,6 +655,21 @@ body.ttrss_main #feeds-holder-backdrop {
   body.ttrss_main #headlines-frame {
     overscroll-behavior-y: contain;
   }
+  body.ttrss_main .hl,
+  body.ttrss_main .cdm {
+    font-size: 16px;
+  }
+  body.ttrss_main .hl div.title a,
+  body.ttrss_main .hl .feed a,
+  body.ttrss_main .hl .author,
+  body.ttrss_main .hl .updated,
+  body.ttrss_main .cdm .header a.title,
+  body.ttrss_main .cdm .header .feed,
+  body.ttrss_main .cdm .header .author,
+  body.ttrss_main .cdm .header .updated,
+  body.ttrss_main .cdm .excerpt {
+    font-size: 16px;
+  }
   body.ttrss_main #feeds-holder_splitter {
     display: none ! important;
   }

--- a/themes/light/tt-rss.less
+++ b/themes/light/tt-rss.less
@@ -780,6 +780,32 @@ body.ttrss_main {
 			overscroll-behavior-y : contain;
 		}
 
+		// On phones, render the whole article list at the standard 16px mobile
+		// body size — matching the open article body and the browser default —
+		// instead of the desktop list's smaller 14px / 11px text. Setting the
+		// row base lifts generic inherited text (tags, the (+)/comments footer
+		// links); the explicit list below lifts the elements the desktop theme
+		// sizes smaller on purpose (titles, feed/author/date, excerpt). Weight,
+		// not size, keeps the title prominent. Desktop is untouched (this is in
+		// the narrow media query); the body.ttrss_main prefix outweighs
+		// .cdm.expandable's explicit 14px title rule.
+		.hl,
+		.cdm {
+			font-size : 16px;
+		}
+
+		.hl div.title a,
+		.hl .feed a,
+		.hl .author,
+		.hl .updated,
+		.cdm .header a.title,
+		.cdm .header .feed,
+		.cdm .header .author,
+		.cdm .header .updated,
+		.cdm .excerpt {
+			font-size : 16px;
+		}
+
 		// The splitter is meaningless while the sidebar is an overlay.
 		#feeds-holder_splitter {
 			display : none ! important;

--- a/themes/night.css
+++ b/themes/night.css
@@ -656,6 +656,21 @@ body.ttrss_main #feeds-holder-backdrop {
   body.ttrss_main #headlines-frame {
     overscroll-behavior-y: contain;
   }
+  body.ttrss_main .hl,
+  body.ttrss_main .cdm {
+    font-size: 16px;
+  }
+  body.ttrss_main .hl div.title a,
+  body.ttrss_main .hl .feed a,
+  body.ttrss_main .hl .author,
+  body.ttrss_main .hl .updated,
+  body.ttrss_main .cdm .header a.title,
+  body.ttrss_main .cdm .header .feed,
+  body.ttrss_main .cdm .header .author,
+  body.ttrss_main .cdm .header .updated,
+  body.ttrss_main .cdm .excerpt {
+    font-size: 16px;
+  }
   body.ttrss_main #feeds-holder_splitter {
     display: none ! important;
   }

--- a/themes/night_blue.css
+++ b/themes/night_blue.css
@@ -656,6 +656,21 @@ body.ttrss_main #feeds-holder-backdrop {
   body.ttrss_main #headlines-frame {
     overscroll-behavior-y: contain;
   }
+  body.ttrss_main .hl,
+  body.ttrss_main .cdm {
+    font-size: 16px;
+  }
+  body.ttrss_main .hl div.title a,
+  body.ttrss_main .hl .feed a,
+  body.ttrss_main .hl .author,
+  body.ttrss_main .hl .updated,
+  body.ttrss_main .cdm .header a.title,
+  body.ttrss_main .cdm .header .feed,
+  body.ttrss_main .cdm .header .author,
+  body.ttrss_main .cdm .header .updated,
+  body.ttrss_main .cdm .excerpt {
+    font-size: 16px;
+  }
   body.ttrss_main #feeds-holder_splitter {
     display: none ! important;
   }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
On phones the article list rendered at the desktop theme's smaller sizes -- 14px titles and 11px feed/author/date metadata -- which is cramped. Render the whole row at the standard 16px mobile body size instead, matching the open article body and the browser default: set the row base so inherited text (tags, the (+)/comments footer links) lifts to 16px, and lift the elements the desktop theme sizes smaller on purpose (titles, feed/author/date, excerpt). Title prominence is kept via font-weight, not size.

Scoped to the @media (max-width: breakpoint-md) block so the desktop layout is unchanged. Themes recompiled via gulp less.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This makes the UI more usable on phones. References https://github.com/tt-rss/tt-rss/issues/157.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
Tested on Firefox for Android

## Screenshots (if appropriate)
<!-- If screenshots will help in understanding the change, include them here. -->

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
