### PR TITLE
Stop sending no-store on the HTML shells

### DIFF
--- a/classes/Handler_Public.php
+++ b/classes/Handler_Public.php
@@ -823,7 +823,13 @@ class Handler_Public extends Handler {
 	}
 
 	static function _render_login_form(string $return_to = ""): void {
-		header('Cache-Control: public');
+		// The form is session-specific: include/login_form.php renders
+		// $_SESSION['login_error_msg'] (and then clears it), plus auth_remote's
+		// prefilled $_SESSION['fake_login'].  'public' let a shared cache store
+		// one visitor's copy and replay it to others, disclosing that login name
+		// and the reason their session failed, and re-showing an error the server
+		// had already cleared.
+		header('Cache-Control: private, no-cache');
 
 		if ($return_to)
 			$_REQUEST['return'] = $return_to;

--- a/include/functions.php
+++ b/include/functions.php
@@ -504,3 +504,32 @@
 
 		return $ts;
 	}
+
+	/**
+	 * Finish a per-user HTML shell: derive an ETag from the buffered document and
+	 * answer a matching conditional request with an empty 304.
+	 *
+	 * The shells are byte-stable for the life of a session, so this turns a
+	 * reload into a validator exchange rather than a retransmission.  Hashing the
+	 * whole body is what makes that safe: every session-specific value in the
+	 * page, the CSRF token included, feeds the hash, so a 304 can only ever be
+	 * served to a client that already holds this exact session's copy.
+	 */
+	function send_conditional_html(string $body): void {
+		$etag = '"' . md5($body) . '"';
+
+		header("ETag: $etag");
+
+		// nginx weakens ETags on responses it compresses, so a client served a
+		// gzipped shell sends back W/"...".  If-None-Match compares weakly in any
+		// case (RFC 9110, 13.1.2), so drop the marker before comparing.
+		$tags = array_map(
+			fn(string $tag) => preg_replace('/^W\//', '', trim($tag)),
+			explode(',', $_SERVER['HTTP_IF_NONE_MATCH'] ?? ''));
+
+		if (in_array($etag, $tags, true)) {
+			http_response_code(304);
+		} else {
+			echo $body;
+		}
+	}

--- a/index.php
+++ b/index.php
@@ -1,4 +1,12 @@
 <?php
+	// Opt out of PHP's session cache limiter before include/sessions.php starts
+	// the session.  Its default ('nocache') stamps this page with 'no-store,
+	// no-cache, must-revalidate', and no-store disqualifies the document from the
+	// back/forward cache, so navigating back re-boots the entire client instead
+	// of restoring it.  Scoped to this entry point on purpose: the API handlers
+	// share the session machinery but not these requirements.
+	session_cache_limiter('');
+
 	require_once __DIR__ . '/include/autoload.php';
 	require_once __DIR__ . '/include/sessions.php';
 
@@ -9,6 +17,18 @@
 	UserHelper::login_sequence();
 
 	header('Content-Type: text/html; charset=utf-8');
+
+	// What the shell actually requires: it embeds this session's CSRF token, the
+	// user's theme and stylesheet and per-plugin CSS, so no shared cache may
+	// store it and it must be revalidated before reuse.  no-store would add only
+	// "never write it to disk", which would guard the CSRF token while leaving
+	// the session cookie that token is bound to in the cookie store regardless.
+	header('Cache-Control: private, no-cache');
+
+	// Buffered so send_conditional_html() at the end can hash it into a
+	// validator; unauthenticated requests never reach here, login_sequence()
+	// renders the login form and exits.
+	ob_start();
 ?>
 <!DOCTYPE html>
 <html>
@@ -326,3 +346,4 @@
 
 </body>
 </html>
+<?php send_conditional_html((string) ob_get_clean());

--- a/prefs.php
+++ b/prefs.php
@@ -1,4 +1,8 @@
 <?php
+	// See index.php: PHP's default session cache limiter would send no-store,
+	// which costs this page the back/forward cache for no benefit it needs.
+	session_cache_limiter('');
+
 	require_once __DIR__ . '/include/autoload.php';
 	require_once __DIR__ . '/include/sessions.php';
 
@@ -9,6 +13,10 @@
 	UserHelper::login_sequence();
 
 	header('Content-Type: text/html; charset=utf-8');
+
+	header('Cache-Control: private, no-cache');
+
+	ob_start();
 ?>
 <!DOCTYPE html>
 <html>
@@ -181,3 +189,4 @@
 
 </body>
 </html>
+<?php send_conditional_html((string) ob_get_clean());


### PR DESCRIPTION
## Description
index.php and prefs.php were sent with

  Expires: Thu, 19 Nov 1981 08:52:00 GMT
  Cache-Control: no-store, no-cache, must-revalidate
  Pragma: no-cache

Nothing here asked for that: it is PHP's default session.cache_limiter of 'nocache', emitted by the session_start() in include/sessions.php.  The 1981 date is a constant in PHP's session extension.  There is no session_cache_limiter() call anywhere in the tree, and DiskCache.php:337 already works around these headers locally rather than changing the default.

What the shells require is that no shared cache store them -- they embed the session's CSRF token, the user's theme and stylesheet and per-plugin CSS -- and that they be revalidated before reuse.  That is 'private, no-cache'.  no-store adds only "never write it to disk", which guards the CSRF token while leaving the session cookie that token is bound to in the cookie store regardless, so it buys nothing here.

It does cost something.  no-store disqualifies a document from the back/forward cache (Firefox excludes it outright over HTTPS; Chrome has historically done the same), so leaving the app and returning re-boots the whole client: fresh HTML, dojo re-require of every module, module registry rebuilt.  On a phone that is an ordinary back gesture.

Since the shells are byte-stable for the life of a session, they can also carry a validator, so a reload becomes an empty 304 instead of a retransmission. send_conditional_html() hashes the buffered document; hashing the whole body is what makes this safe, because every session-specific value in the page feeds the hash and a 304 can therefore only reach a client that already holds this exact session's copy.  Verified: two concurrent sessions get different tags, and one session's tag against the other returns 200.

The limiter opt-out is per entry point, not an ini change -- api/index.php and the public handlers share the session machinery but not these requirements, and they keep PHP's default.

Handler_Public::_render_login_form() had the opposite bug: 'Cache-Control: public' on a form that renders $_SESSION['login_error_msg'] (then clears it) and auth_remote's prefilled $_SESSION['fake_login'].  A shared cache was permitted to store one visitor's copy and replay it, disclosing that login name and why their session failed, and re-showing an error the server had already cleared.  No CSRF exposure -- the login form carries no token and login() does not validate one.

Measured against the running stack, authenticated:

  before  200, no-store, no validator, 4212 B gzipped every load
  after   200, private/no-cache + ETag, then 304 with 0 B on reload

Dropping the limiter also drops its HTTP/1.0 belt-and-braces (the past Expires and response Pragma).  'private' already bars shared caches under HTTP/1.1, and RFC 9111 deprecates Pragma as a response header.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Improve mobile experience

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
Tested on desktop Firefox

## Screenshots (if appropriate)
<!-- If screenshots will help in understanding the change, include them here. -->

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.