### PR TITLE
Tune the existing gzip configuration

### DIFF
--- a/.docker/web-nginx/nginx.conf
+++ b/.docker/web-nginx/nginx.conf
@@ -14,11 +14,42 @@ http {
 
 	sendfile on;
 
+	# nginx's mime.types has no entry for .webmanifest, so the manifest would
+	# otherwise be served as application/octet-stream.
+	types {
+		application/manifest+json  webmanifest;
+	}
+
 	gzip on;
-	gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
-	gzip_min_length 1024;
+
+	# nginx defaults to 1, which on tt-rss's own assets gives up about 16% of
+	# the achievable saving.  Level 6 captures nearly all of it (15.5% of 16.0%
+	# on the headlines JSON) for roughly 0.6ms more per response; 7-9 buy a
+	# further 0.5% and are only worth paying for offline, via gzip_static.
+	gzip_comp_level 6;
+
+	# Serve a precompressed <file>.gz when one exists (see
+	# utils/precompress-assets.sh), which allows level 9 at no request-time cost.
+	gzip_static on;
+
+	# image/svg+xml was missing: images/three-dots.svg is on the critical path
+	# for every page load and compresses 1513 -> 395 bytes.
+	gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript image/svg+xml application/manifest+json;
+
+	# Only effective for static files.  PHP responses arrive over FastCGI with
+	# Transfer-Encoding: chunked and no Content-Length, so nginx cannot know
+	# their size and compresses them regardless of this setting.  Lowered from
+	# 1024 so the smaller SVGs are covered.
+	gzip_min_length 256;
+
 	gzip_proxied any;
 	gzip_vary on;
+
+	# Deliberately not tuning fastcgi_buffers here.  PHP responses arrive in
+	# chunks and the compressor flushes at each boundary, but for gzip the cost
+	# is negligible: raising the buffers from 32k to 2M per request moved the
+	# headlines JSON only from 17,150 to 17,124 bytes, against 17,112 for the
+	# same body compressed offline.  The defaults are already at the ceiling.
 
 	index index.php;
 

--- a/utils/precompress-assets.sh
+++ b/utils/precompress-assets.sh
@@ -1,0 +1,31 @@
+#!/bin/sh -e
+#
+# Write precompressed .gz siblings for tt-rss's static assets, so nginx can
+# serve them via gzip_static instead of compressing on every request.
+#
+# Because the work happens once, ahead of time, it can use level 9, which is
+# not worth paying for on the fly: on tt-rss's cold-load bundle level 6 gives
+# 17.1% over nginx's default of level 1, and level 9 gives 17.4%.
+#
+# Run from the tt-rss root, or pass the root as the first argument.  Safe to
+# re-run: a sibling is only rewritten when it is older than its source.
+#
+# NOTE: gzip_static serves a .gz whenever one exists and never compares it
+# against the source, so a stale sibling means stale content on the wire.  This
+# has to run whenever the assets change, not just once.
+
+ROOT="${1:-.}"
+
+# Only types nginx is configured to compress.  Anything already compressed
+# (png/gif/woff2) is skipped -- re-compressing it would only add bytes.
+find "$ROOT/js" "$ROOT/lib" "$ROOT/themes" "$ROOT/images" \
+		-type f \( -name '*.js' -o -name '*.css' -o -name '*.svg' -o -name '*.json' \) \
+		! -name '*.gz' 2>/dev/null | while read -r f; do
+
+	# Matches gzip_min_length; below it the sibling would never be served.
+	[ "$(wc -c < "$f")" -ge 256 ] || continue
+
+	[ "$f.gz" -nt "$f" ] || gzip -9 -c "$f" > "$f.gz"
+done
+
+echo "precompress: done"


### PR DESCRIPTION
## Description
nginx defaults gzip_comp_level to 1, and the config never overrode it, so tt-rss has been shipping barely-compressed responses.  Level 6 is the knee of the curve: on the headlines JSON it captures 15.5% of the 16.0% available from level 9.  Levels 7-9 are only worth paying for offline, so gzip_static is enabled alongside utils/precompress-assets.sh, which writes level 9 siblings at build time.

image/svg+xml was missing from gzip_types.  images/three-dots.svg is on the critical path for every page load and was being sent uncompressed at 1513 bytes; it is 380 on the wire now.  gzip_min_length drops from 1024 to 256 so the smaller SVGs are covered too, and .webmanifest gains a mime type rather than being served as application/octet-stream.

Measured against the previous configuration, over real responses:

  cold load (718 KB of JS/CSS/SVG/HTML)   244,672 -> 201,702   -17.6%
  headlines JSON, per feed view            20,265 ->  17,124   -15.5%

This costs less CPU rather than more, because gzip_static stops nginx recompressing the same static assets on every request, and that dominates:

  486 KB of JavaScript      3.40 -> 0.08 ms CPU/request
  headlines JSON            0.85 -> 1.51 ms CPU/request
  full page load            6.71 -> 2.62 ms CPU/page

The JSON is the one case that gets more expensive, since PHP output cannot be precompressed.  For scale, generating that same response costs PHP-FPM 12.8ms, so the extra 0.66ms is about 5% of the request's total server cost.  Worker memory is unchanged (measured on fresh containers under identical load).

Two things that came out of measuring rather than assuming:

gzip_min_length only ever applied to static files.  PHP responses come back over FastCGI with Transfer-Encoding: chunked and no Content-Length, so nginx cannot know their size and compresses them whatever the setting says.  A side effect is that the 60-second counter poll, 76 bytes of JSON, goes out as 91 bytes: below roughly 200 bytes the gzip header costs more than it saves. Fixing that would mean emitting Content-Length from PHP, which is out of scope here.

fastcgi_buffers deliberately left alone.  The chunked delivery does cost ratio in principle, but for gzip the effect is negligible: raising the buffers from 32k to 2M per request moved the same response only from 17,150 to 17,124 bytes, against 17,112 compressing the whole body offline.

## Motivation and Context
Make tt-rss more usable on mobile connections

## How Has This Been Tested?
Tested on desktop Firefox.

## Screenshots (if appropriate)
<!-- If screenshots will help in understanding the change, include them here. -->

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
