### PR TITLE
Fix phone-layout toolbar dropdowns dismissing themselves when tapped.

### DIFF
--- a/js/App.js
+++ b/js/App.js
@@ -951,17 +951,43 @@ const App = {
             // existed) from dismissing it the instant the finger lifts. The click
             // handler covers non-touch input (on touch the preventDefault above
             // suppresses it, so it does not double-fire).
+            //
+            // The gesture that OPENS a menu can still reach that click handler:
+            // a toolbar dropdown (dijit.form.Select and every other
+            // _HasDropDown opener) opens its popup on the press itself
+            // (pointerdown), which parks this backdrop under the still-down
+            // finger, and the browser hit-tests the tap's synthesised
+            // compatibility click against the *current* DOM -- the backdrop --
+            // instantly dismissing the menu it just opened. (dijit Buttons,
+            // e.g. the toolbar Actions menu, are immune: a11yclick sets
+            // dojoClick on them, so dojo/touch swallows the tap's
+            // compatibility events and re-dispatches a click at the press
+            // target instead.) Such a ghost click has no matching press on the
+            // backdrop -- its pointerdown landed on the opener before the
+            // backdrop existed -- so only honour clicks preceded by a
+            // pointerdown that actually hit the backdrop; the flag re-arms
+            // every time a popup opens.
+            let backdrop_pressed = false;
+            backdrop.addEventListener("pointerdown", () => {
+               backdrop_pressed = true;
+            });
             backdrop.addEventListener("touchstart", (ev) => {
                ev.preventDefault();
                dijit.popup.close();
             }, {passive: false});
-            backdrop.addEventListener("click", () => dijit.popup.close());
+            backdrop.addEventListener("click", () => {
+               if (backdrop_pressed) {
+                  backdrop_pressed = false;
+                  dijit.popup.close();
+               }
+            });
             document.body.appendChild(backdrop);
 
             const popup = dijit.popup;
             const orig_open = popup.open;
             popup.open = function() {
                const ret = orig_open.apply(this, arguments);
+               backdrop_pressed = false;
                App._syncPopupBackdrop();
                App.reconcileOverlayHistory();
                return ret;


### PR DESCRIPTION
## Description
dijit Selects (and every other _HasDropDown opener) open their popup on pointerdown, which parks the modal popup backdrop under the still-down finger; when the finger lifts, the browser hit-tests the tap's synthesised compatibility click against the current DOM, so it landed on the backdrop and instantly closed the menu it had just opened. dijit Buttons were immune -- a11yclick sets dojoClick on them, making dojo/touch swallow the tap's compatibility events -- which is why the Actions menu worked while the view mode / sort order dropdowns did not. Long-presses produce no compatibility click, which is why tap-and-hold appeared to work.

Only honour backdrop clicks preceded by a pointerdown that actually landed on the backdrop: a ghost click can never qualify (its press hit the opener before the backdrop existed), while real outside taps and mouse clicks still dismiss the menu as before.

## Motivation and Context
Improve mobile experience

## How Has This Been Tested?
Tested on Firefox desktop and mobile

## Screenshots (if appropriate)
<!-- If screenshots will help in understanding the change, include them here. -->

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.