### PR TITLE
Support SVG favicons, preferring them over raster icons

### DIFF
--- a/.docker/web-nginx/nginx.conf
+++ b/.docker/web-nginx/nginx.conf
@@ -32,6 +32,12 @@ http {
 		location ${APP_BASE}/cache {
 			aio threads;
 			internal;
+
+			# everything cached here is untrusted remote content (article media, feed
+			# icons incl. SVG); keep it inert if opened as a document. X-Accel-Redirect
+			# doesn't forward custom headers set by PHP, so this has to live here.
+			add_header Content-Security-Policy "default-src 'none'; img-src 'self'; media-src 'self'; style-src 'unsafe-inline'; sandbox" always;
+			add_header X-Content-Type-Options nosniff always;
 		}
 
 		location ${APP_BASE}/backups {

--- a/classes/API.php
+++ b/classes/API.php
@@ -891,7 +891,7 @@ class API extends Handler {
 		$cache = DiskCache::instance('feed-icons');
 
 		if ($cache->exists((string)$id)) {
-			return $cache->send((string)$id) > 0;
+			return $cache->send((string)$id, allow_svg: true) > 0;
 		} else {
 			return $this->_wrap(self::STATUS_ERR, ["error" => self::E_NOT_FOUND]);
 		}

--- a/classes/DiskCache.php
+++ b/classes/DiskCache.php
@@ -312,7 +312,8 @@ class DiskCache implements Cache_Adapter {
 		return false;
 	}
 
-	public function send(string $filename) {
+	/** @param bool $allow_svg serve SVG (only for content sanitized at ingestion, e.g. feed icons) */
+	public function send(string $filename, bool $allow_svg = false) {
 		$filename = basename($filename);
 
 		if (!$this->exists($filename)) {
@@ -349,7 +350,7 @@ class DiskCache implements Cache_Adapter {
 				$mimetype = "video/mp4";
 
 		# block SVG because of possible embedded javascript (.....)
-		$mimetype_blacklist = [ "image/svg+xml" ];
+		$mimetype_blacklist = $allow_svg ? [] : [ "image/svg+xml" ];
 
 		/* only serve video and images */
 		if (!preg_match("/(image|audio|video)\//", (string)$mimetype) || in_array($mimetype, $mimetype_blacklist)) {
@@ -358,6 +359,13 @@ class DiskCache implements Cache_Adapter {
 
 			print "Stored file has disallowed content type ($mimetype)";
 			return false;
+		}
+
+		if ($mimetype == "image/svg+xml") {
+			// second layer on top of ingestion-time sanitization: no script execution
+			// or external loads if the file ends up opened as a document
+			header("Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'; sandbox");
+			header("X-Content-Type-Options: nosniff");
 		}
 
 		$fake_extension = $this->get_fake_extension($filename);

--- a/classes/Handler_Public.php
+++ b/classes/Handler_Public.php
@@ -773,7 +773,7 @@ class Handler_Public extends Handler {
 		$cache = DiskCache::instance('feed-icons');
 
 		if ($cache->exists((string)$id)) {
-			$cache->send((string)$id);
+			$cache->send((string)$id, allow_svg: true);
 		} else {
 			header($_SERVER["SERVER_PROTOCOL"]." 404 Not Found");
 			echo "File not found.";

--- a/classes/Pref_Feeds.php
+++ b/classes/Pref_Feeds.php
@@ -480,7 +480,13 @@ class Pref_Feeds extends Handler_Protected {
 
 				$cache = DiskCache::instance('feed-icons');
 
-				if ($cache->put((string)$feed_id, file_get_contents($tmp_file))) {
+				$icon_data = file_get_contents($tmp_file);
+
+				// feed icons are served unauthenticated from our origin so SVG has to be sanitized
+				if (RSSUtils::detect_favicon_mime_type((string)$icon_data) == 'image/svg+xml')
+					$icon_data = Sanitizer::sanitize_svg((string)$icon_data);
+
+				if ($icon_data && $cache->put((string)$feed_id, $icon_data)) {
 
 					$feed->set([
 						'favicon_avg_color' => null,

--- a/classes/RSSUtils.php
+++ b/classes/RSSUtils.php
@@ -11,6 +11,7 @@ class RSSUtils {
 		'image/gif',
 		'image/jpeg',
 		'image/png',
+		'image/svg+xml',
 		'image/vnd.microsoft.icon',
 	];
 
@@ -669,7 +670,15 @@ class RSSUtils {
 
 				/* terrible hack: if we crash on floicon shit here, we won't check
 				 * the icon avgcolor again (unless icon got updated) */
-				if (file_exists($favicon_cache->get_full_path($feed)) && function_exists("imagecreatefromstring") && empty($feed_obj->favicon_avg_color)) {
+				if (file_exists($favicon_cache->get_full_path($feed)) && empty($feed_obj->favicon_avg_color)
+					&& $favicon_cache->get_mime_type($feed) == 'image/svg+xml') {
+					// GD can't rasterize SVG, mark the icon so we don't keep retrying
+					Debug::log("favicon: skipping average color calculation for SVG icon", Debug::LOG_VERBOSE);
+
+					$feed_obj->favicon_avg_color = 'fail';
+					$feed_obj->save();
+
+				} else if (file_exists($favicon_cache->get_full_path($feed)) && function_exists("imagecreatefromstring") && empty($feed_obj->favicon_avg_color)) {
 					Debug::log("favicon: trying to calculate average color...", Debug::LOG_VERBOSE);
 
 					$feed_obj->favicon_avg_color = 'fail';
@@ -1791,22 +1800,30 @@ class RSSUtils {
 
 			if (!$contents) {
 				Debug::log("favicon: fetching $favicon_url failed.  Skipping...", Debug::LOG_VERBOSE);
-				break;
+				continue;
 			}
 
-			$finfo = new finfo(FILEINFO_MIME_TYPE);
-			$mime_type = $finfo->buffer($contents);
+			$mime_type = self::detect_favicon_mime_type($contents);
 
 			if ($mime_type === false) {
 				Debug::log("favicon: $favicon_url MIME type couldn't be detected.  Skipping...", Debug::LOG_VERBOSE);
-				break;
+				continue;
 			}
 
 			Debug::log("favicon: $favicon_url MIME type '$mime_type'", Debug::LOG_VERBOSE);
 
 			if (!in_array($mime_type, self::FAVICON_ALLOWED_MIME_TYPES)) {
 				Debug::log("favicon: $favicon_url MIME type '$mime_type' is not allowed.  Skipping...", Debug::LOG_VERBOSE);
-				break;
+				continue;
+			}
+
+			if ($mime_type == 'image/svg+xml') {
+				$contents = Sanitizer::sanitize_svg($contents);
+
+				if ($contents === false) {
+					Debug::log("favicon: $favicon_url SVG couldn't be sanitized.  Skipping...", Debug::LOG_VERBOSE);
+					continue;
+				}
 			}
 
 			$favicon_cache = DiskCache::instance('feed-icons');
@@ -1825,6 +1842,24 @@ class RSSUtils {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Detect the MIME type of favicon data; unlike plain finfo, recognizes SVG
+	 * even when it's detected as generic XML/HTML/text (e.g. no XML prolog).
+	 *
+	 * @return false|string the MIME type, or false if it couldn't be detected
+	 */
+	static function detect_favicon_mime_type(string $contents): false|string {
+		$finfo = new finfo(FILEINFO_MIME_TYPE);
+		$mime_type = $finfo->buffer($contents);
+
+		if (in_array($mime_type, ['image/svg', 'text/xml', 'application/xml', 'text/html', 'text/plain'])
+			&& preg_match('/<svg[\s>]/i', substr($contents, 0, 4096))) {
+			return 'image/svg+xml';
+		}
+
+		return $mime_type;
 	}
 
 	static function is_gzipped(string $feed_data): bool {
@@ -1971,13 +2006,31 @@ class RSSUtils {
 
 				$entries = $xpath->query('/html/head/link[@rel="shortcut icon" or @rel="icon" or @rel="alternate icon"]');
 
+				$svg_favicon_urls = [];
+
 				/** @var DOMElement $entry */
 				foreach ($entries as $entry) {
+					// scheme-specific icons (e.g. media="(prefers-color-scheme: dark)") would be
+					// wrong for users of the opposite scheme, we serve one icon to everybody
+					$media = trim($entry->getAttribute('media'));
+
+					if ($media && strtolower($media) != 'all')
+						continue;
+
 					$favicon_url = UrlHelper::rewrite_relative($url, $entry->getAttribute("href"));
 
-					if ($favicon_url)
-						$favicon_urls[] = $favicon_url;
+					if ($favicon_url) {
+						// prefer SVG icons regardless of document order: they scale and may
+						// adapt to the user's color scheme via embedded media queries
+						if (strtolower($entry->getAttribute('type')) == 'image/svg+xml'
+							|| str_ends_with(strtolower((string)parse_url($favicon_url, PHP_URL_PATH)), '.svg'))
+							$svg_favicon_urls[] = $favicon_url;
+						else
+							$favicon_urls[] = $favicon_url;
+					}
 				}
+
+				$favicon_urls = array_merge($svg_favicon_urls, $favicon_urls);
 			}
 		}
 

--- a/classes/Sanitizer.php
+++ b/classes/Sanitizer.php
@@ -42,6 +42,63 @@ class Sanitizer {
 		return $doc;
 	}
 
+	/**
+	 * Sanitize an SVG image so it may be served from our origin (e.g. as a feed icon):
+	 * keeps only well-known presentational elements (notably including <style>, which
+	 * scheme-adaptive icons rely on for prefers-color-scheme media queries) and drops
+	 * scripting-capable elements, event handler attributes, and non-fragment href targets.
+	 *
+	 * @return false|string the sanitized SVG document, or false if input couldn't be parsed as SVG
+	 */
+	public static function sanitize_svg(string $svg_data) {
+		// SVG is XML so element names are case-sensitive, match them exactly
+		$allowed_elements = ['svg', 'circle', 'clipPath', 'defs', 'desc', 'ellipse', 'g',
+			'line', 'linearGradient', 'mask', 'path', 'pattern', 'polygon', 'polyline',
+			'radialGradient', 'rect', 'stop', 'style', 'symbol', 'text', 'title', 'tspan', 'use'];
+
+		if (trim($svg_data) == '')
+			return false;
+
+		libxml_use_internal_errors(true);
+
+		$doc = new DOMDocument();
+
+		if (!$doc->loadXML($svg_data, LIBXML_NONET)
+			|| !$doc->documentElement
+			|| $doc->documentElement->localName != 'svg') {
+			return false;
+		}
+
+		$xpath = new DOMXPath($doc);
+
+		foreach ($xpath->query('//processing-instruction()') as $pi)
+			$pi->parentNode->removeChild($pi);
+
+		foreach ($xpath->query('//*') as $entry) {
+			/** @var DOMElement $entry */
+
+			if (!in_array($entry->localName, $allowed_elements)) {
+				$entry->parentNode->removeChild($entry);
+				continue;
+			}
+
+			$attrs_to_remove = [];
+
+			foreach ($entry->attributes as $attr) {
+				/** @var DOMAttr $attr */
+				if (str_starts_with(strtolower($attr->nodeName), 'on')
+						|| ($attr->localName == 'href' && !str_starts_with(trim($attr->value), '#'))) {
+					$attrs_to_remove[] = $attr;
+				}
+			}
+
+			foreach ($attrs_to_remove as $attr)
+				$entry->removeAttributeNode($attr);
+		}
+
+		return $doc->saveXML();
+	}
+
 	public static function iframe_whitelisted(DOMElement $entry): bool {
 		$src = parse_url($entry->getAttribute("src"), PHP_URL_HOST);
 

--- a/tests_functional/RSSUtilsTest.php
+++ b/tests_functional/RSSUtilsTest.php
@@ -788,4 +788,29 @@ final class RSSUtilsTest extends TestCase {
         $result = RSSUtils::eval_article_filters($filters, "Test article", "", "", "", []);
         $this->assertCount(0, $result);
     }
+
+    // ------------------------------------------------------------------------
+    // detect_favicon_mime_type() — favicon MIME detection with SVG sniffing
+    // ------------------------------------------------------------------------
+
+    public function test_detect_favicon_mime_type_png(): void {
+        $png = base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==');
+        $this->assertEquals('image/png', RSSUtils::detect_favicon_mime_type($png));
+    }
+
+    public function test_detect_favicon_mime_type_svg_with_prolog(): void {
+        $svg = '<?xml version="1.0" encoding="UTF-8"?><svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0h16v16H0z"/></svg>';
+        $this->assertEquals('image/svg+xml', RSSUtils::detect_favicon_mime_type($svg));
+    }
+
+    public function test_detect_favicon_mime_type_svg_without_prolog(): void {
+        // finfo tends to report these as generic XML/text
+        $svg = '<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0h16v16H0z"/></svg>';
+        $this->assertEquals('image/svg+xml', RSSUtils::detect_favicon_mime_type($svg));
+    }
+
+    public function test_detect_favicon_mime_type_html_is_not_svg(): void {
+        $html = '<!DOCTYPE html><html><head><title>hi</title></head><body>hello</body></html>';
+        $this->assertNotEquals('image/svg+xml', RSSUtils::detect_favicon_mime_type($html));
+    }
 }

--- a/tests_functional/SanitizerTest.php
+++ b/tests_functional/SanitizerTest.php
@@ -99,4 +99,65 @@ final class SanitizerTest extends TestCase {
         $this->assertCount(1, $paragraphs);
     }
 
+    // ──────────────────────────────────────────────────────────────────────
+    // sanitize_svg() — SVG favicon sanitization
+    // ──────────────────────────────────────────────────────────────────────
+
+    public function test_sanitize_svg_keeps_benign_markup(): void {
+        $result = Sanitizer::sanitize_svg('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+            <rect width="16" height="16" fill="#fff"/>
+            <path d="M2 2h12v12H2z" fill="#000"/>
+        </svg>');
+
+        $this->assertNotFalse($result);
+        $this->assertStringContainsString('<rect', $result);
+        $this->assertStringContainsString('<path', $result);
+        $this->assertStringContainsString('viewBox="0 0 16 16"', $result);
+    }
+
+    public function test_sanitize_svg_keeps_color_scheme_style(): void {
+        // the reason we bother with SVG favicons at all: embedded prefers-color-scheme support
+        $result = Sanitizer::sanitize_svg('<svg xmlns="http://www.w3.org/2000/svg">
+            <style>path { fill: #000; } @media (prefers-color-scheme: dark) { path { fill: #fff; } }</style>
+            <path d="M2 2h12v12H2z"/>
+        </svg>');
+
+        $this->assertNotFalse($result);
+        $this->assertStringContainsString('prefers-color-scheme: dark', $result);
+    }
+
+    public function test_sanitize_svg_removes_scripts_and_handlers(): void {
+        $result = Sanitizer::sanitize_svg('<svg xmlns="http://www.w3.org/2000/svg" onload="alert(1)">
+            <script>alert(2)</script>
+            <circle r="8" onclick="alert(3)"/>
+            <foreignObject><body xmlns="http://www.w3.org/1999/xhtml"><img src="x" onerror="alert(4)"/></body></foreignObject>
+        </svg>');
+
+        $this->assertNotFalse($result);
+        $this->assertStringNotContainsString('script', $result);
+        $this->assertStringNotContainsString('alert', $result);
+        $this->assertStringNotContainsString('foreignObject', $result);
+        $this->assertStringNotContainsString('onclick', $result);
+        $this->assertStringNotContainsString('onload', $result);
+    }
+
+    public function test_sanitize_svg_removes_external_references(): void {
+        $result = Sanitizer::sanitize_svg('<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <use href="https://example.com/evil.svg#x"/>
+            <use xlink:href="javascript:alert(1)"/>
+            <use href="#local"/>
+        </svg>');
+
+        $this->assertNotFalse($result);
+        $this->assertStringNotContainsString('example.com', $result);
+        $this->assertStringNotContainsString('javascript:', $result);
+        $this->assertStringContainsString('href="#local"', $result);
+    }
+
+    public function test_sanitize_svg_rejects_non_svg(): void {
+        $this->assertFalse(Sanitizer::sanitize_svg('<html><body>hello</body></html>'));
+        $this->assertFalse(Sanitizer::sanitize_svg('not xml at all'));
+        $this->assertFalse(Sanitizer::sanitize_svg(''));
+    }
+
 }


### PR DESCRIPTION
## Description
Sites like nytimes.com publish an SVG favicon with an embedded prefers-color-scheme media query so the icon adapts to light/dark themes. Previously tt-rss rejected SVG outright and cached whatever raster icon happened to be listed first.

- allow image/svg+xml favicons; sanitize them at ingestion (Sanitizer::sanitize_svg: presentational-element allowlist, keeps <style> for color-scheme support, strips scripts/event handlers/ foreignObject/external references), including user-uploaded icons
- prefer SVG icon candidates in get_favicon_urls() and skip scheme-specific <link media=...> icons since one cached icon is served to all users
- fix favicon fallback: a candidate that fails to fetch or validate now falls through to the next one instead of aborting discovery
- serve SVG only from the feed-icon endpoints (opt-in allow_svg) with CSP/nosniff hardening; also set those headers in the web-nginx /cache location since X-Accel-Redirect drops custom PHP headers
- skip GD average-color calculation for SVG icons

## Motivation and Context
Improve dark mode experience and incidentally make icons higher resolution

## How Has This Been Tested?
Tested on a desktop using dark mode.

## Screenshots (if appropriate)
Before:
<img width="385" height="139" alt="image" src="https://github.com/user-attachments/assets/b905b30f-017f-4ddc-bad4-edde5d2163c7" />

After:
<img width="433" height="189" alt="image" src="https://github.com/user-attachments/assets/1c086f75-f74e-459d-8afe-f5fbd79400a9" />

(note two different feeds)

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.