### PR TITLE
Enable additional high-value ESLint rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -29,6 +29,28 @@ export default [
       'eqeqeq': ['error', 'always'],
       'no-empty': ['error', { 'allowEmptyCatch': true }],
 
+      // Security — block the eval family and javascript: URLs
+      'no-eval': 'error',
+      'no-implied-eval': 'error',
+      'no-new-func': 'error',
+      'no-script-url': 'error',
+      'no-extend-native': 'error',
+
+      // Correctness / bug catchers
+      'array-callback-return': 'error',
+      'no-return-assign': 'error',
+      'no-self-compare': 'error',
+      'no-unmodified-loop-condition': 'error',
+      'no-unreachable-loop': 'error',
+      'no-constructor-return': 'error',
+      'no-new-wrappers': 'error',
+
+      // Modernization (companions to prefer-const)
+      'no-var': 'error',
+      'prefer-spread': 'error',
+      'prefer-object-spread': 'error',
+      'no-useless-rename': 'error',
+
       // Stylistic rules (replacing those deprecated in ESLint)
       '@stylistic/js/linebreak-style': ['error', 'unix'],
       '@stylistic/js/eol-last': 'error',


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add 16 rules that currently have zero violations across js/ and plugins/: the eval-family security rules (no-eval, no-implied-eval, no-new-func, no-script-url, no-extend-native), correctness/bug-catching rules (array-callback-return, no-return-assign, no-self-compare, no-unmodified-loop-condition, no-unreachable-loop, no-constructor-return, no-new-wrappers), and modern-syntax rules complementing the existing prefer-const (no-var, prefer-spread, prefer-object-spread, no-useless-rename).

These act as a regression ratchet only; no source changes were required and 'npm run lint:js' stays clean.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Prevent regressions.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
Ran `npm run lint:js` locally.

## Screenshots (if appropriate)
<!-- If screenshots will help in understanding the change, include them here. -->

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
