### PR TITLE
Open context menus with a long-press on iOS

### DIFF
--- a/js/App.js
+++ b/js/App.js
@@ -871,6 +871,7 @@ const App = {
 
          this.initPullToRefresh();
          this.initSwipeToRead();
+         this.initLongPressContextMenu();
 
          // If the viewport grows back to the docked layout (the hamburger
          // toggle is hidden there), make sure the drawer isn't left open.
@@ -1440,6 +1441,126 @@ const App = {
       }, {passive: true});
 
       frame.addEventListener("touchcancel", cleanup, {passive: true});
+   },
+   // iOS Safari never fires a contextmenu event for a touch long-press, and
+   // contextmenu is the only trigger the delegated dijit.Menu bindings listen
+   // for (headline rows and group headers in Headlines.initHeadlinesMenu(),
+   // feed tree rows in FeedTree._initContextMenus()) -- so on iPhones and
+   // iPads those menus were unreachable. Time the press ourselves and
+   // dispatch the contextmenu event dijit expects at the pressed element;
+   // from there the selector delegation, currentTarget and menu position work
+   // exactly as for a real right-click. Android *does* fire contextmenu
+   // natively at ~500ms, so the timer sits above that: where a native event
+   // exists it wins and cancels the pending press, and a late native
+   // duplicate arriving just after a synthesised open is eaten.
+   //
+   // The menu opens while the finger is still down. When it lifts, the
+   // browser synthesises the tap's compatibility mousedown/mouseup/click,
+   // which would land on the just-opened menu (it opens at the finger) or on
+   // the modal backdrop behind it and activate or dismiss something the user
+   // never aimed at. So once the press qualifies, the gesture's compatibility
+   // events are swallowed at the document, armed only until just after this
+   // pointer's release so the next deliberate tap (e.g. on a menu item) is
+   // unaffected.
+   initLongPressContextMenu: function() {
+      const LONG_PRESS_MS = 600;  // above Android's native long-press delay on purpose
+      const MOVE_SLOP_PX = 10;    // finger drift allowed before it counts as a scroll
+
+      ["feeds-holder", "headlines-frame"].forEach((container_id) => {
+         const container = document.getElementById(container_id);
+         if (!container)
+            return;
+
+         let pending = null;        // the press being timed
+         let synthesized_at = 0;    // when we last dispatched a synthetic contextmenu
+
+         const cancel = () => {
+            if (pending) {
+               window.clearTimeout(pending.timer);
+               pending = null;
+            }
+         };
+
+         const armReleaseSwallow = () => {
+            const swallow = (ev) => {
+               ev.preventDefault();
+               ev.stopPropagation();
+            };
+            const types = ["mousedown", "mouseup", "click"];
+            types.forEach((t) => document.addEventListener(t, swallow, {capture: true, once: true}));
+
+            const disarm = () => {
+               container.removeEventListener("pointerup", disarm);
+               container.removeEventListener("pointercancel", disarm);
+               // compatibility events follow the release almost immediately;
+               // anything later is a new, deliberate tap
+               window.setTimeout(() => {
+                  types.forEach((t) => document.removeEventListener(t, swallow, {capture: true}));
+               }, 150);
+            };
+            container.addEventListener("pointerup", disarm);
+            container.addEventListener("pointercancel", disarm);
+         };
+
+         container.addEventListener("pointerdown", (ev) => {
+            cancel();
+
+            // a second finger means pinch or scroll, not a long-press
+            if (ev.pointerType !== "touch" || !ev.isPrimary)
+               return;
+
+            pending = {
+               pointer_id: ev.pointerId,
+               x: ev.clientX,
+               y: ev.clientY,
+               target: ev.target,
+               timer: window.setTimeout(() => {
+                  const press = pending;
+                  pending = null;
+
+                  const synth = new MouseEvent("contextmenu", {bubbles: true,
+                     cancelable: true, view: window, clientX: press.x, clientY: press.y});
+                  synth.ttrss_synthesized = true;
+                  synthesized_at = Date.now();
+
+                  // Armed before dispatching, and regardless of whether a menu
+                  // is bound here: dijit opens the menu on a deferred tick
+                  // (Menu._scheduleOpen), so "did a menu open" can't be checked
+                  // synchronously -- and a recognised long-press's release
+                  // shouldn't click through to the app in any case, matching
+                  // the native behaviour on Android.
+                  armReleaseSwallow();
+                  press.target.dispatchEvent(synth);
+               }, LONG_PRESS_MS)
+            };
+         }, {passive: true});
+
+         container.addEventListener("pointermove", (ev) => {
+            if (pending && ev.pointerId === pending.pointer_id &&
+                  (Math.abs(ev.clientX - pending.x) > MOVE_SLOP_PX ||
+                   Math.abs(ev.clientY - pending.y) > MOVE_SLOP_PX))
+               cancel();
+         }, {passive: true});
+
+         container.addEventListener("pointerup", cancel, {passive: true});
+         container.addEventListener("pointercancel", cancel, {passive: true});
+
+         // A native contextmenu -- Android's long-press or an actual right
+         // click -- outranks the timer. The reverse race (our timer fired
+         // first, the native event limped in after) would open the menu
+         // twice, so a native event on the heels of a synthesised one is
+         // eaten in the capture phase, before dijit's delegated bubble
+         // handler can see it.
+         container.addEventListener("contextmenu", (ev) => {
+            if (ev.ttrss_synthesized)
+               return;
+            cancel();
+            if (Date.now() - synthesized_at < 400) {
+               ev.preventDefault();
+               ev.stopImmediatePropagation();
+            }
+         }, {capture: true});
+      });
    },
    initHotkeyActions: function() {
       if (this.is_prefs) {

--- a/themes/compact.css
+++ b/themes/compact.css
@@ -789,6 +789,15 @@ body.ttrss_main .hl-swipe-action.ready {
 body.ttrss_main .hl-swipe-action .material-icons {
   font-size: 26px;
 }
+@media (pointer: coarse) {
+  body.ttrss_main .hlMenuAttach,
+  body.ttrss_main .vfeedMenuAttach,
+  body.ttrss_main #headlines-frame .feed-title,
+  body.ttrss_main #feeds-holder .dijitTreeRow {
+    user-select: none;
+    -webkit-touch-callout: none;
+  }
+}
 @media (max-width: 768px) {
   body.ttrss_main .hl,
   body.ttrss_main .cdm .header {

--- a/themes/compact_night.css
+++ b/themes/compact_night.css
@@ -789,6 +789,15 @@ body.ttrss_main .hl-swipe-action.ready {
 body.ttrss_main .hl-swipe-action .material-icons {
   font-size: 26px;
 }
+@media (pointer: coarse) {
+  body.ttrss_main .hlMenuAttach,
+  body.ttrss_main .vfeedMenuAttach,
+  body.ttrss_main #headlines-frame .feed-title,
+  body.ttrss_main #feeds-holder .dijitTreeRow {
+    user-select: none;
+    -webkit-touch-callout: none;
+  }
+}
 @media (max-width: 768px) {
   body.ttrss_main .hl,
   body.ttrss_main .cdm .header {

--- a/themes/light-high-contrast.css
+++ b/themes/light-high-contrast.css
@@ -789,6 +789,15 @@ body.ttrss_main .hl-swipe-action.ready {
 body.ttrss_main .hl-swipe-action .material-icons {
   font-size: 26px;
 }
+@media (pointer: coarse) {
+  body.ttrss_main .hlMenuAttach,
+  body.ttrss_main .vfeedMenuAttach,
+  body.ttrss_main #headlines-frame .feed-title,
+  body.ttrss_main #feeds-holder .dijitTreeRow {
+    user-select: none;
+    -webkit-touch-callout: none;
+  }
+}
 @media (max-width: 768px) {
   body.ttrss_main .hl,
   body.ttrss_main .cdm .header {

--- a/themes/light.css
+++ b/themes/light.css
@@ -789,6 +789,15 @@ body.ttrss_main .hl-swipe-action.ready {
 body.ttrss_main .hl-swipe-action .material-icons {
   font-size: 26px;
 }
+@media (pointer: coarse) {
+  body.ttrss_main .hlMenuAttach,
+  body.ttrss_main .vfeedMenuAttach,
+  body.ttrss_main #headlines-frame .feed-title,
+  body.ttrss_main #feeds-holder .dijitTreeRow {
+    user-select: none;
+    -webkit-touch-callout: none;
+  }
+}
 @media (max-width: 768px) {
   body.ttrss_main .hl,
   body.ttrss_main .cdm .header {

--- a/themes/light/tt-rss.less
+++ b/themes/light/tt-rss.less
@@ -975,6 +975,20 @@ body.ttrss_main {
 		}
 	}
 
+	// Long-press opens the delegated context menus on touch screens (see
+	// App.initLongPressContextMenu()); keep the platform's own long-press
+	// behaviours — iOS Safari's link-preview sheet and text-selection
+	// callout — from also firing on the elements that carry a menu.
+	@media (pointer: coarse) {
+		.hlMenuAttach,
+		.vfeedMenuAttach,
+		#headlines-frame .feed-title,
+		#feeds-holder .dijitTreeRow {
+			user-select : none;
+			-webkit-touch-callout : none;
+		}
+	}
+
 	// Narrow / phone layout: wrap each article row — the title claims the
 	// whole first line or two, and the feed name, date and icons wrap onto a
 	// final line below it. Applies to both list (.hl) and combined (.cdm)

--- a/themes/night.css
+++ b/themes/night.css
@@ -790,6 +790,15 @@ body.ttrss_main .hl-swipe-action.ready {
 body.ttrss_main .hl-swipe-action .material-icons {
   font-size: 26px;
 }
+@media (pointer: coarse) {
+  body.ttrss_main .hlMenuAttach,
+  body.ttrss_main .vfeedMenuAttach,
+  body.ttrss_main #headlines-frame .feed-title,
+  body.ttrss_main #feeds-holder .dijitTreeRow {
+    user-select: none;
+    -webkit-touch-callout: none;
+  }
+}
 @media (max-width: 768px) {
   body.ttrss_main .hl,
   body.ttrss_main .cdm .header {

--- a/themes/night_blue.css
+++ b/themes/night_blue.css
@@ -790,6 +790,15 @@ body.ttrss_main .hl-swipe-action.ready {
 body.ttrss_main .hl-swipe-action .material-icons {
   font-size: 26px;
 }
+@media (pointer: coarse) {
+  body.ttrss_main .hlMenuAttach,
+  body.ttrss_main .vfeedMenuAttach,
+  body.ttrss_main #headlines-frame .feed-title,
+  body.ttrss_main #feeds-holder .dijitTreeRow {
+    user-select: none;
+    -webkit-touch-callout: none;
+  }
+}
 @media (max-width: 768px) {
   body.ttrss_main .hl,
   body.ttrss_main .cdm .header {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
iOS Safari never fires a contextmenu event for a touch long-press, and contextmenu is the only trigger the delegated dijit.Menu bindings listen for, so the headline and feed-tree context menus were unreachable on iPhones and iPads. Android fires the event natively at ~500ms and already worked.

- App.initLongPressContextMenu() times the press itself via pointer events on #headlines-frame and #feeds-holder and dispatches the contextmenu event dijit expects at the pressed element; selector delegation, currentTarget and menu position behave exactly as for a real right-click.
- The 600ms timer sits above Android's native delay on purpose: where a native contextmenu exists it wins and cancels the pending press, and a late native duplicate arriving just after a synthesised open is eaten before dijit can open the menu twice. Movement past 10px, pointerup/pointercancel or a second finger cancels the press, so scrolling, swipe-to-read and pinch are unaffected.
- The menu opens while the finger is still down, so the release would land its compatibility mousedown/mouseup/click on the just-opened menu or the modal popup backdrop. Those events are swallowed at the document, armed only until just after the opening pointer lifts; the next deliberate tap (e.g. on a menu item) goes through normally.
- (pointer: coarse) CSS applies user-select / -webkit-touch-callout none to the menu-bearing elements (headline title wraps, the vfeed chip, group headers, feed tree rows) so iOS's link-preview sheet and selection callout don't fire on the same press; article content stays selectable.

Verified end to end on the dev instance with synthetic pointer events (untrusted events bypass Chromium's native long-press gesture, reproducing iOS's missing contextmenu): long-press opens the correct row's menu on the phone and tablet layouts, menu items execute (starred state and DB flip and stick), the release tap is swallowed, quick taps and scrolls pass through untouched, Android's native path stays single-fire, the device Back gesture still closes the menu first, and desktop right-click is unchanged.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This makes the UI more usable on phones. References https://github.com/tt-rss/tt-rss/issues/157.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
Tested on iPhone 17.  Verified same behavior on Android.

## Screenshots (if appropriate)
<!-- If screenshots will help in understanding the change, include them here. -->

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.