### PR TITLE
Stop polling the backend while the page is hidden

### DIFF
--- a/js/App.js
+++ b/js/App.js
@@ -776,6 +776,38 @@ const App = {
 
       return errorMsg === "";
    },
+   /**
+    * Call fn() every interval_ms, but only while the page is visible.
+    *
+    * A phone spends most of its time with the tab backgrounded or the screen
+    * locked, and a poll issued then has to wake the cellular radio, which
+    * costs considerably more battery than the request costs bytes.  So nothing
+    * is polled while hidden.  Becoming visible refreshes immediately if a full
+    * interval went by in the meantime, and otherwise waits out the remainder,
+    * so that switching back and forth between tabs cannot turn into one
+    * request per switch.
+    */
+   pollWhileVisible: function(fn, interval_ms) {
+      let last_run = Date.now();
+      let timer = 0;
+
+      const run = () => {
+         last_run = Date.now();
+         fn();
+         timer = setTimeout(run, interval_ms);
+      };
+
+      document.addEventListener("visibilitychange", () => {
+         clearTimeout(timer);
+
+         if (document.hidden)
+            return;
+
+         timer = setTimeout(run, Math.max(0, interval_ms - (Date.now() - last_run)));
+      });
+
+      timer = setTimeout(run, interval_ms);
+   },
    updateRuntimeInfo: function() {
       xhr.json("backend.php", {op: "RPC", method: "getruntimeinfo"}, () => {
          // handled by xhr.json()
@@ -1013,9 +1045,7 @@ const App = {
       }
 
       if (!this.getInitParam("bw_limit"))
-         window.setInterval(() => {
-            App.updateRuntimeInfo();
-         }, 60 * 1000)
+         this.pollWhileVisible(() => App.updateRuntimeInfo(), 60 * 1000);
 
 		if (App.getInitParam("safe_mode") && this.isPrefs()) {
 			CommonDialogs.safeModeWarning();

--- a/js/Feeds.js
+++ b/js/Feeds.js
@@ -315,7 +315,7 @@ const	Feeds = {
 		} else {
 			setTimeout(() => {
 				this.requestCounters();
-				setInterval(() => { this.requestCounters(); }, 60 * 1000)
+				App.pollWhileVisible(() => this.requestCounters(), 60 * 1000);
 			}, 250);
 		}
 	},


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

tt-rss keeps two 60-second polls running for the life of the tab: Feeds.requestCounters() and App.updateRuntimeInfo().  Neither checks whether anyone is looking, so a phone with the tab backgrounded or the screen locked keeps issuing two requests a minute.  On cellular the cost of that is dominated by waking the radio, not by the payloads, both of which are small.

Route both through App.pollWhileVisible(), which polls only while the document is visible.  Coming back refreshes immediately if a full interval elapsed while away -- so counters are never stale on return, which the old code could not manage either -- and otherwise waits out the remainder, so flipping between tabs cannot turn into one request per flip.  Nothing is scheduled at all while hidden.

How much this saves depends on the browser, because some already gate part of it.  Chrome throttles hidden-tab timers and then freezes the tab outright on Android, which stops the polls by itself after a few minutes; tt-rss holds no WebSocket, audio or open IndexedDB transaction, so it is freeze-eligible.  Firefox clamps background timers to >= 1s, which does nothing to a 60s interval, so there the polls continue for as long as the tab lives.  Gating in the client covers every browser from the first second and does not depend on freezing staying eligible.

Measured against the dev stack, driving a real visibilitychange over a 70-second window:

*  before
    - hidden 70s -> 2 polls (getruntimeinfo +54s, getAllCounters +55s)
    - visible again -> 0 polls (counters stay stale up to 60s)
*  after
    - hidden 70s -> 0 polls
    - visible again -> 2 polls at +0.0s
    - 6 rapid hide/show flips -> 0 polls

Both timers had to move together: gating only the counters would have halved the wakeups while leaving the radio woken every minute anyway. As a side effect the two stop being staggered ~1s apart after the first hide/show cycle, since both then reschedule from the same instant, so they share one radio wakeup instead of taking two.

The hourly check_for_updates poll is left alone deliberately.  It costs 1/60th the wakeups, and routing it through the same helper would make every tab focus after an hour away trigger an update check.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Reduce power consumption on Firefox for Android

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
Tested on desktop Firefox only.

## Screenshots (if appropriate)
<!-- If screenshots will help in understanding the change, include them here. -->

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
