### PR TITLE
Set mobile keyboard and password-manager hints on the login form

### DIFF
--- a/include/login_form.php
+++ b/include/login_form.php
@@ -127,6 +127,7 @@
 			<fieldset>
 				<label><?= __("Login:") ?></label>
 				<input name="login" id="login" dojoType="dijit.form.TextBox" type="text"
+					autocomplete="username" autocapitalize="none" autocorrect="off" spellcheck="false"
 					onchange="UtilityApp.fetchProfiles()"
 					onfocus="UtilityApp.fetchProfiles()"
 					onblur="UtilityApp.fetchProfiles()"
@@ -138,6 +139,7 @@
 				<label><?= __("Password:") ?></label>
 
 				<input type="password" name="password" required="1"
+					autocomplete="current-password"
 					dojoType="dijit.form.TextBox"
 					class="input input-text"
 					onchange="UtilityApp.fetchProfiles()"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Phone keyboards capitalise and autocorrect the login field by default,
and password managers need the autocomplete roles to offer credentials
reliably on mobile.

- Login: autocomplete="username", autocapitalize="none",
  autocorrect="off", spellcheck="false".
- Password: autocomplete="current-password".

The dojo parser forwards autocorrect to the widget as a param just like
the other attributes; whether it reaches the rendered input is then
gated on the browser exposing a matching IDL property. WebKit does, so
iOS Safari -- the only engine with an autocorrect feature -- renders it.
Chromium has neither the property nor the feature, so the attribute is
simply absent there, with nothing lost.

Verified on the rendered login page that the attributes survive the
parser and that logging in still works, and that simulating WebKit's
autocorrect IDL property makes the attribute reach the input.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This makes the UI more usable on phones. References https://github.com/tt-rss/tt-rss/issues/157.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
Tested by logging out and in again on Android and iPhone.

## Screenshots (if appropriate)
<!-- If screenshots will help in understanding the change, include them here. -->

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.