### PR TITLE
Compress and cache lib/flat-ttrss's icon font

### DIFF
--- a/.docker/web-nginx/nginx.conf
+++ b/.docker/web-nginx/nginx.conf
@@ -14,10 +14,12 @@ http {
 
 	sendfile on;
 
-	# nginx's mime.types has no entry for .webmanifest, so the manifest would
-	# otherwise be served as application/octet-stream.
+	# nginx's mime.types has an entry for neither .webmanifest nor .ttf, so both
+	# would otherwise fall back to default_type.  For the font that is not just
+	# cosmetic: gzip_types below cannot match a type the file never gets.
 	types {
 		application/manifest+json  webmanifest;
+		font/ttf                   ttf;
 	}
 
 	gzip on;
@@ -34,7 +36,14 @@ http {
 
 	# image/svg+xml was missing: images/three-dots.svg is on the critical path
 	# for every page load and compresses 1513 -> 395 bytes.
-	gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript image/svg+xml application/manifest+json;
+	#
+	# font/ttf covers lib/flat-ttrss's icon font, which every page load needs for
+	# dijit's tab, arrow, checkbox and validation glyphs.  It ships as .ttf and
+	# .woff, and the .ttf wins the @font-face cascade, so it was going out at its
+	# full 13436 bytes; gzipped it is 4700.  woff and woff2 are left out on
+	# purpose: a correctly built one is already compressed internally, so gzip
+	# only burns CPU -- material-icons.woff2 comes out 59 bytes *larger*.
+	gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript image/svg+xml application/manifest+json font/ttf;
 
 	# Only effective for static files.  PHP responses arrive over FastCGI with
 	# Transfer-Encoding: chunked and no Content-Length, so nginx cannot know
@@ -53,7 +62,7 @@ http {
 
 	# Static assets are served without any Cache-Control, which leaves browsers
 	# to guess a freshness lifetime and revalidate once their guess expires.
-	# Most asset URLs already carry a numeric version, so they need neither:
+	# Most asset URLs already carry a version token, so they need neither:
 	# javascript_tag() and stylesheet_tag() append ?filemtime() (see
 	# include/controls_compat.php), get_theme_path() does the same, and dojo's
 	# loader appends dojoConfig.cacheBust to every module it fetches lazily
@@ -67,9 +76,22 @@ http {
 	# hand those a year of immutability and serve stale JavaScript after an
 	# upgrade; keyed this way they simply keep revalidating, which costs a round
 	# trip and no body.
+	#
+	# The token is matched as bare alphanumerics rather than digits only, because
+	# tt-rss's own ?filemtime() is not the only scheme in the tree: vendored
+	# bundles bake in a build token, e.g. lib/flat-ttrss asks for its icon font
+	# as ?90nq1s.  Requiring the whole query string to be one such word is what
+	# keeps this narrow -- a key=value pair cannot match for want of an '=', so
+	# public.php?op=feed_icon&id=1 stays on no-cache.  Over a sample access log
+	# it moved exactly one thing into the immutable bucket, that font.
+	#
+	# Caveat for anyone editing a vendored asset: a baked token, unlike
+	# filemtime, is not derived from the file, so replacing such a file without
+	# regenerating the stylesheet that references it leaves clients holding the
+	# old copy for a year.
 	map $args $ttrss_static_cache {
-		default        "no-cache";
-		"~^[0-9]+$"    "public, max-age=31536000, immutable";
+		default                "no-cache";
+		"~^[0-9a-zA-Z]+$"      "public, max-age=31536000, immutable";
 	}
 
 	index index.php;


### PR DESCRIPTION
## Description
The theme draws dijit's tab, arrow, checkbox and validation glyphs from lib/flat-ttrss/fonts/flat-icon, so every page load fetches it -- and it arrived uncompressed and was revalidated each time.

nginx's mime.types has no entry for .ttf, so the font fell back to default_type and went out as application/octet-stream.  Since gzip_types can only match a type the response actually carries, it takes the types entry as well before it has any effect: 13436 -> 4689 bytes.  woff and woff2 stay out of gzip_types, already being compressed internally.

The font is versioned too, as flat-icon.ttf?90nq1s, but the immutable match accepted only digits and so left it revalidating.  Widening that to bare alphanumerics still cannot match a key=value pair, for want of an '='; across an access log of 199 distinct static query strings it promotes this font and nothing else.

Unlike ?filemtime(), a baked build token is not derived from the file it versions, so a vendored asset replaced without regenerating the stylesheet that names it will now stay cached for a year.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Improve tt-rss over slower mobile links

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
Tested on desktop Firefox.

## Screenshots (if appropriate)
<!-- If screenshots will help in understanding the change, include them here. -->

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.