### PR TITLE
Fix deprecated warning with parse_url within get_self_url

### DIFF
--- a/classes/Config.php
+++ b/classes/Config.php
@@ -553,7 +553,7 @@ class Config {
 		} else {
 			$proto = self::is_server_https() ? 'https' : 'http';
 
-			$self_url_path = $proto . '://' . $_SERVER["HTTP_HOST"] . parse_url($_SERVER["REQUEST_URI"], PHP_URL_PATH);
+			$self_url_path = $proto . '://' . $_SERVER["HTTP_HOST"] . parse_url($_SERVER["REQUEST_URI"] ?? '', PHP_URL_PATH);
 			$self_url_path = preg_replace("/(\/api\/{1,})?(\w+\.php)?(\?.*$)?$/", "", $self_url_path);
 			$self_url_path = preg_replace("/(\/plugins(.local)?)\/.{1,}$/", "", $self_url_path);
 		}


### PR DESCRIPTION
## Description
Fix deprecated warning with parse_url within get_self_url 

## Motivation and Context
Running phpunit tests found this 

## How Has This Been Tested?
Running phpunit

```
# phpunit --display-all-issues
PHPUnit 12.5.31 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.23
Configuration: /root/tt-rss/phpunit.xml

...........DDDDDDDDDD.D........................................  63 / 448 ( 14%)
............................................................... 126 / 448 ( 28%)
............................................................... 189 / 448 ( 42%)
............................................................... 252 / 448 ( 56%)
............................................................... 315 / 448 ( 70%)
............................................................... 378 / 448 ( 84%)
............................................................... 441 / 448 ( 98%)
.......                                                         448 / 448 (100%)

Time: 00:00.131, Memory: 31.98 MB

11 tests triggered 1 PHP deprecation:

1) /root/tt-rss/classes/Config.php:556
parse_url(): Passing null to parameter #1 ($url) of type string is deprecated

Triggered by:

* ConfigTest::test_matches_self_url#Case insensitive scheme/host
  /root/tt-rss/tests_functional/ConfigTest.php:144

* ConfigTest::test_matches_self_url#Exact match root
  /root/tt-rss/tests_functional/ConfigTest.php:144

* ConfigTest::test_matches_self_url#HTTP implicit default port
  /root/tt-rss/tests_functional/ConfigTest.php:144

* ConfigTest::test_matches_self_url#Host mismatch
  /root/tt-rss/tests_functional/ConfigTest.php:144

* ConfigTest::test_matches_self_url#IDN Punycode vs Unicode match
  /root/tt-rss/tests_functional/ConfigTest.php:144

* ConfigTest::test_matches_self_url#Implicit vs explicit default port
  /root/tt-rss/tests_functional/ConfigTest.php:144

* ConfigTest::test_matches_self_url#Port mismatch
  /root/tt-rss/tests_functional/ConfigTest.php:144

* ConfigTest::test_matches_self_url#Root matches sub-path
  /root/tt-rss/tests_functional/ConfigTest.php:144

* ConfigTest::test_matches_self_url#Root with trailing slash match
  /root/tt-rss/tests_functional/ConfigTest.php:144

* ConfigTest::test_matches_self_url#Scheme mismatch
  /root/tt-rss/tests_functional/ConfigTest.php:144

* ConfigTest::test_matches_self_url#Subdomain mismatch
  /root/tt-rss/tests_functional/ConfigTest.php:144

OK, but there were issues!
Tests: 448, Assertions: 764, Deprecations: 1.
```

- phpunit with patch 
```
# phpunit
PHPUnit 12.5.31 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.23
Configuration: /root/tt-rss/phpunit.xml

...............................................................  63 / 448 ( 14%)
............................................................... 126 / 448 ( 28%)
............................................................... 189 / 448 ( 42%)
............................................................... 252 / 448 ( 56%)
............................................................... 315 / 448 ( 70%)
............................................................... 378 / 448 ( 84%)
............................................................... 441 / 448 ( 98%)
.......                                                         448 / 448 (100%)

Time: 00:00.244, Memory: 31.98 MB

OK (448 tests, 764 assertions)
```

- Active instance of tt-rss on FreeBSD 15.1 with change

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.