### PR TITLE
Address IPv4/host canonicalization bypasses in 'UrlHelper::has_disallowed_ip()'. GHSA-pfj9-qgh4-9wm

### DIFF
--- a/classes/UrlHelper.php
+++ b/classes/UrlHelper.php
@@ -203,6 +203,38 @@ class UrlHelper {
 	}
 
 	/**
+	 * Normalize dotted IPv4 literals that may use octal, hexadecimal, or decimal syntax
+	 * into a canonical dotted-quad string.
+	 *
+	 * e.g. "0177.0.0.1", "0x7f.0.0.1", and "127.0.0.1" all normalize to "127.0.0.1"
+	 *
+	 * @param string $host hostname or IPv4 literal to normalize
+	 * @return ?string canonical dotted-quad IPv4 string, or null if the input is not a valid dotted IPv4 literal
+	 */
+	static function canonicalize_ipv4_literal(string $host): ?string {
+		// Match 1 to 4 dot-separated octal, hex, or decimal integers
+		if (!preg_match('/^(0x[0-9a-f]+|\d+)(\.(0x[0-9a-f]+|\d+)){0,3}$/i', $host))
+			return null;
+
+		$parts = explode('.', $host);
+		$parts_count = count($parts);
+		$val = 0;
+
+		foreach ($parts as $i => $part) {
+			$octet = intval($part, 0);
+
+			if ($octet < 0 || $octet > ($i === $parts_count - 1 ? (1 << (8 * (5 - $parts_count))) - 1 : 255))
+				return null;
+
+			$val = ($i === $parts_count - 1)
+				? ($val << (8 * (5 - $parts_count))) | $octet
+				: ($val << 8) | $octet;
+		}
+
+		return long2ip($val);
+	}
+
+	/**
 	 * Check if a URL targets a disallowed IP (localhost, loopback, or private IPs on non-standard ports).
 	 *
 	 * Traffic to private IPs on standard ports (80 and 443) is allowed to mimic the original behavior of
@@ -217,55 +249,62 @@ class UrlHelper {
 	 * @return bool true if the URL should be rejected, false otherwise
 	 */
 	static function has_disallowed_ip(string|array $url_or_tokens, bool $validate_resolved_ip = false): bool {
-		$tokens = is_array($url_or_tokens)? $url_or_tokens : parse_url($url_or_tokens);
+		$tokens = is_array($url_or_tokens) ? $url_or_tokens : parse_url($url_or_tokens);
 
 		if (empty($tokens['host']))
 			return false;
 
-		$host = strtolower($tokens['host']);
-
+		$host = trim(strtolower($tokens['host']), '[]');
 		$port = $tokens['port'] ?? null;
-		$standard_port = (($tokens['scheme'] ?? 'http') === 'https') ? 443 : 80;
-		$is_standard_port = ($port === null || $port === $standard_port);
+		$is_standard_port = ($port === null || $port === 80 || $port === 443);
 
-		// strip IPv6 brackets
-		if (str_starts_with($host, '[') && str_ends_with($host, ']'))
-			$host = substr($host, 1, -1);
-
-		if ($host === 'localhost' || str_starts_with($host, '127.'))
+		if ($host === 'localhost')
 			return true;
 
-		if ($host === '::1' || $host === '0:0:0:0:0:0:0:1')
-			return true;
+		// Collect IPs to evaluate-- literal IPs (canonicalizing octal/hex/IPv6) or those from DNS resolution
+		$ips = [];
 
-		// TODO: Improve IPv6 support (fc00::/7 unique local, fe80::/10 link-local)
+		if (filter_var($host, FILTER_VALIDATE_IP)) {
+			$ips[] = $host;
+		} elseif (($canon_ipv4 = self::canonicalize_ipv4_literal($host)) !== null) {
+			$ips[] = $canon_ipv4;
+		} elseif ($validate_resolved_ip) {
+			$records = dns_get_record($host, DNS_A | DNS_AAAA);
 
-		// IPv4 link-local / cloud metadata
-		if (str_starts_with($host, '169.254.'))
-			return true;
-
-		if (!$is_standard_port && preg_match('/^(10\.|192\.168\.|172\.(1[6-9]|2[0-9]|3[0-1])\.)/', $host))
-			return true;
-
-		// if needed, try resolving the hostname and checking the resulting IP
-		if ($validate_resolved_ip && !str_contains($host, ':') && !preg_match('/^\d+\./', $host)) {
-			$ip_addr = gethostbyname($host);
-
-			// failed to resolve
-			// TODO: return true instead?
-			if (!$ip_addr || $ip_addr === $host)
-				return false;
-
-			if (str_starts_with($ip_addr, '127.'))
+			// Fail if resolution fails
+			if (!$records)
 				return true;
 
-			// TODO: maybe check for IPv6 loopback (::1) using dns_get_record()
+			foreach ($records as $r) {
+				if (isset($r['ip']))
+					$ips[] = $r['ip'];
 
-			if (str_starts_with($ip_addr, '169.254.'))
+				if (isset($r['ipv6']))
+					$ips[] = $r['ipv6'];
+			}
+		}
+
+		foreach ($ips as $ip) {
+			// Canonicalize IPv6 and unwrap IPv4-mapped IPv6 (e.g., ::ffff:127.0.0.1 -> 127.0.0.1)
+			if (($bin = inet_pton($ip)) !== false) {
+				$ip = inet_ntop($bin);
+				if (str_starts_with($ip, '::ffff:') && str_contains($ip, '.')) {
+					$ip = substr($ip, 7);
+					$bin = inet_pton($ip);
+				}
+			}
+
+			// Reject loopback, link-local, and reserved ranges (127.0.0.0/8, 169.254.0.0/16, ::1, fe80::/10)
+			if (!filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_RES_RANGE))
 				return true;
 
-			if (!$is_standard_port && preg_match('/^(10\.|192\.168\.|172\.(1[6-9]|2[0-9]|3[0-1])\.)/', $ip_addr))
-					return true;
+			// Explicit check for IPv6 Unique Local Addresses (fc00::/7)
+			if ($bin !== false && strlen($bin) === 16 && (ord($bin[0]) & 0xfe) === 0xfc)
+				return true;
+
+			// Reject RFC1918 / private ranges on non-standard ports
+			if (!$is_standard_port && !filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE))
+				return true;
 		}
 
 		return false;

--- a/rector.php
+++ b/rector.php
@@ -18,4 +18,6 @@ return RectorConfig::configure()
 		Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector::class,
 		// noisy at the moment (needs more review)
 		Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector::class,
+		// TODO: review and re-enable
+		Rector\Visibility\Rector\ClassMethod\ExplicitPublicClassMethodRector::class,
 	]);

--- a/tests/mocked/UrlHelperTest.php
+++ b/tests/mocked/UrlHelperTest.php
@@ -375,6 +375,16 @@ final class UrlHelperTest extends TestCase {
 		$this->assertEquals('https://example.com/page', $result);
 	}
 
+	// ===== canonicalize_ipv4_literal() Tests =====
+
+	public function testCanonicalizeIpv4LiteralNormalizesHexOctalAndDecimalForms(): void {
+		$this->assertSame('127.0.0.1', UrlHelper::canonicalize_ipv4_literal('0177.0.0.1'));
+		$this->assertSame('127.0.0.1', UrlHelper::canonicalize_ipv4_literal('0x7f.0.0.1'));
+		$this->assertSame('127.0.0.1', UrlHelper::canonicalize_ipv4_literal('127.0.0.1'));
+		$this->assertNull(UrlHelper::canonicalize_ipv4_literal('0xgg.0.0.1'));
+		$this->assertNull(UrlHelper::canonicalize_ipv4_literal('1.2.3.4.5'));
+	}
+
 	// ===== has_disallowed_ip() Tests =====
 
 	public function testIsDisallowedIpDetectsLocalhost(): void {
@@ -407,6 +417,14 @@ final class UrlHelperTest extends TestCase {
 	public function testIsDisallowedIpReturnsFalseForInvalidUrl(): void {
 		$this->assertFalse(UrlHelper::has_disallowed_ip('not-a-url'));
 		$this->assertFalse(UrlHelper::has_disallowed_ip(''));
+	}
+
+	public function testIsDisallowedIpRejectsCanonicalizedLoopbackAndMappedIPv6Variants(): void {
+		$this->assertTrue(UrlHelper::has_disallowed_ip('http://0177.0.0.1:8080/'));
+		$this->assertTrue(UrlHelper::has_disallowed_ip('http://0x7f.0.0.1:8080/'));
+		$this->assertTrue(UrlHelper::has_disallowed_ip('http://[::ffff:127.0.0.1]:8080/'));
+		$this->assertTrue(UrlHelper::has_disallowed_ip('http://[::ffff:10.0.0.1]:8080/'));
+		$this->assertFalse(UrlHelper::has_disallowed_ip('http://[::ffff:10.0.0.1]/'));
 	}
 
 	// ===== has_disallowed_ip() - Link-Local / Cloud Metadata Tests =====

--- a/tests_functional/UrlHelperTest.php
+++ b/tests_functional/UrlHelperTest.php
@@ -183,6 +183,30 @@ final class UrlHelperTest extends TestCase {
     }
 
     // ------------------------------------------------------------------------
+    // canonicalize_ipv4_literal
+    // ------------------------------------------------------------------------
+
+    public function test_canonicalize_ipv4_literal_normalizes_octal_hex_decimal(): void {
+        $this->assertSame('127.0.0.1', UrlHelper::canonicalize_ipv4_literal('0177.0.0.1'));
+        $this->assertSame('127.0.0.1', UrlHelper::canonicalize_ipv4_literal('0x7f.0.0.1'));
+        $this->assertSame('127.0.0.1', UrlHelper::canonicalize_ipv4_literal('127.0.0.1'));
+        $this->assertNull(UrlHelper::canonicalize_ipv4_literal('0xgg.0.0.1'));
+        $this->assertNull(UrlHelper::canonicalize_ipv4_literal('1.2.3.4.5'));
+    }
+
+    // ------------------------------------------------------------------------
+    // has_disallowed_ip
+    // ------------------------------------------------------------------------
+
+    public function test_has_disallowed_ip_rejects_canonicalized_loopback_and_mapped_ipv6(): void {
+        $this->assertTrue(UrlHelper::has_disallowed_ip('http://0177.0.0.1:8080/'));
+        $this->assertTrue(UrlHelper::has_disallowed_ip('http://0x7f.0.0.1:8080/'));
+        $this->assertTrue(UrlHelper::has_disallowed_ip('http://[::ffff:127.0.0.1]:8080/'));
+        $this->assertTrue(UrlHelper::has_disallowed_ip('http://[::ffff:10.0.0.1]:8080/'));
+        $this->assertFalse(UrlHelper::has_disallowed_ip('http://[::ffff:10.0.0.1]/'));
+    }
+
+    // ------------------------------------------------------------------------
     // resolve_redirects
     // ------------------------------------------------------------------------
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Address IPv4/host canonicalization bypasses in `UrlHelper::has_disallowed_ip()`.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
[GHSA-pfj9-qgh4-9wm](https://github.com/tt-rss/tt-rss/security/advisories/GHSA-pfj9-qgh4-9wmq) (credit @sec-reex)

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
Local instance.

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
