### PR TITLE
Fix five client-side JS logic errors

### DIFF
--- a/js/Feeds.js
+++ b/js/Feeds.js
@@ -419,7 +419,7 @@ const	Feeds = {
 
 		if (offset !== 0) {
 			query.skip = offset;
-		} else if (!is_cat && feed === this.getActive() && !params.method) {
+		} else if (!is_cat && String(feed) === String(this.getActive()) && !params.method) {
 			query.m = "ForceUpdate";
 		}
 

--- a/js/Headlines.js
+++ b/js/Headlines.js
@@ -1349,7 +1349,7 @@ const Headlines = {
 				this.headlines[data.id].tags = data.tags;
 			}
 
-			document.querySelectorAll(`span[data-tags-for="${data.id}"`).forEach((ctr) => {
+			document.querySelectorAll(`span[data-tags-for="${data.id}"]`).forEach((ctr) => {
 				ctr.innerHTML = Article.renderTags(data.id, data.tags);
 			});
 		}
@@ -1583,7 +1583,7 @@ const Headlines = {
 			const menu = new dijit.Menu({
 				id: "headlinesFeedTitleMenu",
 				targetNodeIds: ["headlines-frame"],
-				selector: "div.cdmFeedTitle"
+				selector: "div.feed-title"
 			});
 
 			menu.addChild(new dijit.MenuItem({

--- a/js/PrefHelpers.js
+++ b/js/PrefHelpers.js
@@ -264,7 +264,7 @@ const	Helpers = {
 				apply: function() {
 					xhr.post("backend.php", this.attr('value'), () => {
 						Element.show("css_edit_apply_msg");
-						document.getElementById("user_css_style").innerText = this.attr('value');
+						document.getElementById("user_css_style").innerText = this.attr('value').value;
 					});
 				},
 				execute: function () {
@@ -521,7 +521,7 @@ const	Helpers = {
 												<h3 style="margin-top: 0">${plugin}</h3>
 												<div class='text-error'>${reply.result}</div>
 												${reply.stderr ? `<pre class="small text-error pre-wrap">${reply.stderr}</pre>` : ''}
-												${reply.stdour ? `<pre class="small text-success pre-wrap">${reply.stdout}</pre>` : ''}
+												${reply.stdout ? `<pre class="small text-success pre-wrap">${reply.stdout}</pre>` : ''}
 												<p class="small">
 													${App.FormFields.icon("error_outline") + " " + __("Exited with RC: %d").replace("%d", reply.git_status)}
 												</p>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
- Feeds.js: open() compared a string feed id from the sidebar tree against the numeric active id with ===, so re-clicking the active feed no longer forced an update (regression from the eqeqeq migration, commit 39182a76e); compare as strings.
- Headlines.js: onTagsUpdated() used an unterminated attribute selector (missing ]) that threw SyntaxError on every tag edit; add the bracket.
- Headlines.js: the vgroup feed-title context menu targeted a nonexistent class (div.cdmFeedTitle); point it at the rendered div.feed-title.
- PrefHelpers.js: the stylesheet Apply handler assigned the dialog form object to <style>.innerText (rendering [object Object]); assign .value.
- PrefHelpers.js: a failed plugin install guarded its stdout block on a misspelled reply.stdour; correct to reply.stdout.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Sweep by Claude

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
Tested Feeds.js change but only visually inspected others.

## Screenshots (if appropriate)
<!-- If screenshots will help in understanding the change, include them here. -->

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.