### PR TITLE
Add npm ecosystem to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,13 @@ updates:
   commit-message:
     prefix: 'Composer:'
 
+- package-ecosystem: npm
+  directory: /
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: 'npm:'
+
 - package-ecosystem: docker
   directories:
   - /.docker/app


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The root package.json/package-lock.json devDependencies (eslint, stylelint, less, gulp, etc.) were not watched by any Dependabot ecosystem, so they had drifted several major versions behind. These tools drive the css-lint and javascript-code-quality CI workflows. Add an npm ecosystem entry so they get weekly update PRs like Composer, Docker, and GitHub Actions.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Keep npm packages up to date.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
Untested.

## Screenshots (if appropriate)
<!-- If screenshots will help in understanding the change, include them here. -->

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.