### PR TITLE
Restore support for compressed responses in 'UrlHelper::fetch()'

### DIFF
--- a/classes/UrlHelper.php
+++ b/classes/UrlHelper.php
@@ -455,6 +455,8 @@ class UrlHelper {
 
 		if ($encoding)
 			$req_options[GuzzleHttp\RequestOptions::HEADERS]['Accept-Encoding'] = $encoding;
+		else
+			$req_options['curl'][\CURLOPT_ENCODING] = '';
 
 		if  ($http_referrer)
 			$req_options[GuzzleHttp\RequestOptions::HEADERS]['Referer'] = $http_referrer;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
As mentioned on #416, the switch to Guzzle inadvertently effectively dropped support for compressed responses.  This change ensures that the default behavior is for `Accept-Encoding` to be sent with whatever curl supports.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Restore support for compressed responses.

Closes #416.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
Local instance.

## Types of Changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
