### PR TITLE
Test for HTML entity or UTF-8 depending on version of libxml2

### DIFF
--- a/tests/mocked/SanitizerUnitTest.php
+++ b/tests/mocked/SanitizerUnitTest.php
@@ -318,9 +318,10 @@ final class SanitizerUnitTest extends TestCase {
 		$words = ['tëst'];
 		$result = Sanitizer::highlight_words_str($str, $words);
 
-		// HTML entities are used for multibyte characters
+		$expected = (LIBXML_VERSION >= 21200) ? 'tëst' : 't&euml;st';
+
 		$this->assertStringContainsString('class="highlight"', $result);
-		$this->assertStringContainsString('t&euml;st', $result);
+		$this->assertStringContainsString($expected, $result);
 	}
 
 	public function test_highlight_words_str_multiple_occurrences(): void {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
highlight_words_str uses mb_* functions 

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Correct test.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
Ran mock tests with patch.

Without:
```
# phpunit --no-configuration --bootstrap tests/MockedDepsBootstrap.php tests/mocked/
PHPUnit 11.5.56 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.23

.....................................F.........................  63 / 169 ( 37%)
............................................................... 126 / 169 ( 74%)
...........................................                     169 / 169 (100%)

Time: 00:00.027, Memory: 27.46 MB

There was 1 failure:

1) SanitizerUnitTest::test_highlight_words_str_multibyte_characters
Failed asserting that '<span>This is a <span class="highlight">tëst</span> string</span>' [UTF-8](length: 66) contains "t&euml;st" [ASCII](length: 9).

/root/tt-rss/tests/mocked/SanitizerUnitTest.php:323

FAILURES!
```

with:
```
# phpunit --no-configuration --bootstrap tests/MockedDepsBootstrap.php tests/mocked/
PHPUnit 11.5.56 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.23

...............................................................  63 / 169 ( 37%)
............................................................... 126 / 169 ( 74%)
...........................................                     169 / 169 (100%)

Time: 00:00.028, Memory: 27.46 MB

OK (169 tests, 411 assertions)
```

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
