### PR TITLE
Send Cache-Control for static assets

### DIFF
--- a/.docker/web-nginx/nginx.conf
+++ b/.docker/web-nginx/nginx.conf
@@ -51,6 +51,27 @@ http {
 	# headlines JSON only from 17,150 to 17,124 bytes, against 17,112 for the
 	# same body compressed offline.  The defaults are already at the ceiling.
 
+	# Static assets are served without any Cache-Control, which leaves browsers
+	# to guess a freshness lifetime and revalidate once their guess expires.
+	# Most asset URLs already carry a numeric version, so they need neither:
+	# javascript_tag() and stylesheet_tag() append ?filemtime() (see
+	# include/controls_compat.php), get_theme_path() does the same, and dojo's
+	# loader appends dojoConfig.cacheBust to every module it fetches lazily
+	# (see index.php).  Such a URL changes whenever its file does, so the
+	# response behind it can be cached indefinitely.
+	#
+	# This keys on the query string rather than on the path, deliberately.  A
+	# minority of requests still arrive with no version at all -- currently
+	# around 6% of the dojo module fetches in an access log, plus the favicons
+	# and the web manifest, which are never versioned.  A path-based rule would
+	# hand those a year of immutability and serve stale JavaScript after an
+	# upgrade; keyed this way they simply keep revalidating, which costs a round
+	# trip and no body.
+	map $args $ttrss_static_cache {
+		default        "no-cache";
+		"~^[0-9]+$"    "public, max-age=31536000, immutable";
+	}
+
 	index index.php;
 
 	resolver ${RESOLVER} valid=5s;
@@ -108,8 +129,18 @@ http {
 			fastcgi_pass ${APP_FASTCGI_PASS};
 		}
 
+		# Only this location needs the header: PHP responses set their own
+		# Cache-Control (no-store, via the session cache limiter), and the cache
+		# and backups locations are internal and matched by prefix before this.
 		location / {
 			try_files $uri $uri/ =404;
+
+			# No "always" here: that would apply the header to error responses
+			# too, so a 404 for a versioned URL -- an asset briefly missing
+			# during a deploy, say -- would be cached as immutable for a year.
+			# nginx's default status list still covers 304, which browsers need
+			# in order to refresh the freshness lifetime.
+			add_header Cache-Control $ttrss_static_cache;
 		}
 	}
 }


### PR DESCRIPTION
## Description
Static assets went out with only Last-Modified and ETag, no Cache-Control at all, which leaves each browser to invent a freshness lifetime and revalidate once its guess runs out.  A warm repeat page load spent 8 conditional requests confirming nothing had changed -- all latency, no payload, and on a phone that is the expensive kind of request.

Most asset URLs are already content-versioned and need none of it: javascript_tag() and stylesheet_tag() append ?filemtime(), get_theme_path() does the same, and dojo's loader appends dojoConfig.cacheBust to the modules it fetches lazily.  Those get a year and immutable, which takes the same repeat load down to 2 requests, both for assets that carry no version (the favicons and the web manifest).

The rule keys on the query string rather than the path, which matters: about 6% of the dojo module fetches in an access log arrive with no version at all, so a rule like "location ~ \.js$ { expires 1y; }" would serve stale JavaScript for a year after an upgrade.  Keyed this way, an unversioned URL falls through to no-cache and keeps revalidating, which is what it needs to do.

Deliberately without add_header's "always" flag.  With it the header also lands on error responses, so a 404 for a versioned URL -- an asset briefly missing mid-deploy -- would be cached as immutable for a year, leaving a broken app that no reload can fix.  nginx's default status list still includes 304, which is required for browsers to refresh the freshness lifetime.

One precondition worth knowing: get_scripts_timestamp(), which feeds dojoConfig.cacheBust, globs only js/*.js.  Updating a vendored file under lib/ without touching anything in js/ leaves the cacheBust value unchanged, so lazily-loaded lib modules would keep serving from cache.  Widening that glob would remove the caveat.  It does not affect lib/dojo/dojo.js or lib/dojo/tt-rss-layer.js, which are versioned per-file by javascript_tag().

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Improve mobile UI performance and OOM behavior.

## How Has This Been Tested?
Tested on desktop Firefox.

## Screenshots (if appropriate)
<!-- If screenshots will help in understanding the change, include them here. -->

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
