### PR TITLE
Add a basic check for curl before setting related props

### DIFF
--- a/classes/UrlHelper.php
+++ b/classes/UrlHelper.php
@@ -24,6 +24,15 @@ class UrlHelper {
 	static string $fetch_effective_ip_addr;
 
 	public static ?GuzzleHttp\ClientInterface $client = null;
+	private static ?bool $using_curl = null;
+
+	/**
+	 * Basic check for whether Guzzle will use a curl handler (indicating we can add curl options as needed).
+	 * This doesn't fully mirror Guzzle's logic, but should hopefully be close enough.
+	 */
+	private static function using_curl(): bool {
+		return self::$using_curl ??= function_exists('curl_exec') || function_exists('curl_multi_exec');
+	}
 
 	private static function get_client(): GuzzleHttp\ClientInterface {
 		if (self::$client == null) {
@@ -455,7 +464,7 @@ class UrlHelper {
 
 		if ($encoding)
 			$req_options[GuzzleHttp\RequestOptions::HEADERS]['Accept-Encoding'] = $encoding;
-		else
+		elseif (self::using_curl())
 			$req_options['curl'][\CURLOPT_ENCODING] = '';
 
 		if  ($http_referrer)
@@ -464,7 +473,7 @@ class UrlHelper {
 		if (in_array($auth_type, ['basic', 'digest']) && $login && $pass) {
 			// Let Guzzle handle the details for auth types it supports
 			$req_options[GuzzleHttp\RequestOptions::AUTH] = [$login, $pass, $auth_type];
-		} elseif ($auth_type === 'any') {
+		} elseif ($auth_type === 'any' && self::using_curl()) {
 			$req_options['curl'][\CURLOPT_HTTPAUTH] = \CURLAUTH_ANY;
 			if ($login && $pass)
 				$req_options['curl'][\CURLOPT_USERPWD] = "$login:$pass";


### PR DESCRIPTION
Do a basic check (loosely and partially based upon what Guzzle does when selecting a handler) before setting curl-specific Guzzle request options.

Closes #426.