### PR TITLE
Clamp article titles at two lines on the narrow layout

### DIFF
--- a/themes/compact.css
+++ b/themes/compact.css
@@ -799,6 +799,20 @@ body.ttrss_main .hl-swipe-action .material-icons {
     flex-basis: 100%;
     order: -1;
   }
+  body.ttrss_main .hl > .title,
+  body.ttrss_main .cdm.expandable:not(.active) .header > .titleWrap {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    overflow: hidden;
+    white-space: normal;
+    padding-bottom: 0;
+    margin-bottom: 4px;
+  }
+  body.ttrss_main .cdm.expandable:not(.active) .header > .titleWrap .excerpt {
+    white-space: normal;
+  }
   body.ttrss_main .hl > .right,
   body.ttrss_main .cdm .header > .right {
     margin-left: auto;

--- a/themes/compact_night.css
+++ b/themes/compact_night.css
@@ -799,6 +799,20 @@ body.ttrss_main .hl-swipe-action .material-icons {
     flex-basis: 100%;
     order: -1;
   }
+  body.ttrss_main .hl > .title,
+  body.ttrss_main .cdm.expandable:not(.active) .header > .titleWrap {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    overflow: hidden;
+    white-space: normal;
+    padding-bottom: 0;
+    margin-bottom: 4px;
+  }
+  body.ttrss_main .cdm.expandable:not(.active) .header > .titleWrap .excerpt {
+    white-space: normal;
+  }
   body.ttrss_main .hl > .right,
   body.ttrss_main .cdm .header > .right {
     margin-left: auto;

--- a/themes/light-high-contrast.css
+++ b/themes/light-high-contrast.css
@@ -799,6 +799,20 @@ body.ttrss_main .hl-swipe-action .material-icons {
     flex-basis: 100%;
     order: -1;
   }
+  body.ttrss_main .hl > .title,
+  body.ttrss_main .cdm.expandable:not(.active) .header > .titleWrap {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    overflow: hidden;
+    white-space: normal;
+    padding-bottom: 0;
+    margin-bottom: 4px;
+  }
+  body.ttrss_main .cdm.expandable:not(.active) .header > .titleWrap .excerpt {
+    white-space: normal;
+  }
   body.ttrss_main .hl > .right,
   body.ttrss_main .cdm .header > .right {
     margin-left: auto;

--- a/themes/light.css
+++ b/themes/light.css
@@ -799,6 +799,20 @@ body.ttrss_main .hl-swipe-action .material-icons {
     flex-basis: 100%;
     order: -1;
   }
+  body.ttrss_main .hl > .title,
+  body.ttrss_main .cdm.expandable:not(.active) .header > .titleWrap {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    overflow: hidden;
+    white-space: normal;
+    padding-bottom: 0;
+    margin-bottom: 4px;
+  }
+  body.ttrss_main .cdm.expandable:not(.active) .header > .titleWrap .excerpt {
+    white-space: normal;
+  }
   body.ttrss_main .hl > .right,
   body.ttrss_main .cdm .header > .right {
     margin-left: auto;

--- a/themes/light/tt-rss.less
+++ b/themes/light/tt-rss.less
@@ -975,9 +975,9 @@ body.ttrss_main {
 		}
 	}
 
-	// Narrow / phone layout: wrap each article row onto two lines — the title
-	// claims the whole first line, and the feed name, date and icons wrap onto
-	// a second line below it. Applies to both list (.hl) and combined (.cdm)
+	// Narrow / phone layout: wrap each article row — the title claims the
+	// whole first line or two, and the feed name, date and icons wrap onto a
+	// final line below it. Applies to both list (.hl) and combined (.cdm)
 	// rows, which share the same left | title | feed | date | right flex layout.
 	@media (max-width: @breakpoint-md) {
 		.hl,
@@ -989,6 +989,31 @@ body.ttrss_main {
 		.cdm .header > .titleWrap {
 			flex-basis : 100%;
 			order : -1;
+		}
+
+		// Long titles get a second line instead of being clipped after one:
+		// closed rows clamp the title block (title plus inline preview or
+		// excerpt) at two lines with an ellipsis. Open (.active) CDM rows
+		// keep the full wrap they get from cdm.less. Bottom padding becomes
+		// a margin so the overflow clip lands exactly on the second line —
+		// the CDM excerpt is a sibling of the clamp-truncated title anchor,
+		// so its third-line glyph tops would paint through any padding.
+		.hl > .title,
+		.cdm.expandable:not(.active) .header > .titleWrap {
+			display : -webkit-box;
+			-webkit-box-orient : vertical;
+			-webkit-line-clamp : 2;
+			line-clamp : 2;
+			overflow : hidden;
+			white-space : normal;
+			padding-bottom : 0;
+			margin-bottom : 4px;
+		}
+
+		// the excerpt's own nowrap (cdm.less) would otherwise keep it from
+		// wrapping through the clamp's second line
+		.cdm.expandable:not(.active) .header > .titleWrap .excerpt {
+			white-space : normal;
 		}
 
 		// keep the trailing icons flush with the right edge of the second line

--- a/themes/night.css
+++ b/themes/night.css
@@ -800,6 +800,20 @@ body.ttrss_main .hl-swipe-action .material-icons {
     flex-basis: 100%;
     order: -1;
   }
+  body.ttrss_main .hl > .title,
+  body.ttrss_main .cdm.expandable:not(.active) .header > .titleWrap {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    overflow: hidden;
+    white-space: normal;
+    padding-bottom: 0;
+    margin-bottom: 4px;
+  }
+  body.ttrss_main .cdm.expandable:not(.active) .header > .titleWrap .excerpt {
+    white-space: normal;
+  }
   body.ttrss_main .hl > .right,
   body.ttrss_main .cdm .header > .right {
     margin-left: auto;

--- a/themes/night_blue.css
+++ b/themes/night_blue.css
@@ -800,6 +800,20 @@ body.ttrss_main .hl-swipe-action .material-icons {
     flex-basis: 100%;
     order: -1;
   }
+  body.ttrss_main .hl > .title,
+  body.ttrss_main .cdm.expandable:not(.active) .header > .titleWrap {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    overflow: hidden;
+    white-space: normal;
+    padding-bottom: 0;
+    margin-bottom: 4px;
+  }
+  body.ttrss_main .cdm.expandable:not(.active) .header > .titleWrap .excerpt {
+    white-space: normal;
+  }
   body.ttrss_main .hl > .right,
   body.ttrss_main .cdm .header > .right {
     margin-left: auto;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Closed rows on phones previously truncated the title to a single nowrap line. Let the title block (title plus inline preview or excerpt) wrap onto a second line instead, clamped with an ellipsis via -webkit-line-clamp, in both list (.hl) and combined (.cdm.expandable) rows. Open (.active) combined rows keep their existing full wrap, and the docked desktop layout is unchanged.

The clamped element trades its bottom padding for a margin because the CDM excerpt is a sibling of the clamp-truncated title anchor: it still lays out lines past the clamp, and their glyph tops would otherwise paint through the padding before the overflow clip. The excerpt's own nowrap is relaxed so it can flow through the second line.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This makes the UI more usable on phones. References https://github.com/tt-rss/tt-rss/issues/157.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->

## Screenshots (if appropriate)
<!-- If screenshots will help in understanding the change, include them here. -->
Before:
<img width="1080" height="2400" alt="2026-06-11 17 05 38" src="https://github.com/user-attachments/assets/91ff23c6-a0d5-4a77-b0f9-79d024f1545a" />

After:
<img width="1080" height="2400" alt="2026-06-11 17 20 09" src="https://github.com/user-attachments/assets/b7b69ad4-afbc-41e3-b9dc-5cf1a10c83d3" />

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.