### PR TITLE
Render CDM article content from the Headlines cache, not row attributes

### DIFF
--- a/js/App.js
+++ b/js/App.js
@@ -414,7 +414,7 @@ const App = {
 			i.parentNode ? i.parentNode.removeChild(i) : true;
 		});
    },
-   // htmlspecialchars()-alike for headlines data-content attribute
+   // htmlspecialchars()-alike for HTML attribute values
    escapeHtml: function(p) {
       if (typeof p !== 'string')
          return p;

--- a/js/Article.js
+++ b/js/Article.js
@@ -252,19 +252,23 @@ const Article = {
 	},
 	unpack: function(row) {
 		if (row.getAttribute("data-is-packed") === "1") {
+			// article content lives in the Headlines cache (a row attribute copy
+			// would retain a second, escaped copy of every loaded article)
+			const hl = Headlines.objectById(parseInt(row.getAttribute("data-article-id")));
+
+			// the row outlived the headlines cache (feed transition)
+			if (!hl)
+				return;
+
 			const container = row.querySelector(".content-inner");
 
-			container.innerHTML = row.getAttribute("data-content").trim() + row.getAttribute("data-rendered-enclosures").trim();
+			container.innerHTML = (hl.content || "").trim() + Article.renderEnclosures(hl.enclosures).trim();
 
 			dojo.parser.parse(container);
 
 			// blank content element might screw up onclick selection and keyboard moving
 			if (container.textContent.length === 0)
 				container.innerHTML += "&nbsp;";
-
-			// in expandable mode, save content for later, so that we can pack unfocused rows back
-			if (App.isCombinedMode() && document.getElementById('main').classList.contains('expandable'))
-				row.setAttribute("data-content-original", row.getAttribute("data-content"));
 
 			row.setAttribute("data-is-packed", "0");
 

--- a/js/Headlines.js
+++ b/js/Headlines.js
@@ -329,7 +329,7 @@ const Headlines = {
 		}
 	},
 	unpackVisible: function(container) {
-		const rows = document.querySelectorAll('#headlines-frame > div[id*=RROW][data-content].cdm');
+		const rows = document.querySelectorAll('#headlines-frame > div[id*=RROW][data-is-packed="1"].cdm');
 
 		for (let i = 0; i < rows.length; i++) {
 			if (App.Scrollable.isChildVisible(rows[i], container)) {
@@ -509,8 +509,6 @@ const Headlines = {
 						data-orig-feed-id="${hl.feed_id}"
 						data-orig-feed-title="${App.escapeHtml(hl.feed_title)}"
 						data-is-packed="1"
-						data-content="${App.escapeHtml(hl.content)}"
-						data-rendered-enclosures="${App.escapeHtml(Article.renderEnclosures(hl.enclosures))}"
 						data-score="${hl.score}"
 						data-article-title="${App.escapeHtml(hl.title)}"
 						onmouseover="Article.mouseIn(${hl.id})"


### PR DESCRIPTION
## Description
Combined-mode rows carried every article's HTML in up to three places: the raw string in the Headlines.headlines cache, an escaped copy in the row's data-content attribute (plus data-rendered-enclosures), and -- in expandable mode -- another write-only attribute copy saved to data-content-original on every unpacked row. Article.unpack() now renders from the cache, making it the single retained copy, and the dead data-content-original write is removed.

Besides the redundant copies this drops the App.escapeHtml() call over full article bodies (~36% size inflation) from the row-render hot path and roughly halves the innerHTML parsed per row (avg 9.1KB -> 4.1KB on the dev feeds). At a 210-headline session that is about 1MB of renderer-side attribute strings.

## Motivation and Context
Trying to reduce memory usage of tt-rss on mobile.  The stated findings come from a synthetic feed my real feed has more long-form articles that inflate memory usage.

## How Has This Been Tested?
Tested on Firefox for desktop.  I think there's some potential impact on plugins that is beyond my testing scope.  I appreciate any feedback on this.

## Screenshots (if appropriate)
n/a

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.