### PR TITLE
Make handling of IPv6 addresses symmetric to IPv4

### DIFF
--- a/classes/UrlHelper.php
+++ b/classes/UrlHelper.php
@@ -306,7 +306,7 @@ class UrlHelper {
 				return true;
 
 			// Explicit check for IPv6 Unique Local Addresses (fc00::/7)
-			if ($bin !== false && strlen($bin) === 16 && (ord($bin[0]) & 0xfe) === 0xfc)
+			if (!$is_standard_port && $bin !== false && strlen($bin) === 16 && (ord($bin[0]) & 0xfe) === 0xfc)
 				return true;
 
 			// Reject RFC1918 / private ranges on non-standard ports


### PR DESCRIPTION
## Description
Local IPv4 addresses are correctly accepted when a standard port is used. Do the same for local IPv6 addresses. This is a regression introduced by 9e8e6a61300414b8be352d4af9d24e57ca5abb65.

## Motivation and Context
Without this fix my setup is broken. Its using multiple docker containers in a compose stack generating RSS feeds which are read by ttrss.

## How Has This Been Tested?
Docker container with IPv6 address in same docker network as the ttrss container. Accessing the feed works again with my change. Previously it was failing with "Requested URL failed extended validation".

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.